### PR TITLE
Add support for generating variant groups without Base.lproj

### DIFF
--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -129,7 +129,9 @@ extension ProjectSpec.Options: Equatable {
     public static func == (lhs: ProjectSpec.Options, rhs: ProjectSpec.Options) -> Bool {
         return lhs.carthageBuildPath == rhs.carthageBuildPath &&
             lhs.bundleIdPrefix == rhs.bundleIdPrefix &&
-            lhs.settingPresets == rhs.settingPresets
+            lhs.settingPresets == rhs.settingPresets &&
+            lhs.createIntermediateGroups == rhs.createIntermediateGroups &&
+            lhs.developmentLanguage == rhs.developmentLanguage
     }
 }
 
@@ -168,5 +170,6 @@ extension ProjectSpec.Options: JSONObjectConvertible {
         bundleIdPrefix = jsonDictionary.json(atKeyPath: "bundleIdPrefix")
         settingPresets = jsonDictionary.json(atKeyPath: "settingPresets") ?? .all
         createIntermediateGroups = jsonDictionary.json(atKeyPath: "createIntermediateGroups") ?? false
+        developmentLanguage = jsonDictionary.json(atKeyPath: "developmentLanguage")
     }
 }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -122,7 +122,6 @@ public class PBXProjGenerator {
 
         sortGroups(group: mainGroup)
 
-        let knownRegions: [String] = ["en", "Base"]
         let projectAttributes: [String: Any] = ["LastUpgradeCheck": currentXcodeVersion].merged(spec.attributes)
         let root = PBXProject(name: spec.name,
                               reference: proj.rootObject,
@@ -130,7 +129,7 @@ public class PBXProjGenerator {
                               compatibilityVersion: "Xcode 3.2",
                               mainGroup: mainGroup.reference,
                               developmentRegion: spec.options.developmentLanguage ?? "en",
-                              knownRegions: knownRegions,
+                              knownRegions: sourceGenerator.knownRegions,
                               targets: targets.references,
                               attributes: projectAttributes)
         proj.projects.append(root)

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -243,9 +243,19 @@ class SourceGenerator {
             groups += subGroups.groups
         }
 
+        // find the base localised directory
+        let baseLocalisedDirectory: Path? = {
+            func findLocalisedDirectory(by languageId: String) -> Path? {
+                return localisedDirectories.first { $0.lastComponent == "\(languageId).lproj" }
+            }
+            return findLocalisedDirectory(by: "Base") ??
+                findLocalisedDirectory(by: NSLocale.canonicalLanguageIdentifier(from: spec.options.developmentLanguage ?? "en"))
+        }()
+
         // create variant groups of the base localisation first
         var baseLocalisationVariantGroups: [PBXVariantGroup] = []
-        if let baseLocalisedDirectory = localisedDirectories.first(where: { $0.lastComponent == "Base.lproj" }) {
+
+        if let baseLocalisedDirectory = baseLocalisedDirectory {
             for filePath in try baseLocalisedDirectory.children().sorted() {
                 let variantGroup = getVariantGroup(path: filePath, inPath: path)
                 groupChildren.append(variantGroup.reference)

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -31,6 +31,8 @@ class SourceGenerator {
 
     var targetName: String = ""
 
+    private(set) var knownRegions: [String] = []
+
     init(spec: ProjectSpec, proj: PBXProj, referenceGenerator: ReferenceGenerator, addObject: @escaping (PBXObject) -> Void) {
         self.spec = spec
         self.proj = proj
@@ -251,6 +253,8 @@ class SourceGenerator {
             return findLocalisedDirectory(by: "Base") ??
                 findLocalisedDirectory(by: NSLocale.canonicalLanguageIdentifier(from: spec.options.developmentLanguage ?? "en"))
         }()
+
+        knownRegions = Array(Set(knownRegions + localisedDirectories.map { $0.lastComponentWithoutExtension }))
 
         // create variant groups of the base localisation first
         var baseLocalisationVariantGroups: [PBXVariantGroup] = []

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -473,8 +473,8 @@
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			knownRegions = (
-				en,
 				Base,
+				en,
 			);
 			mainGroup = G_8448771205358;
 			targets = (

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -225,9 +225,11 @@ func specLoadingTests() {
 
         $0.it("parses options") {
             let options = ProjectSpec.Options(carthageBuildPath: "../Carthage/Build",
-                                              bundleIdPrefix: "com.test")
+                                              createIntermediateGroups: true,
+                                              bundleIdPrefix: "com.test",
+                                              developmentLanguage: "ja")
             let expected = ProjectSpec(basePath: "", name: "test", options: options)
-            let parsedSpec = try getProjectSpec(["options": ["carthageBuildPath": "../Carthage/Build", "bundleIdPrefix": "com.test"]])
+            let parsedSpec = try getProjectSpec(["options": ["carthageBuildPath": "../Carthage/Build", "bundleIdPrefix": "com.test", "createIntermediateGroups": true, "developmentLanguage": "ja"]])
             try expect(parsedSpec) == expected
         }
     }


### PR DESCRIPTION
- fix reading developmentLanguage from yaml
- use developmentLanguage to generate variant groups 
  - find Base Language lproj directory in these order. Base -> developmentLanguage -> en
- add languages found in getGroupSources() to knownRegions

fixes #143