### PR TITLE
Add .mm file as a source type

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -472,7 +472,7 @@ public class PBXProjGenerator {
         }
         if let fileExtension = path.extension {
             switch fileExtension {
-            case "swift", "m", "cpp": return .sources
+            case "swift", "m", "mm", "cpp": return .sources
             case "h", "hh", "hpp", "ipp", "tpp", "hxx", "def": return .headers
             case "xcconfig", "entitlements", "gpx", "lproj", "apns": return nil
             default: return .resources


### PR DESCRIPTION
While working on a project, I discovered that .mm files were being added to the project but not to the build sources phase.