### PR TITLE
Partial config matching

### DIFF
--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -52,8 +52,10 @@ extension ProjectSpec {
 
         buildSettings += settings.buildSettings
 
-        if let configSettings = settings.configSettings[config.name] {
-            buildSettings += getBuildSettings(settings: configSettings, config: config)
+        for (configVariant, settings) in settings.configSettings {
+            if config.name.contains(configVariant) {
+                buildSettings += getBuildSettings(settings: settings, config: config)
+            }
         }
 
         return buildSettings

--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -53,7 +53,7 @@ extension ProjectSpec {
         buildSettings += settings.buildSettings
 
         for (configVariant, settings) in settings.configSettings {
-            if config.name.contains(configVariant) {
+            if config.name.lowercased().contains(configVariant.lowercased()) {
                 buildSettings += getBuildSettings(settings: settings, config: config)
             }
         }

--- a/Sources/XcodeGenKit/SpecValidation.swift
+++ b/Sources/XcodeGenKit/SpecValidation.swift
@@ -29,7 +29,7 @@ extension ProjectSpec {
                 }
             }
             for config in settings.configSettings.keys {
-                if getConfig(config) == nil {
+                if !configs.contains(where: { $0.name.contains(config)}) {
                     errors.append(.invalidConfigReference(config))
                 }
             }

--- a/Sources/XcodeGenKit/SpecValidation.swift
+++ b/Sources/XcodeGenKit/SpecValidation.swift
@@ -28,6 +28,11 @@ extension ProjectSpec {
                     errors.append(.invalidSettingsGroup(group))
                 }
             }
+            for config in settings.configSettings.keys {
+                if getConfig(config) == nil {
+                    errors.append(.invalidConfigReference(config))
+                }
+            }
             return errors
         }
 
@@ -150,6 +155,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidTargetSchemeConfigVariant(target: String, configVariant: String, configType: ConfigType)
         case invalidTargetSchemeTest(target: String, testTarget: String)
         case invalidFileGroup(String)
+        case invalidConfigReference(String)
 
         public var description: String {
             switch self {
@@ -165,6 +171,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
             case let .invalidTargetSchemeConfigVariant(target, configVariant, configType): return "Target \(target.quoted) has invalid scheme config varians which requires a config that has a \(configType.rawValue.quoted) type and contains the name \(configVariant.quoted)"
             case let .invalidTargetSchemeTest(target, test): return "Target \(target.quoted) scheme has invalid test \(test.quoted)"
             case let .invalidFileGroup(group): return "Invalid file group \(group.quoted)"
+            case let .invalidConfigReference(config): return "Invalid config reference \(config.quoted)"
             }
         }
     }

--- a/Sources/XcodeGenKit/SpecValidation.swift
+++ b/Sources/XcodeGenKit/SpecValidation.swift
@@ -29,7 +29,7 @@ extension ProjectSpec {
                 }
             }
             for config in settings.configSettings.keys {
-                if !configs.contains(where: { $0.name.contains(config)}) {
+                if !configs.contains(where: { $0.name.lowercased().contains(config.lowercased())}) {
                     errors.append(.invalidConfigReference(config))
                 }
             }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -37,7 +37,7 @@ func projectGeneratorTests() {
                     let buildConfigs = project.pbxproj.configurationLists.getReference(target.buildConfigurationList),
                     let buildConfigReference = buildConfigs.buildConfigurations.first,
                     let buildConfig = project.pbxproj.buildConfigurations.getReference(buildConfigReference) else {
-                    throw failure("Build Config not found")
+                        throw failure("Build Config not found")
                 }
                 try expect(buildConfig.buildSettings["PRODUCT_BUNDLE_IDENTIFIER"] as? String) == "com.test.MyFramework"
             }
@@ -108,6 +108,17 @@ func projectGeneratorTests() {
                 expectedTargetDebugSettings += ["SETTING 2": "value 2", "SETTING 3": "value 3", "SETTING": "value"]
 
                 try expect(targetDebugSettings.equals(expectedTargetDebugSettings)).beTrue()
+            }
+
+            $0.it("applies partial config settings") {
+                let spec = ProjectSpec(basePath: "", name: "test", configs: [
+                    Config(name: "Staging Debug", type: .debug),
+                    Config(name: "Staging Release", type: .release)],
+                                       settings: Settings(configSettings: ["Staging": ["SETTING1": "VALUE1"], "Debug": ["SETTING2": "VALUE2"]]))
+
+                var buildSettings = spec.getProjectBuildSettings(config: spec.configs.first!)
+                try expect(buildSettings["SETTING1"] as? String) == "VALUE1"
+                try expect(buildSettings["SETTING2"] as? String) == "VALUE2"
             }
         }
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -114,7 +114,7 @@ func projectGeneratorTests() {
                 let spec = ProjectSpec(basePath: "", name: "test", configs: [
                     Config(name: "Staging Debug", type: .debug),
                     Config(name: "Staging Release", type: .release)],
-                                       settings: Settings(configSettings: ["Staging": ["SETTING1": "VALUE1"], "Debug": ["SETTING2": "VALUE2"]]))
+                                       settings: Settings(configSettings: ["staging": ["SETTING1": "VALUE1"], "debug": ["SETTING2": "VALUE2"]]))
 
                 var buildSettings = spec.getProjectBuildSettings(config: spec.configs.first!)
                 try expect(buildSettings["SETTING1"] as? String) == "VALUE1"

--- a/docs/ProjectSpec.md
+++ b/docs/ProjectSpec.md
@@ -103,7 +103,7 @@ settingGroups:
 Settings can either be a simple map of build settings `[String: String]`, or can be more advanced with the following properties:
 
 - ⚪️ **groups**: `[String]` - List of setting groups to include and merge
-- ⚪️ **configs**: [String: [Settings](#settings)] - Mapping of config name to a settings spec. These settings will only be applied for that config
+- ⚪️ **configs**: [String: [Settings](#settings)] - Mapping of config name to a settings spec. These settings will only be applied for that config. Each key will be matched to any configs that contain the key and is case insensitive. So if you had `Staging Debug` and `Staging Release`, you could apply settings to both of them using `staging`.
 - ⚪️ **base**: `[String: String]` - Used to specify default settings that apply to any config
 
 ```yaml


### PR DESCRIPTION
This makes 2 changes to how configs are referenced and applied in `Settings` (in project settings, target settings, setting groups)

- partials are matched
- matches are case insensitive

This means you can apply settings in a wider way.

For example you can do the following:
```
configs:
  Test Debug: debug
  Staging Debug: debug
  Production Debug: debug
  Test Release: release
  Staging Release: release
  Production Release: release
settings:
  configs:
    test: # applies to both Test Debug and Test Release configs
      BUILD_SETTING: test
    debug: # applies to all debug configs
      OTHER_BUILD_SETTING: debug setting
```

This also adds some missing validation in the spec validator