### PR TITLE
Make build a PHONY task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ install: build
 	mkdir -p $(SHARE_PATH)
 	cp -R $(CURRENT_PATH)/SettingPresets $(SHARE_PATH)/SettingPresets
 
+.PHONY: build
 build:
 	swift build --disable-sandbox -c release -Xswiftc -static-stdlib
 


### PR DESCRIPTION
This solves the issue where if someone is generating a xcodeproj to work
on XcodeGen, and their build directories are local, this command would
assume that it should only run if something in that directory is
changed, which isn't the case, we want it to run all the time and for
swiftpm to decide if something has changed.