### PR TITLE
Support CompilerFlags in Sources

### DIFF
--- a/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -6,17 +6,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF1073850101 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1332263601 /* AppDelegate.swift */; };
+		BF1073850101 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1332263601 /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		BF1401236301 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR3032072501 /* Alamofire.framework */; };
 		BF1628293501 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2554453101 /* Standalone.swift */; };
-		BF1744565901 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6218091901 /* ViewController.swift */; };
+		BF1744565901 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6218091901 /* ViewController.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		BF2018435801 /* Framework_iOS.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR4722960401 /* Framework_iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BF2250910101 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG2043127501 /* Main.storyboard */; };
 		BF2445564001 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG2858723001 /* LaunchScreen.storyboard */; };
 		BF2513089601 /* LocalizedStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG3182922801 /* LocalizedStoryboard.storyboard */; };
 		BF2535278401 = {isa = PBXBuildFile; fileRef = FR4387045301 /* Framework_watchOS.framework */; };
 		BF3008399601 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR3032072503 /* Alamofire.framework */; };
-		BF3154421201 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR5980633301 /* Assets.xcassets */; };
+		BF3154421201 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR5980633301 /* Assets.xcassets */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		BF3314441201 = {isa = PBXBuildFile; fileRef = FR5251191201 /* Framework_macOS.framework */; };
 		BF3515549501 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR7740960501 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF3515549502 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR7740960501 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -263,8 +263,8 @@
 			isa = PBXGroup;
 			children = (
 				G83406189501 /* Configs */,
-				G66512504301 /* StandaloneFiles */,
 				G82523211001 /* App_iOS */,
+				G66512504301 /* StandaloneFiles */,
 				G78312289901 /* App_iOS_Tests */,
 				G46615002701 /* Framework */,
 				G46615002701 /* Framework */,
@@ -644,9 +644,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF1628293501 /* Standalone.swift in Sources */,
 				BF1073850101 /* AppDelegate.swift in Sources */,
 				BF1744565901 /* ViewController.swift in Sources */,
+				BF1628293501 /* Standalone.swift in Sources */,
 			);
 		};
 /* End PBXSourcesBuildPhase section */

--- a/Fixtures/TestProject/spec.yml
+++ b/Fixtures/TestProject/spec.yml
@@ -11,8 +11,10 @@ targets:
     type: application
     platform: iOS
     sources:
-      - App_iOS
-      - StandaloneFiles/Standalone.swift
+      - path: App_iOS
+        compilerFlags:
+          - "-Werror"
+      - path: StandaloneFiles/Standalone.swift
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.project$(BUNDLE_ID_SUFFIX)
       INFOPLIST_FILE: App_iOS/Info.plist

--- a/Sources/ProjectSpec/Source.swift
+++ b/Sources/ProjectSpec/Source.swift
@@ -7,13 +7,16 @@
 
 import Foundation
 import JSONUtilities
+import PathKit
 
 public struct Source {
 
     public var path: String
+    public var compilerFlags: [String]
 
-    public init(path: String) {
+    public init(path: String, compilerFlags: [String] = []) {
         self.path = path
+        self.compilerFlags = compilerFlags
     }
 }
 
@@ -36,12 +39,22 @@ extension Source: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
         path = try jsonDictionary.json(atKeyPath: "path")
+        let maybeCompilerFlagsString: String? = jsonDictionary.json(atKeyPath: "compilerFlags")
+        let maybeCompilerFlagsArray: [String]? = jsonDictionary.json(atKeyPath: "compilerFlags")
+        compilerFlags = maybeCompilerFlagsArray ??
+            maybeCompilerFlagsString.map{ $0.split(separator: " ").map{ String($0) } } ?? []
     }
 }
 
 extension Source: Equatable {
 
     public static func == (lhs: Source, rhs: Source) -> Bool {
-        return lhs.path == rhs.path
+        return lhs.path == rhs.path && lhs.compilerFlags == rhs.compilerFlags
+    }
+}
+
+extension Source: Hashable {
+    public var hashValue: Int {
+        return path.hashValue ^ compilerFlags.joined(separator: ":").hashValue
     }
 }

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -73,6 +73,8 @@ func specLoadingTests() {
             targetDictionary1["sources"] = [
                 "source1",
                 ["path": "source2"],
+                ["path": "sourceWithFlags", "compilerFlags": ["-Werror"]],
+                ["path": "sourceWithFlagsStr", "compilerFlags": "-Werror -Wextra"]
             ]
             var targetDictionary2 = validTarget
             targetDictionary2["sources"] = "source3"
@@ -80,7 +82,7 @@ func specLoadingTests() {
             let target1 = try Target(name: "test", jsonDictionary: targetDictionary1)
             let target2 = try Target(name: "test", jsonDictionary: targetDictionary2)
 
-            try expect(target1.sources) == [Source(path: "source1"), Source(path: "source2")]
+            try expect(target1.sources) == [Source(path: "source1"), Source(path: "source2"), Source(path: "sourceWithFlags", compilerFlags: ["-Werror"]), Source(path: "sourceWithFlagsStr", compilerFlags: ["-Werror", "-Wextra"])]
             try expect(target2.sources) == [Source(path: "source3")]
         }
 

--- a/docs/ProjectSpec.md
+++ b/docs/ProjectSpec.md
@@ -196,7 +196,14 @@ targets:
 The above will generate 2 targets named `MyFramework_iOS` and `MyFramework_tvOS`, with all the relevant platform build settings. They will both have a `PRODUCT_NAME` of `MyFramework`
 
 ### Sources
-Specifies the source directories for a target. This can either be a single path or a list of paths. Applicable source files, resources, headers, and lproj files will be parsed appropriately
+Specifies the source directories for a target. This can either be a single source or a list of sources. Applicable source files, resources, headers, and lproj files will be parsed appropriately.
+
+A source can be provided via a string (the path) or an object of the form:
+
+**Source Object**:
+
+- 🔵 **path**: `String` - The path to the source file or directory.
+- ⚪️ **compilerFlags**: `[String]` or `String` - A list of compilerFlags to add to files under this specific path provided as a list or a space delimitted string. Defaults to empty.
 
 ```yaml
 targets:
@@ -205,7 +212,12 @@ targets:
   MyOtherTarget
     sources:
       - MyOtherTargetSource1
-      - MyOtherTargetSource2
+      - path: MyOtherTargetSource2
+        compilerFlags:
+          - "-Werror"
+          - "-Wextra"
+      - path: MyOtherTargetSource3
+        compilerFlags: "-Werror -Wextra"
 ```
 
 ### Dependency


### PR DESCRIPTION
Added support for compilerFlags in source list. If any source file
metadata (like compilerFlags) is attached to a directory the metadata
propagates downwards to all children recursively until the files are
reached.

Since there is an extra bit of metadata we need to carry around during
production of PBXObjects, we can no longer pass a `Path` directly.
`Source` needs `path` to be `String` because we don't know the
basePath until the spec is fully loaded. When we do have the basePath
we can compute the real `Path` and start to use PathKit APIs.

I attempted a first pass where I just used the `Source` everywhere and
forwarded along a basePath at all operations that needed it, but that
was too messy, so I ended up making another struct that enriched the
source with the basePath (called `EnrichedSource`). I don't love the
name, let me know if you come up with a better one.

Fixtures and unit tests are updated as well.