### PR TITLE
Add unit tests to target schemes

### DIFF
--- a/Fixtures/TestProject/GeneratedProject.xcodeproj/project.pbxproj
+++ b/Fixtures/TestProject/GeneratedProject.xcodeproj/project.pbxproj
@@ -8,16 +8,25 @@
 
 /* Begin PBXBuildFile section */
 		BF1073850101 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1332263601 /* AppDelegate.swift */; };
+		BF1462768401 = {isa = PBXBuildFile; fileRef = FR2653659501 /* TestProjectTests.xctest */; };
 		BF1744565901 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6218091901 /* ViewController.swift */; };
 		BF2753556301 /* MyFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR2993497801 /* MyFramework.framework */; };
 		BF3154421201 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR5980633301 /* Assets.xcassets */; };
 		BF3515549501 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR7740960501 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF3862341101 = {isa = PBXBuildFile; fileRef = FR2993497801 /* MyFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF5986511201 = {isa = PBXBuildFile; fileRef = FR6523263101 /* TestProject.app */; };
+		BF5986511201 /* TestProject.app in Frameworks */ = {isa = PBXBuildFile; fileRef = FR6523263101 /* TestProject.app */; };
+		BF9001417701 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6877173101 /* TestProjectTests.swift */; };
 		BF9155249601 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7078510801 /* FrameworkFile.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		CIP265365901 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P81399456601 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT6523263101;
+			remoteInfo = TestProject;
+		};
 		CIP652326301 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = P81399456601 /* Project object */;
@@ -44,17 +53,28 @@
 		FR1332263601 /* AppDelegate.swift */ = {isa = PBXFileReference; path = AppDelegate.swift; sourceTree = "<group>"; };
 		FR1345298501 /* Info.plist */ = {isa = PBXFileReference; path = Info.plist; sourceTree = "<group>"; };
 		FR1345298502 /* Info.plist */ = {isa = PBXFileReference; path = Info.plist; sourceTree = "<group>"; };
+		FR1345298503 /* Info.plist */ = {isa = PBXFileReference; path = Info.plist; sourceTree = "<group>"; };
+		FR2653659501 /* TestProjectTests.xctest */ = {isa = PBXFileReference; explicitFileType = xctest; includeInIndex = 0; path = TestProjectTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR2993497801 /* MyFramework.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; path = MyFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR3676338401 /* Base */ = {isa = PBXFileReference; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		FR3676338402 /* Base */ = {isa = PBXFileReference; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		FR5980633301 /* Assets.xcassets */ = {isa = PBXFileReference; path = Assets.xcassets; sourceTree = "<group>"; };
 		FR6218091901 /* ViewController.swift */ = {isa = PBXFileReference; path = ViewController.swift; sourceTree = "<group>"; };
 		FR6523263101 /* TestProject.app */ = {isa = PBXFileReference; explicitFileType = app; includeInIndex = 0; path = TestProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR6877173101 /* TestProjectTests.swift */ = {isa = PBXFileReference; path = TestProjectTests.swift; sourceTree = "<group>"; };
 		FR7078510801 /* FrameworkFile.swift */ = {isa = PBXFileReference; path = FrameworkFile.swift; sourceTree = "<group>"; };
 		FR7740960501 /* MyFramework.h */ = {isa = PBXFileReference; path = MyFramework.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		FBP265365901 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF5986511201,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FBP652326301 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -66,6 +86,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		G26536595301 /* TestProjectTests */ = {
+			isa = PBXGroup;
+			children = (
+				FR1345298503 /* Info.plist */,
+				FR6877173101 /* TestProjectTests.swift */,
+			);
+			name = TestProjectTests;
+			path = TestProjectTests;
+			sourceTree = "<group>";
+		};
 		G29934978701 /* MyFramework */ = {
 			isa = PBXGroup;
 			children = (
@@ -96,6 +126,7 @@
 			children = (
 				G65232631501 /* TestProject */,
 				G29934978701 /* MyFramework */,
+				G26536595301 /* TestProjectTests */,
 				G86202385201 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -104,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				FR2993497801 /* MyFramework.framework */,
+				FR2653659501 /* TestProjectTests.xctest */,
 				FR6523263101 /* TestProject.app */,
 			);
 			name = Products;
@@ -112,6 +144,13 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		HBP265365901 /* Frameworks */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		HBP299349701 /* Frameworks */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -130,6 +169,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		NT2653659501 /* TestProjectTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = XCCL26536501 /* Build configuration list for PBXNativeTarget "TestProjectTests" */;
+			buildPhases = (
+				SBP265365901 /* Sources */,
+				RBP265365901 /* Resources */,
+				HBP265365901 /* Headers */,
+				FBP265365901 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD8877980201 /* PBXTargetDependency */,
+			);
+			name = TestProjectTests;
+			productReference = FR2653659501;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		NT2993497801 /* MyFramework */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = XCCL29934901 /* Build configuration list for PBXNativeTarget "MyFramework" */;
@@ -185,11 +242,19 @@
 			targets = (
 				NT6523263101 /* TestProject */,
 				NT2993497801 /* MyFramework */,
+				NT2653659501 /* TestProjectTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		RBP265365901 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		RBP299349701 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -239,6 +304,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		SBP265365901 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF9001417701 /* TestProjectTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		SBP299349701 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -263,6 +336,11 @@
 			isa = PBXTargetDependency;
 			target = NT2993497801 /* MyFramework */;
 			targetProxy = CIP652326301 /* PBXContainerItemProxy */;
+		};
+		TD8877980201 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = NT6523263101 /* TestProject */;
+			targetProxy = CIP265365901 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -367,6 +445,20 @@
 			};
 			name = Debug;
 		};
+		XCBC60448901 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = TestProjectTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestProject.app/TestProject";
+			};
+			name = Release;
+		};
 		XCBC86437501 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -424,6 +516,20 @@
 			};
 			name = Release;
 		};
+		XCBC89077001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = TestProjectTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestProject.app/TestProject";
+			};
+			name = Debug;
+		};
 		XCBC89204001 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -444,6 +550,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		XCCL26536501 /* Build configuration list for PBXNativeTarget "TestProjectTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				XCBC60448901 /* Release */,
+				XCBC89077001 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
 		XCCL29934901 /* Build configuration list for PBXNativeTarget "MyFramework" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Fixtures/TestProject/GeneratedProject.xcodeproj/xcshareddata/xcschemes/TestProject.xcscheme
+++ b/Fixtures/TestProject/GeneratedProject.xcodeproj/xcshareddata/xcschemes/TestProject.xcscheme
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Scheme LastUpgradeVersion="0830" version="1.3">
+	<AnalyzeAction buildConfiguration="Debug" />
+	<ArchiveAction buildConfiguration="Release" revealArchiveInOrganizer="YES" />
+	<TestAction selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" shouldUseLaunchSchemeArgsEnv="YES" buildConfiguration="Debug">
+		<Testables>
+			<TestableReference skipped="NO">
+				<BuildableReference BlueprintIdentifier="NT2653659501" ReferencedContainer="container:GeneratedProject.xcodeproj" BuildableName="TestProjectTests.xctest" BlueprintName="TestProject" BuildableIdentifier="primary" />
+			</TestableReference>
+		</Testables>
+		<MacroExpansion>
+			<BuildableReference BlueprintIdentifier="NT6523263101" ReferencedContainer="container:GeneratedProject.xcodeproj" BuildableName="TestProject.app" BlueprintName="TestProject" BuildableIdentifier="primary" />
+		</MacroExpansion>
+	</TestAction>
+	<ProfileAction savedToolIdentifier="" useCustomWorkingDirectory="NO" shouldUseLaunchSchemeArgsEnv="YES" buildConfiguration="Release" debugDocumentVersioning="YES">
+		<BuildableProductRunnable runnableDebuggingMode="0">
+			<BuildableReference BlueprintIdentifier="NT6523263101" ReferencedContainer="container:GeneratedProject.xcodeproj" BuildableName="TestProject.app" BlueprintName="TestProject" BuildableIdentifier="primary" />
+		</BuildableProductRunnable>
+	</ProfileAction>
+	<BuildAction parallelizeBuildables="YES" buildImplicitDependencies="YES">
+		<BuildActionEntries>
+			<BuildActionEntry buildForArchiving="YES" buildForTesting="YES" buildForRunning="YES" buildForProfiling="YES" buildForAnalyzing="YES">
+				<BuildableReference BlueprintIdentifier="NT6523263101" ReferencedContainer="container:GeneratedProject.xcodeproj" BuildableName="TestProject.app" BlueprintName="TestProject" BuildableIdentifier="primary" />
+			</BuildActionEntry>
+			<BuildActionEntry buildForArchiving="NO" buildForTesting="YES" buildForRunning="NO" buildForProfiling="NO" buildForAnalyzing="YES">
+				<BuildableReference BlueprintIdentifier="NT2653659501" ReferencedContainer="container:GeneratedProject.xcodeproj" BuildableName="TestProjectTests.xctest" BlueprintName="TestProject" BuildableIdentifier="primary" />
+			</BuildActionEntry>
+		</BuildActionEntries>
+	</BuildAction>
+	<LaunchAction selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" launchStyle="0" buildConfiguration="Debug" debugServiceExtension="internal" ignoresPersistentStateOnLaunch="NO" useCustomWorkingDirectory="NO" allowLocationSimulation="YES" debugDocumentVersioning="YES">
+		<BuildableProductRunnable runnableDebuggingMode="0">
+			<BuildableReference BlueprintIdentifier="NT6523263101" ReferencedContainer="container:GeneratedProject.xcodeproj" BuildableName="TestProject.app" BlueprintName="TestProject" BuildableIdentifier="primary" />
+		</BuildableProductRunnable>
+	</LaunchAction>
+</Scheme>

--- a/Fixtures/TestProject/TestProject.xcodeproj/project.pbxproj
+++ b/Fixtures/TestProject/TestProject.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CC2A0EC21F33D50E00C324B9 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2A0EC11F33D50E00C324B9 /* TestProjectTests.swift */; };
 		CCA4B60E1F1FC00500DF34A1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA4B60D1F1FC00500DF34A1 /* AppDelegate.swift */; };
 		CCA4B6101F1FC00500DF34A1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCA4B60F1F1FC00500DF34A1 /* ViewController.swift */; };
 		CCA4B6131F1FC00500DF34A1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CCA4B6111F1FC00500DF34A1 /* Main.storyboard */; };
@@ -19,6 +20,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		CC2A0EC41F33D50E00C324B9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CCA4B6021F1FC00500DF34A1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CCA4B6091F1FC00500DF34A1;
+			remoteInfo = TestProject;
+		};
 		CCA71FED1F225E4C00F772C1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = CCA4B6021F1FC00500DF34A1 /* Project object */;
@@ -43,6 +51,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		CC2A0EBF1F33D50E00C324B9 /* TestProjectTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestProjectTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC2A0EC11F33D50E00C324B9 /* TestProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectTests.swift; sourceTree = "<group>"; };
+		CC2A0EC31F33D50E00C324B9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CCA4B60A1F1FC00500DF34A1 /* TestProject.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestProject.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCA4B60D1F1FC00500DF34A1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CCA4B60F1F1FC00500DF34A1 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -57,6 +68,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		CC2A0EBC1F33D50E00C324B9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CCA4B6071F1FC00500DF34A1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -75,11 +93,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		CC2A0EC01F33D50E00C324B9 /* TestProjectTests */ = {
+			isa = PBXGroup;
+			children = (
+				CC2A0EC11F33D50E00C324B9 /* TestProjectTests.swift */,
+				CC2A0EC31F33D50E00C324B9 /* Info.plist */,
+			);
+			path = TestProjectTests;
+			sourceTree = "<group>";
+		};
 		CCA4B6011F1FC00500DF34A1 = {
 			isa = PBXGroup;
 			children = (
 				CCA4B60C1F1FC00500DF34A1 /* TestProject */,
 				CCA71FE91F225E4C00F772C1 /* MyFramework */,
+				CC2A0EC01F33D50E00C324B9 /* TestProjectTests */,
 				CCA4B60B1F1FC00500DF34A1 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -89,6 +117,7 @@
 			children = (
 				CCA4B60A1F1FC00500DF34A1 /* TestProject.app */,
 				CCA71FE81F225E4C00F772C1 /* MyFramework.framework */,
+				CC2A0EBF1F33D50E00C324B9 /* TestProjectTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -130,6 +159,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		CC2A0EBE1F33D50E00C324B9 /* TestProjectTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CC2A0EC81F33D50E00C324B9 /* Build configuration list for PBXNativeTarget "TestProjectTests" */;
+			buildPhases = (
+				CC2A0EBB1F33D50E00C324B9 /* Sources */,
+				CC2A0EBC1F33D50E00C324B9 /* Frameworks */,
+				CC2A0EBD1F33D50E00C324B9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CC2A0EC51F33D50E00C324B9 /* PBXTargetDependency */,
+			);
+			name = TestProjectTests;
+			productName = TestProjectTests;
+			productReference = CC2A0EBF1F33D50E00C324B9 /* TestProjectTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		CCA4B6091F1FC00500DF34A1 /* TestProject */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CCA4B61C1F1FC00500DF34A1 /* Build configuration list for PBXNativeTarget "TestProject" */;
@@ -179,6 +226,12 @@
 				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = "Yonas Kolb";
 				TargetAttributes = {
+					CC2A0EBE1F33D50E00C324B9 = {
+						CreatedOnToolsVersion = 8.3.3;
+						DevelopmentTeam = U7E5MQU624;
+						ProvisioningStyle = Automatic;
+						TestTargetID = CCA4B6091F1FC00500DF34A1;
+					};
 					CCA4B6091F1FC00500DF34A1 = {
 						CreatedOnToolsVersion = 8.3.3;
 						DevelopmentTeam = U7E5MQU624;
@@ -207,11 +260,19 @@
 			targets = (
 				CCA4B6091F1FC00500DF34A1 /* TestProject */,
 				CCA71FE71F225E4C00F772C1 /* MyFramework */,
+				CC2A0EBE1F33D50E00C324B9 /* TestProjectTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		CC2A0EBD1F33D50E00C324B9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CCA4B6081F1FC00500DF34A1 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -263,6 +324,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		CC2A0EBB1F33D50E00C324B9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CC2A0EC21F33D50E00C324B9 /* TestProjectTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CCA4B6061F1FC00500DF34A1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -283,6 +352,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		CC2A0EC51F33D50E00C324B9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CCA4B6091F1FC00500DF34A1 /* TestProject */;
+			targetProxy = CC2A0EC41F33D50E00C324B9 /* PBXContainerItemProxy */;
+		};
 		CCA71FEE1F225E4C00F772C1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = CCA71FE71F225E4C00F772C1 /* MyFramework */;
@@ -310,6 +384,34 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		CC2A0EC61F33D50E00C324B9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = U7E5MQU624;
+				INFOPLIST_FILE = TestProjectTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yonaskolb.TestProjectTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestProject.app/TestProject";
+			};
+			name = Debug;
+		};
+		CC2A0EC71F33D50E00C324B9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = U7E5MQU624;
+				INFOPLIST_FILE = TestProjectTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.yonaskolb.TestProjectTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/TestProject.app/TestProject";
+			};
+			name = Release;
+		};
 		CCA4B61A1F1FC00500DF34A1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -483,6 +585,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		CC2A0EC81F33D50E00C324B9 /* Build configuration list for PBXNativeTarget "TestProjectTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CC2A0EC61F33D50E00C324B9 /* Debug */,
+				CC2A0EC71F33D50E00C324B9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		CCA4B6051F1FC00500DF34A1 /* Build configuration list for PBXProject "TestProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Fixtures/TestProject/TestProject/AppDelegate.swift
+++ b/Fixtures/TestProject/TestProject/AppDelegate.swift
@@ -21,28 +21,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-        // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-    }
-
-
 }
 

--- a/Fixtures/TestProject/TestProjectTests/Info.plist
+++ b/Fixtures/TestProject/TestProjectTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/Fixtures/TestProject/TestProjectTests/TestProjectTests.swift
+++ b/Fixtures/TestProject/TestProjectTests/TestProjectTests.swift
@@ -1,0 +1,35 @@
+//
+//  TestProjectTests.swift
+//  TestProjectTests
+//
+//  Created by Yonas Kolb on 4/8/17.
+//  Copyright © 2017 Yonas Kolb. All rights reserved.
+//
+
+import XCTest
+
+class TestProjectTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}

--- a/Fixtures/TestProject/spec.yml
+++ b/Fixtures/TestProject/spec.yml
@@ -9,6 +9,9 @@ targets:
       PRODUCT_BUNDLE_IDENTIFIER: com.test
     dependencies:
       - target: MyFramework
+    scheme:
+      testTargets:
+        - TestProjectTests
     postbuildScripts:
       - name: Swiftlint
         script: |
@@ -26,3 +29,12 @@ targets:
     postbuildScripts:
       - name: Swiftlint
         path: scripts/swiftlint.sh
+  - name: TestProjectTests
+    type: bundle.unit-test
+    platform: iOS
+    sources: TestProjectTests
+    settings:
+      TEST_HOST: $(BUILT_PRODUCTS_DIR)/TestProject.app/TestProject
+      INFOPLIST_FILE: TestProjectTests/Info.plist
+    dependencies:
+      - target: TestProject

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -21,7 +21,7 @@ public struct Target {
     public var prebuildScripts: [RunScript]
     public var postbuildScripts: [RunScript]
     public var configFiles: [String: String]
-    public var generateSchemes: [String]
+    public var scheme: TargetScheme?
 
     public var filename: String {
         var name = self.name
@@ -31,7 +31,7 @@ public struct Target {
         return name
     }
 
-    public init(name: String, type: PBXProductType, platform: Platform, settings: Settings = .empty, configFiles: [String: String] = [:], sources: [String] = [], sourceExludes: [String] = [], dependencies: [Dependency] = [], prebuildScripts: [RunScript] = [], postbuildScripts: [RunScript] = [], generateSchemes: [String] = []) {
+    public init(name: String, type: PBXProductType, platform: Platform, settings: Settings = .empty, configFiles: [String: String] = [:], sources: [String] = [], sourceExludes: [String] = [], dependencies: [Dependency] = [], prebuildScripts: [RunScript] = [], postbuildScripts: [RunScript] = [], scheme: TargetScheme? = nil) {
         self.name = name
         self.type = type
         self.platform = platform
@@ -42,7 +42,25 @@ public struct Target {
         self.dependencies = dependencies
         self.prebuildScripts = prebuildScripts
         self.postbuildScripts = postbuildScripts
-        self.generateSchemes = generateSchemes
+        self.scheme = scheme
+    }
+}
+
+public struct TargetScheme {
+    public let testTargets: [String]
+    public let configVariants: [String]
+
+    public init(testTargets: [String] = [], configVariants: [String] = []) {
+        self.testTargets = testTargets
+        self.configVariants = configVariants
+    }
+}
+
+extension TargetScheme: JSONObjectConvertible {
+
+    public init(jsonDictionary: JSONDictionary) throws {
+        testTargets = jsonDictionary.json(atKeyPath: "testTargets") ?? []
+        configVariants = jsonDictionary.json(atKeyPath: "configVariants") ?? []
     }
 }
 
@@ -77,7 +95,7 @@ extension Target: JSONObjectConvertible {
         }
         prebuildScripts = jsonDictionary.json(atKeyPath: "prebuildScripts") ?? []
         postbuildScripts = jsonDictionary.json(atKeyPath: "postbuildScripts") ?? []
-        generateSchemes = jsonDictionary.json(atKeyPath: "generateSchemes") ?? []
+        scheme = jsonDictionary.json(atKeyPath: "scheme")
     }
 }
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -158,7 +158,7 @@ func projectGeneratorTests() {
             $0.it("generates target schemes from config variant") {
                 let configVariants = ["Test", "Production"]
                 var target = application
-                target.generateSchemes = configVariants
+                target.scheme = TargetScheme(configVariants: configVariants)
                 let configs: [Config] = [
                     Config(name: "Test Debug", type: .debug),
                     Config(name: "Production Debug", type: .debug),

--- a/docs/ProjectSpec.md
+++ b/docs/ProjectSpec.md
@@ -180,16 +180,20 @@ targets:
       		othercommand
 ```
 
-#### generateSchemes
-This is a convenience used to automatically generate schemes for a target based on large amount of configs. A list of names is provided, then for each of these names a scheme is created, using configs that contain the name with debug and release variants. This is useful for having different environment schemes.
+#### scheme
+This is a convenience used to automatically generate schemes for a target based on different configs  or included tests.
 
-For example, the following spec would create 3 schemes called:
+- **configVariants**: This generates a scheme for each entry, using configs that contain the name with debug and release variants. This is useful for having different environment schemes.
+- **testTargets**: a list of test targets that should be included in the scheme. These will be added to the build targets and the test entries
+
+For example, the spec below would create 3 schemes called:
 
 - MyApp Test
 - MyApp Staging
 - MyApp Production
 
-Each scheme would use different build configuration for the different build types, specifically debug configs for `run`, `test`, and `anaylze`, and release configs for `profile` and `archive`
+Each scheme would use different build configuration for the different build types, specifically debug configs for `run`, `test`, and `anaylze`, and release configs for `profile` and `archive`.
+The MyUnitTests target would also be linked.
 
 ```
 configs:
@@ -201,8 +205,12 @@ configs:
   Production Release: release
 targets
   - name: MyApp
-    generateSchemes:
-      - Test
-      - Staging
-      - Production
+    scheme:
+      testTargets:
+        - MyUnitTests
+      configVariants:
+        - Test
+        - Staging
+        - Production
+  - name: MyUnitTests
 ```


### PR DESCRIPTION
This changes `Target.generateSchemes` to `Target.scheme` which contains `testTargets` and `configVariants`

Fixes #20