### PR TITLE
Always embed frameworks for macOS, but provide link option for ObjC selector calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+### Fixed
+- Always embed frameworks for macOS, but provide link option for ObjC selector calls [#79](https://github.com/yonaskolb/XcodeGen/pull/79) @toshi0383
+
 ## 1.2.3
 
 ### Fixed

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -225,7 +225,8 @@ public struct Dependency: Equatable {
             lhs.type == rhs.type &&
             lhs.codeSign == rhs.codeSign &&
             lhs.removeHeaders == rhs.removeHeaders &&
-            lhs.embed == rhs.embed
+            lhs.embed == rhs.embed &&
+            lhs.link == rhs.link
     }
 
     public var buildSettings: [String: Any] {

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -203,13 +203,15 @@ public struct Dependency: Equatable {
     public var type: DependencyType
     public var reference: String
     public var embed: Bool?
+    public var link: Bool?
     public var codeSign: Bool = true
     public var removeHeaders: Bool = true
 
-    public init(type: DependencyType, reference: String, embed: Bool? = nil) {
+    public init(type: DependencyType, reference: String, embed: Bool? = nil, link: Bool? = nil) {
         self.type = type
         self.reference = reference
         self.embed = embed
+        self.link = link
     }
 
     public enum DependencyType {
@@ -255,6 +257,8 @@ extension Dependency: JSONObjectConvertible {
         }
 
         embed = jsonDictionary.json(atKeyPath: "embed")
+
+        link = jsonDictionary.json(atKeyPath: "link")
 
         if let bool: Bool = jsonDictionary.json(atKeyPath: "codeSign") {
             codeSign = bool

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -295,8 +295,16 @@ public class PBXProjGenerator {
                 let buildFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, fileReference + target.name), fileRef: fileReference)
                 addObject(buildFile)
                 carthageFrameworksByPlatform[target.platform.carthageDirectoryName]?.append(fileReference)
-
-                targetFrameworkBuildFiles.append(buildFile.reference)
+                 if target.platform == .macOS {
+                    let embedFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, fileReference + target.name), fileRef: fileReference, settings: dependency.buildSettings)
+                    addObject(embedFile)
+                    copyFiles.append(embedFile.reference)
+                    if let link = dependency.link, link {
+                        targetFrameworkBuildFiles.append(buildFile.reference)
+                    }
+                 } else {
+                    targetFrameworkBuildFiles.append(buildFile.reference)
+                 }
             }
         }
 

--- a/docs/ProjectSpec.md
+++ b/docs/ProjectSpec.md
@@ -218,6 +218,12 @@ These only applied to `target` and `framework` dependencies.
 - ⚪️ **codeSign**: `Bool` - Whether the `codeSignOnCopy` setting is applied when embedding framework. Defaults to true
 - ⚪️ **removeHeaders**: `Bool` - Whether the `removeHeadersOnCopy` setting is applied when embedding the framework. Defaults to true
 
+**Carthage link option for macOS**:
+
+For macOS, Carthage frameworks are to be always embedded. But sometime you need to link, too.
+
+- ⚪️ **link**: `Bool` - [macOS only] Whether to link the dependency. Defaults to false.
+
 **Carthage Dependency**
 
 Carthage frameworks are expected to be in `CARTHAGE_BUILD_PATH/PLATFORM/FRAMEWORK.framework` where:


### PR DESCRIPTION
SeeAlso: https://github.com/Carthage/Carthage#if-youre-building-for-os-x

For Objective-C runtime compatibility, `Linked Frameworks and Binaries` is sometimes necessary.

# project.yml
```yml
    dependencies:
      - target: LGTMKit_macOS
      - carthage: APIKit
      - carthage: Alamofire
      - carthage: Himotoki
      - carthage: MASPreferences
        link: true
      - carthage: Nuke
      - carthage: Realm
      - carthage: RealmSwift
      - carthage: Result
      - carthage: RxBlocking
      - carthage: RxCocoa
      - carthage: RxSwift
      - carthage: RxTest
      - carthage: SwiftyUserDefaults
      - carthage: Toast
        link: true
```

# Generated Project
<img width="554" alt="screen shot 2017-09-30 at 6 46 29" src="https://user-images.githubusercontent.com/6007952/31037429-cc82f60c-a5ab-11e7-95be-c4daa1272b09.png">

e.g. Toggling MASPreferences' tabbar causes `unrecognized selector` runtime error, unless you have `MASPreferences.framework` both embedded and linked.