### PR TITLE
Exclude more file types from resources

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -450,7 +450,7 @@ public class PBXProjGenerator {
             switch fileExtension {
             case "swift", "m", "cpp": return .sources
             case "h", "hh", "hpp", "ipp", "tpp", "hxx", "def": return .headers
-            case "xcconfig": return nil
+            case "xcconfig", "entitlements", "gpx", "lproj", "apns": return nil
             default: return .resources
             }
         }


### PR DESCRIPTION
Entitlements files, gpx files, explicit lproj directories, and apns test files should
never be included in a target's copy resources phase.

Ideally this would also include files with the plist extension, but
there are some outliers such as AppIntentVocabulary.plist.