### PR TITLE
Add support for simple files excludes from sources #5.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TOOL_NAME = XcodeGen
-VERSION = 1.3.0
+VERSION = 1.3.1
 
 PREFIX = /usr/local
 INSTALL_PATH = $(PREFIX)/bin/$(TOOL_NAME)

--- a/Sources/ProjectSpec/Source.swift
+++ b/Sources/ProjectSpec/Source.swift
@@ -13,10 +13,12 @@ public struct Source {
 
     public var path: String
     public var compilerFlags: [String]
+    public var excludes: [String]
 
-    public init(path: String, compilerFlags: [String] = []) {
+    public init(path: String, compilerFlags: [String] = [], excludes: [String] = []) {
         self.path = path
         self.compilerFlags = compilerFlags
+        self.excludes = excludes
     }
 }
 
@@ -43,6 +45,10 @@ extension Source: JSONObjectConvertible {
         let maybeCompilerFlagsArray: [String]? = jsonDictionary.json(atKeyPath: "compilerFlags")
         compilerFlags = maybeCompilerFlagsArray ??
             maybeCompilerFlagsString.map{ $0.split(separator: " ").map{ String($0) } } ?? []
+        let maybeExcludesString: String? = jsonDictionary.json(atKeyPath: "excludes")
+        let maybeExcludesArray: [String]? = jsonDictionary.json(atKeyPath: "excludes")
+        excludes = maybeExcludesArray ??
+            maybeExcludesString.map{ $0.split(separator: " ").map{ String($0) } } ?? []        
     }
 }
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -568,6 +568,7 @@ public class PBXProjGenerator {
             (try path.children().sorted(), path)
 
         let excludedFiles: [String] = [".DS_Store"]
+        let sourceExcludedFiles: [String] = source.excludes.map { "\(source.path)/\($0)" }
 
         let directories = children
             .filter { $0.isDirectory && $0.extension == nil && $0.extension != "lproj" }
@@ -576,6 +577,7 @@ public class PBXProjGenerator {
         let filePaths = children
             .filter { $0.isFile || $0.extension != nil && $0.extension != "lproj" }
             .filter { !excludedFiles.contains($0.lastComponent) }
+            .filter { !sourceExcludedFiles.contains($0.string) }
             .sorted { $0.lastComponent < $1.lastComponent }
 
         let localisedDirectories = children

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -93,7 +93,11 @@ func specLoadingTests() {
                 "source1",
                 ["path": "source2"],
                 ["path": "sourceWithFlags", "compilerFlags": ["-Werror"]],
-                ["path": "sourceWithFlagsStr", "compilerFlags": "-Werror -Wextra"]
+                ["path": "sourceWithFlagsStr", "compilerFlags": "-Werror -Wextra"],
+                ["path": "sourceWithExcludes", "excludes": ["Foo.swift"]],
+                ["path": "sourceWithExcludesStr", "excludes": "Foo.swift Bar.swift"],
+                ["path": "sourceWithCompilerFlagsExcludes", "compilerFlags": ["-Werror"], "excludes": ["Foo.swift"]],
+                ["path": "sourceWithCompilerFlagsExcludesStr", "compilerFlags": "-Werror -Wextra", "excludes": "Foo.swift Bar.swift"],
             ]
             var targetDictionary2 = validTarget
             targetDictionary2["sources"] = "source3"
@@ -101,7 +105,16 @@ func specLoadingTests() {
             let target1 = try Target(name: "test", jsonDictionary: targetDictionary1)
             let target2 = try Target(name: "test", jsonDictionary: targetDictionary2)
 
-            try expect(target1.sources) == [Source(path: "source1"), Source(path: "source2"), Source(path: "sourceWithFlags", compilerFlags: ["-Werror"]), Source(path: "sourceWithFlagsStr", compilerFlags: ["-Werror", "-Wextra"])]
+            let target1SourcesExpect = [Source(path: "source1"), 
+                                        Source(path: "source2"), 
+                                        Source(path: "sourceWithFlags", compilerFlags: ["-Werror"]), 
+                                        Source(path: "sourceWithFlagsStr", compilerFlags: ["-Werror", "-Wextra"]),
+                                        Source(path: "sourceWithExcludes", excludes: ["Foo.swift"]), 
+                                        Source(path: "sourceWithExcludesStr", excludes: ["Foo.swift", "Bar.swift"]),
+                                        Source(path: "sourceWithCompilerFlagsExcludes", compilerFlags: ["-Werror"], excludes: ["Foo.swift"]),
+                                        Source(path: "sourceWithCompilerFlagsExcludesStr", compilerFlags: ["-Werror", "-Wextra"], excludes: ["Foo.swift", "Bar.swift"])]
+
+            try expect(target1.sources) == target1SourcesExpect
             try expect(target2.sources) == [Source(path: "source3")]
         }
 


### PR DESCRIPTION
Hi @yonaskolb,

I understand you may be working on a solution for excludes as hinted in #25, but for now this seems to be resolving the immediate issue of excluding file(s) given a source path.

Please have a look and let me know if you have any feedbacks.