### PR TITLE
Support file sources

### DIFF
--- a/Fixtures/TestProject/App_iOS/AppDelegate.swift
+++ b/Fixtures/TestProject/App_iOS/AppDelegate.swift
@@ -18,6 +18,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         _ = FrameworkStruct()
+        // Standalone files added to project by path-to-file.
+        _ = standaloneHello()
         return true
     }
 

--- a/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 /* Begin PBXBuildFile section */
 		BF1073850101 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1332263601 /* AppDelegate.swift */; };
 		BF1401236301 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR3032072501 /* Alamofire.framework */; };
+		BF1628293501 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2554453101 /* Standalone.swift */; };
 		BF1744565901 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6218091901 /* ViewController.swift */; };
 		BF2018435801 /* Framework_iOS.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR4722960401 /* Framework_iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BF2250910101 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG2043127501 /* Main.storyboard */; };
@@ -70,6 +71,7 @@
 		FR1345298502 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FR1345298503 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FR1473702401 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		FR2554453101 /* Standalone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Standalone.swift; sourceTree = "<group>"; };
 		FR3032072501 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
 		FR3032072502 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
 		FR3032072503 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
@@ -195,6 +197,15 @@
 			path = tvOS;
 			sourceTree = "<group>";
 		};
+		G66512504301 /* StandaloneFiles */ = {
+			isa = PBXGroup;
+			children = (
+				FR2554453101 /* Standalone.swift */,
+			);
+			name = StandaloneFiles;
+			path = StandaloneFiles;
+			sourceTree = "<group>";
+		};
 		G67871650901 /* watchOS */ = {
 			isa = PBXGroup;
 			children = (
@@ -243,6 +254,7 @@
 			isa = PBXGroup;
 			children = (
 				G83406189501 /* Configs */,
+				G66512504301 /* StandaloneFiles */,
 				G82523211001 /* App_iOS */,
 				G78312289901 /* App_iOS_Tests */,
 				G46615002701 /* Framework */,
@@ -620,6 +632,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF1628293501 /* Standalone.swift in Sources */,
 				BF1073850101 /* AppDelegate.swift in Sources */,
 				BF1744565901 /* ViewController.swift in Sources */,
 			);

--- a/Fixtures/TestProject/StandaloneFiles/Standalone.swift
+++ b/Fixtures/TestProject/StandaloneFiles/Standalone.swift
@@ -1,0 +1,3 @@
+func standaloneHello() -> String {
+  return "Hello"
+}

--- a/Fixtures/TestProject/spec.yml
+++ b/Fixtures/TestProject/spec.yml
@@ -10,7 +10,9 @@ targets:
   App_iOS:
     type: application
     platform: iOS
-    sources: App_iOS
+    sources:
+      - App_iOS
+      - StandaloneFiles/Standalone.swift
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.project$(BUNDLE_ID_SUFFIX)
       INFOPLIST_FILE: App_iOS/Info.plist


### PR DESCRIPTION
The `sources` key of the project spec only supported directories and not
files. Now it supports both!

This commit introduces a `getGroups` overload that doesn't explicitly
invoke `path.children()`, but instead accepts `children` as a parameter.
This allows us to invoke the `children` overload of getGroups with just
the files we want to include (determined by specifying the sources).

Now for sourcePaths that are files, we first group them by common
parent directories and then feed those specific files in the children
parameter of `getGroups`.

Motivation: We have directories where we need to compile a subset of
files in the same folder -- and we already have a nice way to get the exact
list of files we need for an arbitrary target. We need this feature to avoid
extra manual effort grouping files by directories and moving files around.