### PR TITLE
Fix the build issues when using the Xcode 9 GM.

### DIFF
--- a/Sources/ProjectSpec/Decoding.swift
+++ b/Sources/ProjectSpec/Decoding.swift
@@ -13,7 +13,7 @@ import Yams
 
 extension Dictionary where Key: JSONKey {
 
-    public func json<T: NamedJSONDictionaryConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
+    public func json<T: NamedJSONDictionaryConvertible>(atKeyPath keyPath: JSONUtilities.KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
         guard let dictionary = json(atKeyPath: keyPath) as JSONDictionary? else {
             return []
         }
@@ -26,7 +26,7 @@ extension Dictionary where Key: JSONKey {
         return items
     }
 
-    public func json<T: NamedJSONConvertible>(atKeyPath keyPath: KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
+    public func json<T: NamedJSONConvertible>(atKeyPath keyPath: JSONUtilities.KeyPath, invalidItemBehaviour: InvalidItemBehaviour<T> = .remove) throws -> [T] {
         guard let dictionary = json(atKeyPath: keyPath) as JSONDictionary? else {
             return []
         }

--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -23,7 +23,7 @@ func generate(spec: String, project: String) {
     do {
         spec = try SpecLoader.loadSpec(path: specPath)
         print("Loaded spec: \(spec.targets.count) targets, \(spec.schemes.count) schemes, \(spec.configs.count) configs")
-    } catch let error as DecodingError {
+    } catch let error as JSONUtilities.DecodingError {
         print("Parsing spec failed: \(error.description)")
         return
     } catch {


### PR DESCRIPTION
This change fixes this issue: https://github.com/yonaskolb/XcodeGen/issues/51

The build issues include:

- KeyPath class was added in Swift 4, which collides with the KeyPath defined in JSONUtilies.
  This was fixed by disambiguating the type by specifying "JSONUtilities.KeyPath" instead of just "KeyPath".
- DecodingError was added in Swift 4, which collides with DecodingError defined in JSONUtilities.
  This was fixed by disambiguating the type by specifying "JSONUtilities.DecodingError" instead of just "DecodingError".
- There were several places where xcodeproj was expecint [String] and the code was calling it with Set<String>. Apparently this worked in Swift 3.2, but no longer works in Swift 4. So these places were corrected by:
  - Not creating a Set() when an array was needed
  - Calling .sorted() on the Set to produce an array