### PR TITLE
Don't add unnecessary headers build phase

### DIFF
--- a/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -295,18 +295,6 @@
 				BF3515549503 /* MyFramework.h in Headers */,
 			);
 		};
-		HBP783122801 /* Frameworks */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-		};
-		HBP825232101 /* Frameworks */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -388,7 +376,6 @@
 			buildPhases = (
 				SBP783122801 /* Sources */,
 				RBP783122801 /* Resources */,
-				HBP783122801 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -405,7 +392,6 @@
 			buildPhases = (
 				SBP825232101 /* Sources */,
 				RBP825232101 /* Resources */,
-				HBP825232101 /* Headers */,
 				FBP825232101 /* Frameworks */,
 				CFBP64939301 /* CopyFiles */,
 				SSBP81062201 /* Carthage */,

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -354,9 +354,11 @@ public class PBXProjGenerator {
         addObject(resourcesBuildPhase)
         buildPhases.append(resourcesBuildPhase.reference)
 
-        let headersBuildPhase = PBXHeadersBuildPhase(reference: generateUUID(PBXHeadersBuildPhase.self, target.name), files: getBuildFilesForPhase(.headers))
-        addObject(headersBuildPhase)
-        buildPhases.append(headersBuildPhase.reference)
+        if target.type == .framework || target.type == .dynamicLibrary {
+            let headersBuildPhase = PBXHeadersBuildPhase(reference: generateUUID(PBXHeadersBuildPhase.self, target.name), files: getBuildFilesForPhase(.headers))
+            addObject(headersBuildPhase)
+            buildPhases.append(headersBuildPhase.reference)
+        }
 
         if !targetFrameworkBuildFiles.isEmpty {
 


### PR DESCRIPTION
I found that header files are unwantedly copied into the application package.
I checked that only the dynamicLibrary and the framework contained headers from the newly created project from the template.

|type|needs headers|
|:-:|:-:|
|application|NO|
|framework|YES|
|dynamicLibrary|YES|
|staticLibrary|copies by Copy Files build phase|
|bundle|NO|
|unitTestBundle|NO|
|uiTestBundle|NO|
|appExtension|NO|
|commandLineTool|NO|
|watchApp|NO|
|watch2App|NO|
|watchExtension|NO|
|watch2Extension|NO|
|tvExtension|NO|
|messagesApplication|NO|
|messagesExtension|NO|
|stickerPack|NO|
|xpcService|NO|