### PR TITLE
Correct README --help argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ xcodegen
 
 This will look for a project spec in the current directory called `project.yml`
 
-Use `xcodegen help` to see the list of options:
+Use `xcodegen --help` to see the list of options:
 
 - **--spec**: An optional path to a `.yml` or `.json` project spec
 - **--project**: An optional path to a directory where the project will be generated. By default this is the current directory


### PR DESCRIPTION
This needs dashes, if you run it without it XcodeGen does print some
help but only because the command failed.