### PR TITLE
Allow copying of resource files from targets

### DIFF
--- a/Sources/ProjectSpec/ProjectExtensions.swift
+++ b/Sources/ProjectSpec/ProjectExtensions.swift
@@ -46,6 +46,10 @@ extension PBXProductType {
         }
     }
 
+    public var isFramework: Bool {
+        return fileExtension == "framework"
+    }
+
     public var isExtension: Bool {
         return fileExtension == "appex"
     }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -229,7 +229,8 @@ public class PBXProjGenerator {
 
         var dependencies: [String] = []
         var targetFrameworkBuildFiles: [String] = []
-        var copyFiles: [String] = []
+        var copyFrameworksReferences: [String] = []
+        var copyResourcesReferences: [String] = []
         var copyWatchReferences: [String] = []
         var extensions: [String] = []
 
@@ -261,10 +262,12 @@ public class PBXProjGenerator {
                     if dependencyTarget.type.isExtension {
                         // embed app extension
                         extensions.append(embedFile.reference)
+                    } else if dependencyTarget.type.isFramework {
+                        copyFrameworksReferences.append(embedFile.reference)
                     } else if dependencyTarget.type.isApp && dependencyTarget.platform == .watchOS {
                         copyWatchReferences.append(embedFile.reference)
                     } else {
-                        copyFiles.append(embedFile.reference)
+                        copyResourcesReferences.append(embedFile.reference)
                     }
                 }
 
@@ -283,7 +286,7 @@ public class PBXProjGenerator {
                 if embed {
                     let embedFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, fileReference + target.name), fileRef: fileReference, settings: dependency.buildSettings)
                     addObject(embedFile)
-                    copyFiles.append(embedFile.reference)
+                    copyFrameworksReferences.append(embedFile.reference)
                 }
             case .carthage:
                 if carthageFrameworksByPlatform[target.platform.carthageDirectoryName] == nil {
@@ -304,7 +307,7 @@ public class PBXProjGenerator {
                 if target.platform == .macOS && target.type.isApp {
                     let embedFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, fileReference + target.name), fileRef: fileReference, settings: dependency.buildSettings)
                     addObject(embedFile)
-                    copyFiles.append(embedFile.reference)
+                    copyFrameworksReferences.append(embedFile.reference)
                 }
             }
         }
@@ -348,7 +351,7 @@ public class PBXProjGenerator {
         addObject(sourcesBuildPhase)
         buildPhases.append(sourcesBuildPhase.reference)
 
-        let resourcesBuildPhase = PBXResourcesBuildPhase(reference: generateUUID(PBXResourcesBuildPhase.self, target.name), files: getBuildFilesForPhase(.resources))
+        let resourcesBuildPhase = PBXResourcesBuildPhase(reference: generateUUID(PBXResourcesBuildPhase.self, target.name), files: getBuildFilesForPhase(.resources) + copyResourcesReferences)
         addObject(resourcesBuildPhase)
         buildPhases.append(resourcesBuildPhase.reference)
 
@@ -379,13 +382,13 @@ public class PBXProjGenerator {
             buildPhases.append(copyFilesPhase.reference)
         }
 
-        if !copyFiles.isEmpty {
+        if !copyFrameworksReferences.isEmpty {
 
             let copyFilesPhase = PBXCopyFilesBuildPhase(
                 reference: generateUUID(PBXCopyFilesBuildPhase.self, "embed frameworks" + target.name),
                 dstPath: "",
                 dstSubfolderSpec: .frameworks,
-                files: copyFiles)
+                files: copyFrameworksReferences)
 
             addObject(copyFilesPhase)
             buildPhases.append(copyFilesPhase.reference)


### PR DESCRIPTION
Previously we were assuming that all targets that were not app
extensions should be added to the copy frameworks build phase, even
though we didn't have any guarantee they were actually frameworks. This
updates that to ensure that things copied in the copy frameworks phase
are actually frameworks, and then falls back to the resources phase
instead. This fixes the ability to embed bundle targets, and copy them
as resources.

Fixes https://github.com/yonaskolb/XcodeGen/issues/91