### PR TITLE
Filter out NSNull elements from the json dictionary.

### DIFF
--- a/Sources/XcodeGenKit/SpecLoader.swift
+++ b/Sources/XcodeGenKit/SpecLoader.swift
@@ -16,7 +16,8 @@ public struct SpecLoader {
 
     public static func loadSpec(path: Path) throws -> ProjectSpec {
         let dictionary = try loadDictionary(path: path)
-        return try ProjectSpec(jsonDictionary: dictionary)
+        let filteredDictionary = SpecLoader.filterNull(dictionary) as! [String:Any]
+        return try ProjectSpec(jsonDictionary: filteredDictionary)
     }
 
     private static func loadDictionary(path: Path) throws -> JSONDictionary {
@@ -51,5 +52,24 @@ public struct SpecLoader {
             }
         }
         return merged
+    }
+
+    private static func filterNull(_ object:Any) -> Any {
+        var returnedValue : Any = object
+        if let dict = object as? [String:Any] {
+            var mutabledic : [String: Any] = [:]
+            for (key, value) in dict {
+                mutabledic[key] = SpecLoader.filterNull(value)
+            }
+            returnedValue = mutabledic
+        }
+        else if let array = object as? [Any] {
+            var mutableArray: [Any] = array
+            for (index, value) in array.enumerated() {
+                mutableArray[index] = SpecLoader.filterNull(value)
+            }
+            returnedValue = mutableArray
+        }
+        return (object is NSNull) ? "" : returnedValue
     }
 }


### PR DESCRIPTION
This change allows overriding default BuildSettings.

For example:

If I want to keep the attribute SWIFT_OBJC_INTERFACE_HEADER_NAME empty,
(by default it contains some value). I just need to override this value
in the settings spec.

Previously, If I keep property empty, the generated settings value
appear as <null>.