### PR TITLE
Move basePath into ProjectSpec

### DIFF
--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -14,6 +14,7 @@ import Yams
 
 public struct ProjectSpec {
 
+    public var basePath: Path
     public var name: String
     public var targets: [Target]
     public var settings: Settings
@@ -56,7 +57,8 @@ public struct ProjectSpec {
         }
     }
 
-    public init(name: String, configs: [Config] = [], targets: [Target] = [], settings: Settings = .empty, settingGroups: [String: Settings] = [:], schemes: [Scheme] = [], options: Options = Options(), fileGroups: [String] = [], configFiles: [String: String] = [:], attributes: [String: Any] = [:]) {
+    public init(basePath: Path, name: String, configs: [Config] = [], targets: [Target] = [], settings: Settings = .empty, settingGroups: [String: Settings] = [:], schemes: [Scheme] = [], options: Options = Options(), fileGroups: [String] = [], configFiles: [String: String] = [:], attributes: [String: Any] = [:]) {
+        self.basePath = basePath
         self.name = name
         self.targets = targets
         self.configs = configs
@@ -124,9 +126,10 @@ extension ProjectSpec.Options: Equatable {
     }
 }
 
-extension ProjectSpec: JSONObjectConvertible {
+extension ProjectSpec {
 
-    public init(jsonDictionary: JSONDictionary) throws {
+    public init(basePath: Path, jsonDictionary: JSONDictionary) throws {
+        self.basePath = basePath
         let jsonDictionary = try ProjectSpec.filterJSON(jsonDictionary: jsonDictionary)
         name = try jsonDictionary.json(atKeyPath: "name")
         settings = jsonDictionary.json(atKeyPath: "settings") ?? .empty

--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -33,7 +33,7 @@ func generate(spec: String, project: String) {
     }
 
     do {
-        let projectGenerator = ProjectGenerator(spec: spec, path: specPath.parent())
+        let projectGenerator = ProjectGenerator(spec: spec)
         let project = try projectGenerator.generateProject()
         print("⚙️  Generated project")
 

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -16,12 +16,10 @@ import ProjectSpec
 public class ProjectGenerator {
 
     var spec: ProjectSpec
-    var path: Path
     let currentXcodeVersion = "0900"
 
-    public init(spec: ProjectSpec, path: Path) {
+    public init(spec: ProjectSpec) {
         self.spec = spec
-        self.path = path
     }
 
     var defaultDebugConfig: Config {
@@ -33,8 +31,8 @@ public class ProjectGenerator {
     }
 
     public func generateProject() throws -> XcodeProj {
-        try spec.validate(path: path)
-        let pbxProjGenerator = PBXProjGenerator(spec: spec, path: path, currentXcodeVersion: currentXcodeVersion)
+        try spec.validate()
+        let pbxProjGenerator = PBXProjGenerator(spec: spec, currentXcodeVersion: currentXcodeVersion)
         let pbxProject = try pbxProjGenerator.generate()
         let workspace = try generateWorkspace()
         let sharedData = try generateSharedData(pbxProject: pbxProject)

--- a/Sources/XcodeGenKit/SpecLoader.swift
+++ b/Sources/XcodeGenKit/SpecLoader.swift
@@ -16,7 +16,7 @@ public struct SpecLoader {
 
     public static func loadSpec(path: Path) throws -> ProjectSpec {
         let dictionary = try loadDictionary(path: path)
-        return try ProjectSpec(jsonDictionary: dictionary)
+        return try ProjectSpec(basePath: path.parent(), jsonDictionary: dictionary)
     }
 
     private static func loadDictionary(path: Path) throws -> JSONDictionary {

--- a/Sources/XcodeGenKit/SpecValidation.swift
+++ b/Sources/XcodeGenKit/SpecValidation.swift
@@ -11,7 +11,7 @@ import PathKit
 
 extension ProjectSpec {
 
-    public mutating func validate(path: Path) throws {
+    public mutating func validate() throws {
 
         if configs.isEmpty {
             configs = [Config(name: "Debug", type: .debug), Config(name: "Release", type: .release)]
@@ -32,13 +32,13 @@ extension ProjectSpec {
         }
 
         for fileGroup in fileGroups {
-            if !(path + fileGroup).exists {
+            if !(basePath + fileGroup).exists {
                 errors.append(.invalidFileGroup(fileGroup))
             }
         }
 
         for (config, configFile) in configFiles {
-            if !(path + configFile).exists {
+            if !(basePath + configFile).exists {
                 errors.append(.invalidConfigFile(configFile: configFile, config: config))
             }
         }
@@ -55,7 +55,7 @@ extension ProjectSpec {
             }
 
             for (config, configFile) in target.configFiles {
-                if !(path + configFile).exists {
+                if !(basePath + configFile).exists {
                     errors.append(.invalidTargetConfigFile(configFile: configFile, config: config, target: target.name))
                 }
             }
@@ -67,7 +67,7 @@ extension ProjectSpec {
             }
 
             for source in target.sources {
-                let sourcePath = path + source
+                let sourcePath = basePath + source
                 if !sourcePath.exists {
                     errors.append(.missingTargetSource(target: target.name, source: sourcePath.string))
                 }
@@ -94,7 +94,7 @@ extension ProjectSpec {
             let scripts = target.prebuildScripts + target.postbuildScripts
             for script in scripts {
                 if case let .path(pathString) = script.script {
-                    let scriptPath = path + pathString
+                    let scriptPath = basePath + pathString
                     if !scriptPath.exists {
                         errors.append(.invalidBuildScriptPath(target: target.name, path: pathString))
                     }

--- a/Tests/XcodeGenKitTests/FixtureTests.swift
+++ b/Tests/XcodeGenKitTests/FixtureTests.swift
@@ -7,8 +7,8 @@ import ProjectSpec
 let fixturePath = Path(#file).parent().parent().parent() + "Fixtures"
 
 func generate(specPath: Path, projectPath: Path) throws -> XcodeProj {
-    let spec = try ProjectSpec(path: specPath)
-    let generator = ProjectGenerator(spec: spec, path: specPath.parent())
+    let spec = try SpecLoader.loadSpec(path: specPath)
+    let generator = ProjectGenerator(spec: spec)
     let project = try generator.generateProject()
     let oldProject = try XcodeProj(path: projectPath)
     try project.write(path: projectPath, override: true)

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -12,7 +12,7 @@ func specLoadingTests() {
         for (key, value) in spec {
             specDictionary[key] = value
         }
-        return try ProjectSpec(jsonDictionary: specDictionary)
+        return try ProjectSpec(basePath: "", jsonDictionary: specDictionary)
     }
 
     func expectProjectSpecError(_ spec: [String: Any], _ expectedError: ProjectSpecError) throws {
@@ -82,7 +82,7 @@ func specLoadingTests() {
             try expect(target.dependencies[2]) == Dependency(type: .framework, reference: "path")
         }
 
-        $0.it("parsed cross platform targets") {
+        $0.it("parses cross platform targets") {
             let targetDictionary: [String: Any] = [
                 "platform": ["iOS", "tvOS"],
                 "type": "framework",
@@ -128,7 +128,7 @@ func specLoadingTests() {
         }
 
         $0.it("parses settings") {
-            let spec = try ProjectSpec(path: fixturePath + "settings_test.yml")
+            let spec = try SpecLoader.loadSpec(path: fixturePath + "settings_test.yml")
             let buildSettings: BuildSettings = ["SETTING": "value"]
             let configSettings: [String: Settings] = ["config1": Settings(buildSettings: ["SETTING1": "value"])]
             let groups = ["preset1"]
@@ -176,7 +176,7 @@ func specLoadingTests() {
             var options = ProjectSpec.Options()
             options.carthageBuildPath = "../Carthage/Build"
             options.bundleIdPrefix = "com.test"
-            let expected = ProjectSpec(name: "test", options: options)
+            let expected = ProjectSpec(basePath: "", name: "test", options: options)
             let parsedSpec = try getProjectSpec(["options": ["carthageBuildPath": "../Carthage/Build", "bundleIdPrefix": "com.test"]])
             try expect(parsedSpec) == expected
         }


### PR DESCRIPTION
This removes the need to store and pass around the basePath of a spec