### PR TITLE
Strip XcodeGen after building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ install: build
 
 build:
 	swift build --disable-sandbox -c release -Xswiftc -static-stdlib
+	strip $(BUILD_PATH)
 
 uninstall:
 	rm -f $(INSTALL_PATH)


### PR DESCRIPTION
This removes the symbols from the final binary, making it much smaller.
In my tests it took the binary from 13mbs to 8.6mbs.