### PR TITLE
Fix dependency framework/library linking

### DIFF
--- a/Fixtures/TestProject/GeneratedProject.xcodeproj/project.pbxproj
+++ b/Fixtures/TestProject/GeneratedProject.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BF3862341101 /* MyFramework.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR2993497801 /* MyFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BF5986511201 = {isa = PBXBuildFile; fileRef = FR6523263101 /* TestProject.app */; };
 		BF6182896901 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR9215298301 /* Result.framework */; };
+		BF7015992001 /* MyFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR2993497801 /* MyFramework.framework */; };
 		BF9001417701 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6877173101 /* TestProjectTests.swift */; };
 		BF9155249601 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7078510801 /* FrameworkFile.swift */; };
 /* End PBXBuildFile section */
@@ -80,6 +81,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF7015992001 /* MyFramework.framework in Frameworks */,
 				BF6182896901 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/ProjectSpec/ProjectExtensions.swift
+++ b/Sources/ProjectSpec/ProjectExtensions.swift
@@ -46,6 +46,14 @@ extension PBXProductType {
         }
     }
 
+    public var isFramework: Bool {
+        return self == .framework
+    }
+
+    public var isLibrary: Bool {
+        return self == .staticLibrary || self == .dynamicLibrary
+    }
+
     public var isExtension: Bool {
         return fileExtension == "appex"
     }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -256,7 +256,8 @@ public class PBXProjGenerator {
                     targetFrameworkBuildFiles.append(buildFile.reference)
                 }
 
-                if embed {
+                if embed && !dependencyTarget.type.isLibrary {
+
                     let embedSettings = dependency.buildSettings
                     let embedFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, dependencyFileReference + target.name), fileRef: dependencyFileReference, settings: embedSettings)
                     addObject(embedFile)

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -25,7 +25,7 @@ public class PBXProjGenerator {
     var variantGroupsByPath: [Path: PBXVariantGroup] = [:]
 
     var targetNativeReferences: [String: String] = [:]
-    var targetBuildFileReferences: [String: String] = [:]
+    var targetBuildFiles: [String: PBXBuildFile] = [:]
     var targetFileReferences: [String: String] = [:]
     var topLevelGroups: [PBXGroup] = []
     var carthageFrameworksByPlatform: [String: [String]] = [:]
@@ -93,7 +93,7 @@ public class PBXProjGenerator {
 
             let buildFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, fileReference.reference), fileRef: fileReference.reference)
             addObject(buildFile)
-            targetBuildFileReferences[target.name] = buildFile.reference
+            targetBuildFiles[target.name] = buildFile
         }
 
         let targets = try spec.targets.map(generateTarget)
@@ -249,9 +249,12 @@ public class PBXProjGenerator {
                 addObject(targetDependency)
                 dependencies.append(targetDependency.reference)
 
-                // don't bother linking a target dependency
-                // let dependencyBuildFile = targetBuildFileReferences[dependencyTargetName]!
-                // targetFrameworkBuildFiles.append(dependencyBuildFile)
+                if dependencyTarget.type.isLibrary || dependencyTarget.type.isFramework {
+                    let dependencyBuildFile = targetBuildFiles[dependencyTargetName]!
+                    let buildFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, dependencyBuildFile.reference + target.name), fileRef: dependencyBuildFile.fileRef)
+                    addObject(buildFile)
+                    targetFrameworkBuildFiles.append(buildFile.reference)
+                }
 
                 if embed {
                     let embedSettings = dependency.buildSettings

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,4 +5,5 @@ XCTMain([
     testCase(GeneratorTests.allTests),
     testCase(SpecLoadingTests.allTests),
     testCase(FixtureTests.allTests),
+    testCase(ProjectSpecTests.allTests),
 ])

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -1,0 +1,28 @@
+import Spectre
+import XcodeGenKit
+import xcproj
+import ProjectSpec
+
+func projectSpecTests() {
+
+    describe("ProjectSpec") {
+
+        let framework = Target(name: "MyFramework", type: .framework, platform: .iOS,
+                               settings: Settings(buildSettings: ["SETTING_2": "VALUE"]))
+        let staticLibrary = Target(name: "MyStaticLibrary", type: .staticLibrary, platform: .iOS,
+                                   settings: Settings(buildSettings: ["SETTING_2": "VALUE"]))
+        let dynamicLibrary = Target(name: "MyDynamicLibrary", type: .dynamicLibrary, platform: .iOS,
+                                    settings: Settings(buildSettings: ["SETTING_2": "VALUE"]))
+
+        $0.describe("Types") {
+            $0.it("is a framework when it has the right extension") {
+                try expect(framework.type.isFramework).to.beTrue()
+            }
+
+            $0.it("is a library when it has the right type") {
+                try expect(staticLibrary.type.isLibrary).to.beTrue()
+                try expect(dynamicLibrary.type.isLibrary).to.beTrue()
+            }
+        }
+    }
+}

--- a/Tests/XcodeGenKitTests/XCTest.swift
+++ b/Tests/XcodeGenKitTests/XCTest.swift
@@ -7,5 +7,6 @@ class XCodeGenKitTests: XCTestCase {
         projectGeneratorTests()
         specLoadingTests()
         fixtureTests()
+        projectSpecTests()
     }
 }


### PR DESCRIPTION
This PR updates XcodeGen to link framework and library dependencies of targets, into the dependent targets. This is required for them to be usable at runtime. This also removes libraries from the copy framework build phase, since that just results in a `.a` file ending up in your final package.

This should fix https://github.com/yonaskolb/XcodeGen/issues/92