### PR TITLE
Always embed and link frameworks for macOS

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -297,6 +297,11 @@ public class PBXProjGenerator {
                 carthageFrameworksByPlatform[target.platform.carthageDirectoryName]?.append(fileReference)
 
                 targetFrameworkBuildFiles.append(buildFile.reference)
+                if target.platform == .macOS {
+                    let embedFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, fileReference + target.name), fileRef: fileReference, settings: dependency.buildSettings)
+                    addObject(embedFile)
+                    copyFiles.append(embedFile.reference)
+                }
             }
         }
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -297,7 +297,7 @@ public class PBXProjGenerator {
                 carthageFrameworksByPlatform[target.platform.carthageDirectoryName]?.append(fileReference)
 
                 targetFrameworkBuildFiles.append(buildFile.reference)
-                if target.platform == .macOS {
+                if target.platform == .macOS && target.type.isApp {
                     let embedFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, fileReference + target.name), fileRef: fileReference, settings: dependency.buildSettings)
                     addObject(embedFile)
                     copyFiles.append(embedFile.reference)


### PR DESCRIPTION
Replaces #79.
XcodeGen currently don't support embedding Carthage frameworks.
SeeAlso: https://github.com/Carthage/Carthage#if-youre-building-for-os-x

# project.yml
```yml
...
targets:
  LGTM:
    platform: macOS
    type: application
    sources:
      - LGTM
    dependencies:
      - target: LGTMKit_macOS
      - carthage: APIKit
      - carthage: Alamofire
      - carthage: Himotoki
      - carthage: MASPreferences
      - carthage: Nuke
      - carthage: Realm
      - carthage: RealmSwift
      - carthage: Result
      - carthage: RxCocoa
      - carthage: RxSwift
      - carthage: SwiftyUserDefaults
      - carthage: Toast
...
```

# Before
<img width="707" alt="screen shot 2017-10-01 at 9 32 42" src="https://user-images.githubusercontent.com/6007952/31050648-9e1ce634-a68b-11e7-8bb1-61ae727bb723.png">

# After
<img width="717" alt="screen shot 2017-10-01 at 9 33 20" src="https://user-images.githubusercontent.com/6007952/31050650-a6a5d856-a68b-11e7-9e4a-885996ef96ab.png">