### PR TITLE
Source options

### DIFF
--- a/Sources/ProjectSpec/Source.swift
+++ b/Sources/ProjectSpec/Source.swift
@@ -1,0 +1,47 @@
+//
+//  Source.swift
+//  ProjectSpec
+//
+//  Created by Yonas Kolb on 31/10/17.
+//
+
+import Foundation
+import JSONUtilities
+
+public struct Source {
+
+    public var path: String
+
+    public init(path: String) {
+        self.path = path
+    }
+}
+
+extension Source: ExpressibleByStringLiteral {
+
+    public init(stringLiteral value: String) {
+        self = Source(path: value)
+    }
+
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self = Source(path: value)
+    }
+
+    public init(unicodeScalarLiteral value: String) {
+        self = Source(path: value)
+    }
+}
+
+extension Source: JSONObjectConvertible {
+
+    public init(jsonDictionary: JSONDictionary) throws {
+        path = try jsonDictionary.json(atKeyPath: "path")
+    }
+}
+
+extension Source: Equatable {
+
+    public static func == (lhs: Source, rhs: Source) -> Bool {
+        return lhs.path == rhs.path
+    }
+}

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -69,7 +69,7 @@ extension ProjectSpec {
             }
 
             for source in target.sources {
-                let sourcePath = basePath + source
+                let sourcePath = basePath + source.path
                 if !sourcePath.exists {
                     errors.append(.invalidTargetSource(target: target.name, source: sourcePath.string))
                 }

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -68,6 +68,22 @@ func specLoadingTests() {
             try expectTargetError(target, .invalidDependency([invalid: "name"]))
         }
 
+        $0.it("parses sources") {
+            var targetDictionary1 = validTarget
+            targetDictionary1["sources"] = [
+                "source1",
+                ["path": "source2"],
+            ]
+            var targetDictionary2 = validTarget
+            targetDictionary2["sources"] = "source3"
+
+            let target1 = try Target(name: "test", jsonDictionary: targetDictionary1)
+            let target2 = try Target(name: "test", jsonDictionary: targetDictionary2)
+
+            try expect(target1.sources) == [Source(path: "source1"), Source(path: "source2")]
+            try expect(target2.sources) == [Source(path: "source3")]
+        }
+
         $0.it("parses target dependencies") {
             var targetDictionary = validTarget
             targetDictionary["dependencies"] = [


### PR DESCRIPTION
This adds a new `Source` struct to replace the previous `String` model. This sets the stage to add various options to a targets sources by using a more expanded definition of a source. 
Some possible we could build on top of this are:
- name - an optional override for the name of the file/directory
- compilerFlags
- excludes - maybe using a glob pattern
- group  - could specify which group this sits in, defaults to the top level
- type - group or folder reference (defaults to group)
- buildPhase - overrides the guessing of what build phase files are for

These are now all valid ways to define a list of sources and are parsed into the same `[Source]` array:
```
sources: MySources
sources:
  - MySources
sources:
  - path: MySources
```