### PR TITLE
Updates for xcproj updates to PBXProj

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -66,11 +66,11 @@
       },
       {
         "package": "xcproj",
-        "repositoryURL": "https://github.com/rahul-malik/xcproj.git",
+        "repositoryURL": "https://github.com/xcodeswift/xcproj.git",
         "state": {
           "branch": null,
-          "revision": "1923c0f53d9dfb7257b2ff08e4819be8efe25001",
-          "version": null
+          "revision": "a6a1b9b2cbb89e89e09456037ad92906e2a1507a",
+          "version": "1.4.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -66,11 +66,11 @@
       },
       {
         "package": "xcproj",
-        "repositoryURL": "https://github.com/xcodeswift/xcproj.git",
+        "repositoryURL": "https://github.com/rahul-malik/xcproj.git",
         "state": {
           "branch": null,
-          "revision": "fc8cbfce8a6bc1a98773181afe8da97c2516b722",
-          "version": "1.2.0"
+          "revision": "1923c0f53d9dfb7257b2ff08e4819be8efe25001",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(url: "https://github.com/yonaskolb/JSONUtilities.git", from: "3.3.0"),
         .package(url: "https://github.com/kylef/Spectre.git", from: "0.7.0"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "2.1.0"),
-        .package(url: "https://github.com/xcodeswift/xcproj.git", from: "1.0.0"),
+        .package(url: "https://github.com/xcodeswift/xcproj.git", .revision("f6d733fc7cc1e6f6bc67da05f6ffadbfe721a8f0"))
     ],
     targets: [
         .target(name: "XcodeGen", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(url: "https://github.com/yonaskolb/JSONUtilities.git", from: "3.3.0"),
         .package(url: "https://github.com/kylef/Spectre.git", from: "0.7.0"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "2.1.0"),
-        .package(url: "https://github.com/xcodeswift/xcproj.git", .revision("f6d733fc7cc1e6f6bc67da05f6ffadbfe721a8f0"))
+        .package(url: "https://github.com/xcodeswift/xcproj.git", from: "1.4.0")
     ],
     targets: [
         .target(name: "XcodeGen", dependencies: [

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -136,7 +136,7 @@ public class PBXProjGenerator {
     func sortGroups(group: PBXGroup) {
         // sort children
         let children: [GroupChild] = group.children
-            .flatMap { proj.objects.groups[$0] ?? proj.objects.fileReferences[$0] ?? proj.objects.variantGroups[$0] }
+            .flatMap { proj.getGroupChild(reference: $0) }
             .sorted { child1, child2 in
                 if child1.sortOrder == child2.sortOrder {
                     return child1.childName < child2.childName

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -49,7 +49,7 @@ public class ProjectGenerator {
 
         func getBuildEntry(_ buildTarget: Scheme.BuildTarget) -> XCScheme.BuildAction.Entry {
 
-            let targetReference = pbxProject.nativeTargets.first { $0.name == buildTarget.target }!
+            let targetReference = pbxProject.objects.nativeTargets.referenceValues.first { $0.name == buildTarget.target }!
 
             let buildableReference = XCScheme.BuildableReference(referencedContainer: "container:\(spec.name).xcodeproj", blueprintIdentifier: targetReference.reference, buildableName: "\(buildTarget.target).\(targetReference.productType!.fileExtension!)", blueprintName: scheme.name)
 

--- a/Sources/XcodeGenKit/XCProjExtensions.swift
+++ b/Sources/XcodeGenKit/XCProjExtensions.swift
@@ -46,7 +46,7 @@ extension PBXVariantGroup: GroupChild {
 extension PBXProj {
 
     public func printGroups() -> String {
-        guard let project = projects.first, let mainGroup = groups.getReference(project.mainGroup) else {
+        guard let project = objects.projects.first?.value, let mainGroup = objects.groups.getReference(project.mainGroup) else {
             return ""
         }
         return printGroup(group: mainGroup)
@@ -55,11 +55,11 @@ extension PBXProj {
     public func printGroup(group: PBXGroup) -> String {
         var string = group.childName
         for reference in group.children {
-            if let group = groups.getReference(reference) {
+            if let group = objects.groups.getReference(reference) {
                 string += "\n 📁  " + printGroup(group: group).replacingOccurrences(of: "\n ", with: "\n    ")
-            } else if let fileReference = fileReferences.getReference(reference) {
+            } else if let fileReference = objects.fileReferences.getReference(reference) {
                 string += "\n 📄  " + fileReference.childName
-            } else if let variantGroup = variantGroups.getReference(reference) {
+            } else if let variantGroup = objects.variantGroups.getReference(reference) {
                 string += "\n 🌎  " + variantGroup.childName
             }
         }
@@ -67,6 +67,6 @@ extension PBXProj {
     }
 
     public func getGroupChild(reference: String) -> GroupChild? {
-        return groups.getReference(reference) ?? fileReferences.getReference(reference) ?? variantGroups.getReference(reference)
+        return objects.groups.getReference(reference) ?? objects.fileReferences.getReference(reference) ?? objects.variantGroups.getReference(reference)
     }
 }

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -1,5 +1,6 @@
 // !$*UTF8*$!
 {
+	archiveVersion = 1;
 	classes = {
 	};
 	objectVersion = 46;
@@ -63,49 +64,51 @@
 /* Begin PBXCopyFilesBuildPhase section */
 		CFBP_6493932244 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
 				BF_905038616071 /* Framework_iOS.framework in CopyFiles */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FR_118219888726 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LocalizedStoryboard.storyboard; sourceTree = "<group>"; };
-		FR_172952167809 /* FrameworkFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkFile.swift; sourceTree = "<group>"; };
-		FR_183521624014 /* MyFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyFramework.h; sourceTree = "<group>"; };
-		FR_196911129660 /* MoreUnder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreUnder.swift; sourceTree = "<group>"; };
-		FR_238161558082 /* MyBundle.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = MyBundle.bundle; sourceTree = "<group>"; };
-		FR_247808626608 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_256263906698 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		FR_118219888726 /* Base */ = {isa = PBXFileReference; name = Base; path = Base.lproj/LocalizedStoryboard.storyboard; sourceTree = "<group>"; };
+		FR_172952167809 /* FrameworkFile.swift */ = {isa = PBXFileReference; path = FrameworkFile.swift; sourceTree = "<group>"; };
+		FR_183521624014 /* MyFramework.h */ = {isa = PBXFileReference; path = MyFramework.h; sourceTree = "<group>"; };
+		FR_196911129660 /* MoreUnder.swift */ = {isa = PBXFileReference; path = MoreUnder.swift; sourceTree = "<group>"; };
+		FR_238161558082 /* MyBundle.bundle */ = {isa = PBXFileReference; path = MyBundle.bundle; sourceTree = "<group>"; };
+		FR_247808626608 /* Info.plist */ = {isa = PBXFileReference; path = Info.plist; sourceTree = "<group>"; };
+		FR_256263906698 /* Base */ = {isa = PBXFileReference; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		FR_257073931060 /* ResourceFolder */ = {isa = PBXFileReference; name = ResourceFolder; path = Resources/ResourceFolder; sourceTree = SOURCE_ROOT; };
-		FR_257516580010 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
-		FR_408537768279 /* StandaloneAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = StandaloneAssets.xcassets; sourceTree = "<group>"; };
-		FR_410645050443 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
-		FR_438704538506 /* Framework_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = Framework_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_452853029807 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
-		FR_472296042419 /* Framework_iOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = Framework_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_473000061463 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_481575785861 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		FR_500792082643 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LocalizedStoryboard.strings; sourceTree = "<group>"; };
-		FR_525119120469 /* Framework_macOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = Framework_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_257516580010 /* Alamofire.framework */ = {isa = PBXFileReference; path = Alamofire.framework; sourceTree = "<group>"; };
+		FR_408537768279 /* StandaloneAssets.xcassets */ = {isa = PBXFileReference; path = StandaloneAssets.xcassets; sourceTree = "<group>"; };
+		FR_410645050443 /* Alamofire.framework */ = {isa = PBXFileReference; path = Alamofire.framework; sourceTree = "<group>"; };
+		FR_438704538506 /* Framework_watchOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; path = Framework_watchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_452853029807 /* Alamofire.framework */ = {isa = PBXFileReference; path = Alamofire.framework; sourceTree = "<group>"; };
+		FR_472296042419 /* Framework_iOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; path = Framework_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_473000061463 /* Base */ = {isa = PBXFileReference; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_481575785861 /* ViewController.swift */ = {isa = PBXFileReference; path = ViewController.swift; sourceTree = "<group>"; };
+		FR_500792082643 /* en */ = {isa = PBXFileReference; name = en; path = en.lproj/LocalizedStoryboard.strings; sourceTree = "<group>"; };
+		FR_525119120469 /* Framework_macOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; path = Framework_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_602633703434 /* en */ = {isa = PBXFileReference; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
-		FR_609193904586 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		FR_635802719871 /* base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = base.xcconfig; sourceTree = "<group>"; };
-		FR_655678458041 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_660690926982 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = config.xcconfig; sourceTree = "<group>"; };
-		FR_662315837182 /* Framework_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = Framework_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_675266829517 /* Standalone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Standalone.swift; sourceTree = "<group>"; };
-		FR_722239415598 /* TestProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectTests.swift; sourceTree = "<group>"; };
-		FR_725187762757 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FR_609193904586 /* Base */ = {isa = PBXFileReference; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		FR_635802719871 /* base.xcconfig */ = {isa = PBXFileReference; path = base.xcconfig; sourceTree = "<group>"; };
+		FR_655678458041 /* Info.plist */ = {isa = PBXFileReference; path = Info.plist; sourceTree = "<group>"; };
+		FR_660690926982 /* config.xcconfig */ = {isa = PBXFileReference; path = config.xcconfig; sourceTree = "<group>"; };
+		FR_662315837182 /* Framework_tvOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; path = Framework_tvOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_675266829517 /* Standalone.swift */ = {isa = PBXFileReference; path = Standalone.swift; sourceTree = "<group>"; };
+		FR_722239415598 /* TestProjectTests.swift */ = {isa = PBXFileReference; path = TestProjectTests.swift; sourceTree = "<group>"; };
+		FR_725187762757 /* Info.plist */ = {isa = PBXFileReference; path = Info.plist; sourceTree = "<group>"; };
 		FR_746876637628 /* Base */ = {isa = PBXFileReference; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
-		FR_752394658615 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
-		FR_771029596306 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_783122899910 /* App_iOS_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = xctest; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_iOS_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_825232110500 /* App_iOS.app */ = {isa = PBXFileReference; explicitFileType = app; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_854336462818 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		FR_868653349092 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		FR_752394658615 /* Alamofire.framework */ = {isa = PBXFileReference; path = Alamofire.framework; sourceTree = "<group>"; };
+		FR_771029596306 /* en */ = {isa = PBXFileReference; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_783122899910 /* App_iOS_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = xctest; includeInIndex = 0; path = App_iOS_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_825232110500 /* App_iOS.app */ = {isa = PBXFileReference; explicitFileType = app; includeInIndex = 0; path = App_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_854336462818 /* AppDelegate.swift */ = {isa = PBXFileReference; path = AppDelegate.swift; sourceTree = "<group>"; };
+		FR_868653349092 /* Assets.xcassets */ = {isa = PBXFileReference; path = Assets.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -326,33 +329,37 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		HBP_43870453850 /* Frameworks */ = {
+		HBP_43870453850 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				BF_813358525536 /* MyFramework.h in Headers */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_47229604241 /* Frameworks */ = {
+		HBP_47229604241 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				BF_425679397292 /* MyFramework.h in Headers */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_52511912046 /* Frameworks */ = {
+		HBP_52511912046 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				BF_496472559782 /* MyFramework.h in Headers */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_66231583718 /* Frameworks */ = {
+		HBP_66231583718 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				BF_734036107922 /* MyFramework.h in Headers */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
@@ -371,7 +378,7 @@
 			dependencies = (
 			);
 			name = Framework_watchOS;
-			productReference = FR_438704538506;
+			productReference = FR_438704538506 /* Framework_watchOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		NT_472296042419 /* Framework_iOS */ = {
@@ -388,7 +395,7 @@
 			dependencies = (
 			);
 			name = Framework_iOS;
-			productReference = FR_472296042419;
+			productReference = FR_472296042419 /* Framework_iOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		NT_525119120469 /* Framework_macOS */ = {
@@ -405,7 +412,7 @@
 			dependencies = (
 			);
 			name = Framework_macOS;
-			productReference = FR_525119120469;
+			productReference = FR_525119120469 /* Framework_macOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		NT_662315837182 /* Framework_tvOS */ = {
@@ -422,7 +429,7 @@
 			dependencies = (
 			);
 			name = Framework_tvOS;
-			productReference = FR_662315837182;
+			productReference = FR_662315837182 /* Framework_tvOS.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		NT_783122899910 /* App_iOS_Tests */ = {
@@ -437,7 +444,7 @@
 				TD_436638162860 /* PBXTargetDependency */,
 			);
 			name = App_iOS_Tests;
-			productReference = FR_783122899910;
+			productReference = FR_783122899910 /* App_iOS_Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		NT_825232110500 /* App_iOS */ = {
@@ -458,7 +465,7 @@
 				TD_354342487294 /* PBXTargetDependency */,
 			);
 			name = App_iOS;
-			productReference = FR_825232110500;
+			productReference = FR_825232110500 /* App_iOS.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -472,11 +479,14 @@
 			buildConfigurationList = CL_844877120535 /* Build configuration list for PBXProject "Project" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
+			hasScannedForEncodings = 0;
 			knownRegions = (
 				Base,
 				en,
 			);
 			mainGroup = G_8448771205358;
+			projectDirPath = "";
+			projectRoot = "";
 			targets = (
 				NT_825232110500 /* App_iOS */,
 				NT_783122899910 /* App_iOS_Tests */,
@@ -503,6 +513,7 @@
 				BF_721498080533 /* ResourceFolder in Resources */,
 				BF_860391087135 /* StandaloneAssets.xcassets in Resources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
@@ -519,7 +530,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script!\"\n";
+			shellScript = "echo \\\"You ran a script!\\\"\n";
 		};
 		SSBP_3642175431 /* MyScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -533,7 +544,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script\"\n";
+			shellScript = "echo \\\"You ran a script\\\"\n";
 		};
 		SSBP_4276308994 /* Strip Unused Architectures from Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -547,7 +558,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
-			shellScript = "################################################################################\n#\n# Copyright 2015 Realm Inc.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n################################################################################\n\n# This script strips all non-valid architectures from dynamic libraries in\n# the application's `Frameworks` directory.\n#\n# The following environment variables are required:\n#\n# BUILT_PRODUCTS_DIR\n# FRAMEWORKS_FOLDER_PATH\n# VALID_ARCHS\n# EXPANDED_CODE_SIGN_IDENTITY\n\n\n# Signs a framework with the provided identity\ncode_sign() {\n  # Use the current code_sign_identitiy\n  echo \"Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}\"\n  echo \"/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements $1\"\n  /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \"$1\"\n}\n\n# Set working directory to product’s embedded frameworks\ncd \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\n\nif [ \"$ACTION\" = \"install\" ]; then\n  echo \"Copy .bcsymbolmap files to .xcarchive\"\n  find . -name '*.bcsymbolmap' -type f -exec mv {} \"${CONFIGURATION_BUILD_DIR}\" \;\nelse\n  # Delete *.bcsymbolmap files from framework bundle unless archiving\n  find . -name '*.bcsymbolmap' -type f -exec rm -rf \"{}\" +\;\nfi\n\necho \"Stripping frameworks\"\n\nfor file in $(find . -type f -perm +111); do\n  # Skip non-dynamic libraries\n  if ! [[ \"$(file \"$file\")\" == *\"dynamically linked shared library\"* ]]; then\n    continue\n  fi\n  # Get architectures for current file\n  archs=\"$(lipo -info \"${file}\" | rev | cut -d ':' -f1 | rev)\"\n  stripped=\"\"\n  for arch in $archs; do\n    if ! [[ \"${VALID_ARCHS}\" == *\"$arch\"* ]]; then\n      # Strip non-valid architectures in-place\n      lipo -remove \"$arch\" -output \"$file\" \"$file\" || exit 1\n      stripped=\"$stripped $arch\"\n    fi\n  done\n  if [[ \"$stripped\" != \"\" ]]; then\n    echo \"Stripped $file of architectures:$stripped\"\n    if [ \"${CODE_SIGNING_REQUIRED}\" == \"YES\" ]; then\n      code_sign \"${file}\"\n    fi\n  fi\ndone\n";
+			shellScript = "################################################################################\n#\n# Copyright 2015 Realm Inc.\n#\n# Licensed under the Apache License, Version 2.0 (the \\\"License\\\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \\\"AS IS\\\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n################################################################################\n\n# This script strips all non-valid architectures from dynamic libraries in\n# the application's `Frameworks` directory.\n#\n# The following environment variables are required:\n#\n# BUILT_PRODUCTS_DIR\n# FRAMEWORKS_FOLDER_PATH\n# VALID_ARCHS\n# EXPANDED_CODE_SIGN_IDENTITY\n\n\n# Signs a framework with the provided identity\ncode_sign() {\n  # Use the current code_sign_identitiy\n  echo \\\"Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}\\\"\n  echo \\\"/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements $1\\\"\n  /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \\\"$1\\\"\n}\n\n# Set working directory to product’s embedded frameworks\ncd \\\"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\\\"\n\nif [ \\\"$ACTION\\\" = \\\"install\\\" ]; then\n  echo \\\"Copy .bcsymbolmap files to .xcarchive\\\"\n  find . -name '*.bcsymbolmap' -type f -exec mv {} \\\"${CONFIGURATION_BUILD_DIR}\\\" \\;\nelse\n  # Delete *.bcsymbolmap files from framework bundle unless archiving\n  find . -name '*.bcsymbolmap' -type f -exec rm -rf \\\"{}\\\" +\\;\nfi\n\necho \\\"Stripping frameworks\\\"\n\nfor file in $(find . -type f -perm +111); do\n  # Skip non-dynamic libraries\n  if ! [[ \\\"$(file \\\"$file\\\")\\\" == *\\\"dynamically linked shared library\\\"* ]]; then\n    continue\n  fi\n  # Get architectures for current file\n  archs=\\\"$(lipo -info \\\"${file}\\\" | rev | cut -d ':' -f1 | rev)\\\"\n  stripped=\\\"\\\"\n  for arch in $archs; do\n    if ! [[ \\\"${VALID_ARCHS}\\\" == *\\\"$arch\\\"* ]]; then\n      # Strip non-valid architectures in-place\n      lipo -remove \\\"$arch\\\" -output \\\"$file\\\" \\\"$file\\\" || exit 1\n      stripped=\\\"$stripped $arch\\\"\n    fi\n  done\n  if [[ \\\"$stripped\\\" != \\\"\\\" ]]; then\n    echo \\\"Stripped $file of architectures:$stripped\\\"\n    if [ \\\"${CODE_SIGNING_REQUIRED}\\\" == \\\"YES\\\" ]; then\n      code_sign \\\"${file}\\\"\n    fi\n  fi\ndone\n";
 		};
 		SSBP_7793755940 /* MyScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -561,7 +572,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script\"\n";
+			shellScript = "echo \\\"You ran a script\\\"\n";
 		};
 		SSBP_7909350562 /* MyScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -575,7 +586,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script\"\n";
+			shellScript = "echo \\\"You ran a script\\\"\n";
 		};
 		SSBP_8106229290 /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -605,7 +616,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script\"\n";
+			shellScript = "echo \\\"You ran a script\\\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -616,6 +627,7 @@
 			files = (
 				BF_624802436672 /* FrameworkFile.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		SBP_47229604241 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -623,6 +635,7 @@
 			files = (
 				BF_456457948943 /* FrameworkFile.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		SBP_52511912046 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -630,6 +643,7 @@
 			files = (
 				BF_901390118565 /* FrameworkFile.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		SBP_66231583718 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -637,6 +651,7 @@
 			files = (
 				BF_243071719122 /* FrameworkFile.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		SBP_78312289991 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -644,6 +659,7 @@
 			files = (
 				BF_360196406184 /* TestProjectTests.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 		SBP_82523211050 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -654,6 +670,7 @@
 				BF_561304997165 /* Standalone.swift in Sources */,
 				BF_331192862207 /* ViewController.swift in Sources */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -748,9 +765,9 @@
 		BC_128103534773 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -893,9 +910,9 @@
 		BC_265230327262 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1175,9 +1192,9 @@
 		BC_480688547948 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1287,9 +1304,9 @@
 		BC_530755208334 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1743,9 +1760,9 @@
 		BC_749393271654 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1874,9 +1891,9 @@
 		BC_799916603316 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -2019,6 +2036,7 @@
 				BC_835911551172 /* Test Debug */,
 				BC_685135820012 /* Test Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 		CL_472296042419 /* Build configuration list for PBXNativeTarget "Framework_iOS" */ = {
@@ -2031,6 +2049,7 @@
 				BC_351179072988 /* Test Debug */,
 				BC_210338877784 /* Test Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 		CL_525119120469 /* Build configuration list for PBXNativeTarget "Framework_macOS" */ = {
@@ -2043,6 +2062,7 @@
 				BC_108053643718 /* Test Debug */,
 				BC_741359447852 /* Test Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 		CL_662315837182 /* Build configuration list for PBXNativeTarget "Framework_tvOS" */ = {
@@ -2055,6 +2075,7 @@
 				BC_655752097950 /* Test Debug */,
 				BC_380703106572 /* Test Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 		CL_783122899910 /* Build configuration list for PBXNativeTarget "App_iOS_Tests" */ = {
@@ -2067,6 +2088,7 @@
 				BC_240587562436 /* Test Debug */,
 				BC_793714544511 /* Test Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 		CL_825232110500 /* Build configuration list for PBXNativeTarget "App_iOS" */ = {
@@ -2079,6 +2101,7 @@
 				BC_749393271654 /* Test Debug */,
 				BC_530755208334 /* Test Release */,
 			);
+			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 		CL_844877120535 /* Build configuration list for PBXProject "Project" */ = {

--- a/Tests/XcodeGenKitTests/FixtureTests.swift
+++ b/Tests/XcodeGenKitTests/FixtureTests.swift
@@ -34,11 +34,11 @@ func fixtureTests() {
             guard let project = project else { return }
 
             func getFileReferences(_ path: String) -> [PBXFileReference] {
-                return project.pbxproj.fileReferences.filter { $0.path == path }
+                return project.pbxproj.objects.fileReferences.referenceValues.filter { $0.path == path }
             }
 
             func getVariableGroups(_ name: String?) -> [PBXVariantGroup] {
-                return project.pbxproj.variantGroups.filter { $0.name == name }
+                return project.pbxproj.objects.variantGroups.referenceValues.filter { $0.name == name }
             }
 
             let resourceName = "LocalizedStoryboard.storyboard"


### PR DESCRIPTION
Required changes in order to adopt: https://github.com/xcodeswift/xcproj/pull/136

# Performance Overview & Results

This PR is primarily motivated by improving the performance in generating a large project. The improvements in this PR are largely by converting many properties in PBXProj (of xcproj) to dictionaries vs arrays which provides constant time lookups for hot code paths vs linear searches.

Control: (before any sort of lookup improvements):
https://github.com/xcodeswift/xcproj/commit/49aab802779cfb767a3c0f818ea042e79dd8b0a3

Optimized:
https://github.com/yonaskolb/XcodeGen/pull/158/commits/f2c4ebabfd57f813da444e276850e7f23dd847c9

## Project Complexity

aggregateTargets		0 	
buildConfigurations		200 	
buildFiles		31305 	
configurationLists		100 	
containerItemProxies		378 	
copyFilesBuildPhases		2 	
fileElements		0 	
fileReferences		9489 	
frameworksBuildPhases		12 	
groups		675 	
headersBuildPhases		0 	
nativeTargets		99 	
projects		1 
referenceProxies		0 	
resourcesBuildPhases		17 	
shellScriptBuildPhases		8 	
sourcesBuildPhases		99 	
targetDependencies		378 	
variantGroups		0 	
versionGroups		0 	

## Hardware: 
- OS: macOS High Sierra
- MacBook Pro (Retina, 13-inch, Early 2015)
- Processor: 3.1 GHz Intel Core i7
- Memory: 16 GB 1867 MHz DDR3
- Laptop is plugged in for all tests

## Test Script
- Delete existing project, kill any lingering processes
- Generate the full project 5x
- Drop the top / bottom outliers and average the remaining generation times.


### Before Optimizations (in seconds)
1: 88.1857219934464s
2: 119.523904979229s
3: 98.0418360233307s
4: 93.2748199701309s
5: 94.7779580354691s
*Average*: **~95 seconds** `((98+93+94)/3)`

### After Optimizations (in seconds)
1: 46.6170199513435s
2: 74.6580080389977s
3: 33.5623190402985s
4: 37.5278360247612s
5: 29.6541140079498s
*Average*: **~38 seconds** `((33+37+46)/3)`

### Comparison
*Average Percentage Improvement*: **60%** `((1 - (38/95)) * 100)`

