### PR TITLE
Add support to C and C++ files in ‘Compile sources’

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -429,7 +429,7 @@ public class PBXProjGenerator {
         }
         if let fileExtension = path.extension {
             switch fileExtension {
-            case "swift", "m": return .sources
+            case "swift", "m", "cpp": return .sources
             case "h", "hh", "hpp", "ipp", "tpp", "hxx", "def": return .headers
             case "xcconfig": return nil
             default: return .resources


### PR DESCRIPTION
Previously the Compile Sources section was empty because it was not able
to recognize the file extension.