### PR TITLE
add support --version option

### DIFF
--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -15,6 +15,8 @@ import ProjectSpec
 import JSONUtilities
 import Rainbow
 
+let version = "1.3.0"
+
 func generate(spec: String, project: String) {
 
     let specPath = Path(spec).normalize()
@@ -58,4 +60,4 @@ command(
     Option<String>("spec", "project.yml", flag: "s", description: "The path to the spec file"),
     Option<String>("project", "", flag: "p", description: "The path to the folder where the project should be generated"),
     generate)
-    .run()
+    .run(version)


### PR DESCRIPTION
I think that it is better for xcodegen to have `--version` option as it is for many commands.

However, I think that this will increase the effort of editing main.swift for version up process. 😟 
If you feel troublesome, you can reject this pull request. 😇 