### PR TITLE
Add option for not linking dependencies

### DIFF
--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -201,6 +201,7 @@ public struct Dependency: Equatable {
     public var embed: Bool?
     public var codeSign: Bool = true
     public var removeHeaders: Bool = true
+    public var link: Bool = true
 
     public init(type: DependencyType, reference: String, embed: Bool? = nil) {
         self.type = type
@@ -219,7 +220,8 @@ public struct Dependency: Equatable {
             lhs.type == rhs.type &&
             lhs.codeSign == rhs.codeSign &&
             lhs.removeHeaders == rhs.removeHeaders &&
-            lhs.embed == rhs.embed
+            lhs.embed == rhs.embed &&
+            lhs.link == rhs.link
     }
 
     public var buildSettings: [String: Any] {
@@ -252,6 +254,9 @@ extension Dependency: JSONObjectConvertible {
 
         embed = jsonDictionary.json(atKeyPath: "embed")
 
+        if let bool: Bool = jsonDictionary.json(atKeyPath: "link") {
+            link = bool
+        }
         if let bool: Bool = jsonDictionary.json(atKeyPath: "codeSign") {
             codeSign = bool
         }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -248,7 +248,7 @@ public class PBXProjGenerator {
                 addObject(targetDependency)
                 dependencies.append(targetDependency.reference)
 
-                if dependencyTarget.type.isLibrary || dependencyTarget.type.isFramework {
+                if (dependencyTarget.type.isLibrary || dependencyTarget.type.isFramework) && dependency.link {
                     let dependencyBuildFile = targetBuildFiles[dependencyTargetName]!
                     let buildFile = PBXBuildFile(reference: generateUUID(PBXBuildFile.self, dependencyBuildFile.reference + target.name), fileRef: dependencyBuildFile.fileRef)
                     addObject(buildFile)

--- a/docs/ProjectSpec.md
+++ b/docs/ProjectSpec.md
@@ -219,6 +219,7 @@ A dependency can be one of a 3 types:
 These only applied to `target` and `framework` dependencies.
 
 - ⚪️ **embed**: `Bool` - Whether to embed the dependency. Defaults to true for application target and false for non application targets.
+- ⚪️ **link**: `Bool` - Whether to link the dependency. Defaults to true but only static library and dynamic frameworks are linked. This only applies for target dependencies.
 - ⚪️ **codeSign**: `Bool` - Whether the `codeSignOnCopy` setting is applied when embedding framework. Defaults to true
 - ⚪️ **removeHeaders**: `Bool` - Whether the `removeHeadersOnCopy` setting is applied when embedding the framework. Defaults to true
 


### PR DESCRIPTION
This adds a new attribute to Dependency that allows consumers to choose
to not link a dependency. This is useful for if you have this dependency
tree with static libraries:

App -> A -> Shared
App -> B -> Shared

Where A and B both share a static library dependency, that is finally
linked into App. If Shared is added to the link phase of A and B, you
end up with duplicate symbols during the link phase. With this change
consumers could set link: False on A and B's dependency on Shared, this
way Shared will get build before A and B, but not linked.