### PR TITLE
Don't apply base project settings if config doesn't have a type

### DIFF
--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -16,11 +16,10 @@ import JSONUtilities
 extension ProjectSpec {
 
     public func getProjectBuildSettings(config: Config) -> BuildSettings {
-
         var buildSettings: BuildSettings = [:]
-        buildSettings += SettingsPresetFile.base.getBuildSettings()
 
         if let type = config.type {
+            buildSettings += SettingsPresetFile.base.getBuildSettings()
             buildSettings += SettingsPresetFile.config(type).getBuildSettings()
         }
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -62,6 +62,15 @@ func projectGeneratorTests() {
                 try expect(configs).contains(name: "config1")
                 try expect(configs).contains(name: "config2")
             }
+            
+            $0.it("clears config settings when missing type") {
+                let spec = ProjectSpec(name: "test", configs: [Config(name: "config")])
+                let project = try getProject(spec)
+                guard let config = project.pbxproj.buildConfigurations.first else {
+                    throw failure("configuration not found")
+                }
+                try expect(config.buildSettings.isEmpty).to.beTrue()
+            }
 
             $0.it("merges settings") {
                 let spec = try ProjectSpec(path: fixturePath + "settings_test.yml")


### PR DESCRIPTION
Resolves #89

Previously when a configuration didn't have a debug or release type, it wouldn't apply the debug or release setting presets. It now also won't apply the shared base settings from `SettingPresets/base.yml`

This allows for generating a project with no project settings
```
configs:
  Debug: none
  Release: none
```

Target build settings remain unaffected