### PR TITLE
fix duplicate file reference

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -549,8 +549,6 @@ public class PBXProjGenerator {
         for localisedDirectory in localisedDirectories {
             let localisationName = localisedDirectory.lastComponentWithoutExtension
             for path in try localisedDirectory.children().sorted { $0.lastComponent < $1.lastComponent } {
-
-
                 let filePath = "\(localisedDirectory.lastComponent)/\(path.lastComponent)"
 
                 // find base localisation variant group
@@ -571,7 +569,9 @@ public class PBXProjGenerator {
                 }
 
                 if let variantGroup = variantGroup {
-                    variantGroup.children.append(fileReference)
+                    if !variantGroup.children.contains(fileReference) {
+                        variantGroup.children.append(fileReference)
+                    }
                 } else {
                     // add SourceFile to group if there is no Base.lproj directory
                     let buildFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, fileReference),


### PR DESCRIPTION
This fixes the issue that appending same file reference multiple times reported in https://github.com/yonaskolb/XcodeGen/pull/70#issuecomment-338495091.

```bash
2017-10-23 10:53:05.884 xcodebuild[28358:1645638] warning:  The file reference for "Base.lproj/Localizable.strings" is a member of multiple groups ("Localizable.strings" and "Localizable.strings"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
make: *** [build] Error 1
```
