### PR TITLE
Dependency embed options

### DIFF
--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -194,31 +194,44 @@ extension Target: JSONObjectConvertible {
     }
 }
 
-public enum Dependency: Equatable {
+public struct Dependency: Equatable {
 
-    case target(String)
-    case framework(String)
-    case carthage(String)
+    public let type: DependencyType
+    public let reference: String
+    public let embed: Bool?
+
+    public init(type: DependencyType, reference: String, embed: Bool? = nil) {
+        self.type = type
+        self.reference = reference
+        self.embed = embed
+    }
+
+    public enum DependencyType {
+        case target
+        case framework
+        case carthage
+    }
 
     public static func ==(lhs: Dependency, rhs: Dependency) -> Bool {
-        switch (lhs, rhs) {
-        case let (.target(lhs), .target(rhs)): return lhs == rhs
-        case let (.framework(lhs), .framework(rhs)): return lhs == rhs
-        case let (.carthage(lhs), .carthage(rhs)): return lhs == rhs
-        default: return false
-        }
+        return lhs.reference == rhs.reference &&
+        lhs.type == rhs.type &&
+        lhs.embed == rhs.embed
     }
 }
 
 extension Dependency: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
+        embed = jsonDictionary.json(atKeyPath: "embed")
         if let target: String = jsonDictionary.json(atKeyPath: "target") {
-            self = .target(target)
+            type = .target
+            reference = target
         } else if let framework: String = jsonDictionary.json(atKeyPath: "framework") {
-            self = .framework(framework)
+            type = .framework
+            reference = framework
         } else if let carthage: String = jsonDictionary.json(atKeyPath: "carthage") {
-            self = .carthage(carthage)
+            type = .carthage
+            reference = carthage
         } else {
             throw ProjectSpecError.invalidDependency(jsonDictionary)
         }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -203,8 +203,9 @@ public class PBXProjGenerator {
         var extensions: [String] = []
 
         for dependancy in target.dependencies {
-            switch dependancy {
-            case let .target(dependencyTargetName):
+            switch dependancy.type {
+            case .target:
+                let dependencyTargetName = dependancy.reference
                 guard let dependencyTarget = spec.getTarget(dependencyTargetName) else { continue }
                 let dependencyFileReference = targetFileReferences[dependencyTargetName]!
 
@@ -235,15 +236,15 @@ public class PBXProjGenerator {
                     }
                 }
 
-            case let .framework(framework):
-                let fileReference = getFileReference(path: Path(framework), inPath: basePath)
+            case .framework:
+                let fileReference = getFileReference(path: Path(dependancy.reference), inPath: basePath)
                 let buildFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, fileReference + target.name), fileRef: fileReference)
                 addObject(buildFile)
                 targetFrameworkBuildFiles.append(buildFile.reference)
                 if !frameworkFiles.contains(fileReference) {
                     frameworkFiles.append(fileReference)
                 }
-            case let .carthage(carthage):
+            case .carthage:
                 if carthageFrameworksByPlatform[target.platform.rawValue] == nil {
                     carthageFrameworksByPlatform[target.platform.rawValue] = []
                 }

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -58,8 +58,8 @@ public class ProjectGenerator {
 
         for target in spec.targets {
             for dependency in target.dependencies {
-                if case let .target(targetName) = dependency, spec.getTarget(targetName) == nil {
-                    errors.append(.invalidTargetDependency(target: target.name, dependency: targetName))
+                if dependency.type == .target, spec.getTarget(dependency.reference) == nil {
+                    errors.append(.invalidTargetDependency(target: target.name, dependency: dependency.reference))
                 }
             }
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -19,7 +19,7 @@ func projectGeneratorTests() {
 
         let application = Target(name: "MyApp", type: .application, platform: .iOS,
                                  settings: Settings(buildSettings: ["SETTING_1": "VALUE"]),
-                                 dependencies: [.target("MyFramework")])
+                                 dependencies: [Dependency(type: .target, reference: "MyFramework")])
 
         let framework = Target(name: "MyFramework", type: .framework, platform: .iOS,
                                settings: Settings(buildSettings: ["SETTING_2": "VALUE"]))

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -53,15 +53,15 @@ func specLoadingTests() {
         $0.it("parses target dependencies") {
             var targetDictionary = validTarget
             targetDictionary["dependencies"] = [
-                ["target": "name"],
+                ["target": "name", "embed": false],
                 ["carthage": "name"],
                 ["framework": "path"],
             ]
             let target = try Target(jsonDictionary: targetDictionary)
             try expect(target.dependencies.count) == 3
-            try expect(target.dependencies[0]) == .target("name")
-            try expect(target.dependencies[1]) == .carthage("name")
-            try expect(target.dependencies[2]) == .framework("path")
+            try expect(target.dependencies[0]) == Dependency(type: .target, reference: "name", embed: false)
+            try expect(target.dependencies[1]) == Dependency(type: .carthage, reference: "name")
+            try expect(target.dependencies[2]) == Dependency(type: .framework, reference: "path")
         }
 
         $0.it("parsed cross platform targets") {

--- a/docs/ProjectSpec.md
+++ b/docs/ProjectSpec.md
@@ -171,15 +171,23 @@ targets:
 ```
 
 ### Dependency
-A dependency can be one of a few types:
+A dependency can be one of a 3 types:
 
 - `target: name` - links to another target
 - `framework: path` - links to a framework
 - `carthage: name` - helper for linking to a carthage framework
 
-**Carthage notes**
+**Embed options**:
 
-Carthage frameworks expected to be in `CARTHAGE_BUILD_PATH/PLATFORM/FRAMEWORK.framework` where:
+These only applied to `target` and `framework` dependencies.
+
+- ⚪️ **embed**: `Bool` - Whether to embed the dependency. Defaults to true for application target and false for non application targets.
+- ⚪️ **codeSign**: `Bool` - Whether the `codeSignOnCopy` setting is applied when embedding framework. Defaults to true
+- ⚪️ **removeHeaders**: `Bool` - Whether the `removeHeadersOnCopy` setting is applied when embedding the framework. Defaults to true
+
+**Carthage Dependency**
+
+Carthage frameworks are expected to be in `CARTHAGE_BUILD_PATH/PLATFORM/FRAMEWORK.framework` where:
 
  - `CARTHAGE_BUILD_PATH` = `options.carthageBuildPath` or `Carthage/Build` by default
  - `PLATFORM` = the target's platform


### PR DESCRIPTION
Fixes #27

This adds a `embed` `codeSign` and `removeHeaders` properties on Dependency. 
`embed` has different defaults depending if it's set on a app target or not. See ProjectSpec.MD for details