### PR TITLE
[WIP] Initial idea for testing SourceGenerator

### DIFF
--- a/Sources/XcodeGenKit/File.swift
+++ b/Sources/XcodeGenKit/File.swift
@@ -1,0 +1,51 @@
+//
+//  File.swift
+//  XcodeGenKit
+//
+//  Created by ryohey on 2017/11/18.
+//
+
+import Foundation
+import PathKit
+
+internal struct FilePath {
+    var string: String
+    var basename: String { return NSString(string: string).lastPathComponent }
+    var `extension`: String { return NSString(string: basename).pathExtension }
+    var basenameWithoutExtension: String { return NSString(string: basename).deletingPathExtension }
+}
+
+internal indirect enum File {
+    case directory(FilePath, [File]) // path, children
+    case file(FilePath) // path
+
+    var isDirectory: Bool {
+        switch self {
+        case .directory(_, _): return true
+        case .file(_): return false
+        }
+    }
+
+    var isFile: Bool {
+        switch self {
+        case .directory(_, _): return false
+        case .file(_): return true
+        }
+    }
+
+    var path: FilePath {
+        switch self {
+        case .directory(let path, _): return path
+        case .file(let path): return path
+        }
+    }
+}
+
+internal extension Path {
+    func getFileTree() throws -> File {
+        if isFile {
+            return .file(FilePath(string: string))
+        }
+        return .directory(FilePath(string: string), try children().map { try $0.getFileTree() })
+    }
+}

--- a/Sources/XcodeGenKit/File.swift
+++ b/Sources/XcodeGenKit/File.swift
@@ -8,16 +8,24 @@
 import Foundation
 import PathKit
 
-internal struct FilePath {
+public struct FilePath {
     var string: String
     var basename: String { return NSString(string: string).lastPathComponent }
     var `extension`: String { return NSString(string: basename).pathExtension }
     var basenameWithoutExtension: String { return NSString(string: basename).deletingPathExtension }
 }
 
-internal indirect enum File {
+public indirect enum File {
     case directory(FilePath, [File]) // path, children
     case file(FilePath) // path
+
+    public init(_ path: String) {
+        self = .file(FilePath(string: path))
+    }
+
+    public init(_ path: String, _ children: [File]) {
+        self = .directory(FilePath(string: path), children)
+    }
 
     var isDirectory: Bool {
         switch self {
@@ -41,7 +49,7 @@ internal indirect enum File {
     }
 }
 
-internal extension Path {
+extension Path {
     func getFileTree() throws -> File {
         if isFile {
             return .file(FilePath(string: string))

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -158,53 +158,6 @@ class SourceGenerator {
         return variantGroup
     }
 
-    private func getSourceChildren(targetSource: TargetSource, dirPath: Path) throws -> [Path] {
-
-        func getSourceExcludes(targetSource: TargetSource, dirPath: Path) -> [Path] {
-            return targetSource.excludes.map {
-                Path.glob("\(dirPath)/\($0)")
-                    .map {
-                        guard $0.isDirectory else {
-                            return [$0]
-                        }
-
-                        return (try? $0.recursiveChildren().filter { $0.isFile }) ?? []
-                    }
-                    .reduce([], +)
-            }
-            .reduce([], +)
-        }
-
-        let defaultExcludedFiles = [".DS_Store"].map { dirPath + Path($0) }
-
-        let sourcePath = Path(targetSource.path)
-
-        /*
-         Exclude following if mentioned in TargetSource.excludes.
-         Any path related to source dirPath
-         + Pre-defined Excluded files
-         */
-
-        let sourceExcludeFilePaths: Set<Path> = Set(getSourceExcludes(targetSource: targetSource, dirPath: sourcePath)
-            + defaultExcludedFiles)
-
-        return try dirPath.children()
-            .filter {
-                if $0.isDirectory {
-                    let pathChildren = try $0.children()
-                        .filter {
-                            return !sourceExcludeFilePaths.contains($0)
-                        }
-
-                    return !pathChildren.isEmpty
-                } else if $0.isFile {
-                    return !sourceExcludeFilePaths.contains($0)
-                } else {
-                    return false
-                }
-            }
-    }
-
     private func getGroupSources(targetSource: TargetSource, path: Path, isBaseGroup: Bool) throws -> (sourceFiles: [SourceFile], groups: [PBXGroup]) {
         let file = try path.getFileTree()
         guard case let .directory(filename, children) = file else {

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -17,7 +17,7 @@ struct SourceFile {
     let buildPhase: BuildPhase?
 }
 
-class SourceGenerator {
+public class SourceGenerator {
 
     var rootGroups: Set<String> = []
     private var fileReferencesByPath: [Path: String] = [:]
@@ -31,9 +31,9 @@ class SourceGenerator {
 
     var targetName: String = ""
 
-    private(set) var knownRegions: Set<String> = []
+    public private(set) var knownRegions: Set<String> = []
 
-    init(spec: ProjectSpec, proj: PBXProj, referenceGenerator: ReferenceGenerator, addObject: @escaping (PBXObject) -> Void) {
+    public init(spec: ProjectSpec, proj: PBXProj, referenceGenerator: ReferenceGenerator, addObject: @escaping (PBXObject) -> Void) {
         self.spec = spec
         self.proj = proj
         self.referenceGenerator = referenceGenerator
@@ -51,7 +51,7 @@ class SourceGenerator {
         getFileGroups(in: directory)
     }
 
-    func getFileGroups(in directory: File) {
+    public func getFileGroups(in directory: File) {
         _ = getGroupSources(targetSource: TargetSource(path: directory.path.string), directory: directory, isBaseGroup: true)
     }
 

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -1,0 +1,41 @@
+//
+//  SourceGeneratorTests.swift
+//  XcodeGenKit
+//
+//  Created by ryohey on 2017/11/18.
+//
+
+import Spectre
+import XcodeGenKit
+import xcproj
+import PathKit
+import ProjectSpec
+import Yams
+
+
+func sourceGeneratorTests() {
+
+    describe("SourceGenerator") {
+        let application = Target(name: "MyApp", type: .application, platform: .iOS,
+                                 settings: Settings(buildSettings: ["SETTING_1": "VALUE"]),
+                                 dependencies: [])
+        let options = ProjectSpec.Options(bundleIdPrefix: "com.test")
+        let spec = ProjectSpec(basePath: "", name: "test", targets: [application], options: options)
+        var objects: [PBXObject] = []
+        let referenceGenerator = ReferenceGenerator()
+        let proj = PBXProj(objectVersion: 46, rootObject: referenceGenerator.generate(PBXProject.self, "test"))
+        let sourceGenerator = SourceGenerator(spec: spec, proj: proj, referenceGenerator: referenceGenerator, addObject: { objects.append($0) })
+
+        $0.it("_") {
+            let dir: File = File("Src", [
+                File("main.swift"),
+                File("ViewController.swift"),
+                File("Base.lproj", [File("Main.storyboard")]),
+                File("en.lproj", [File("Main.strings")]),
+                ])
+            sourceGenerator.getFileGroups(in: dir)
+            try expect(sourceGenerator.knownRegions.contains("Base")).to.beTrue()
+            try expect(sourceGenerator.knownRegions.contains("en")).to.beTrue()
+        }
+    }
+}

--- a/Tests/XcodeGenKitTests/XCTest.swift
+++ b/Tests/XcodeGenKitTests/XCTest.swift
@@ -8,5 +8,6 @@ class XCodeGenKitTests: XCTestCase {
         specLoadingTests()
         fixtureTests()
         projectSpecTests()
+        sourceGeneratorTests()
     }
 }


### PR DESCRIPTION
This adds a tree structure of path strings so that we can test more cases easily.

## Problem

There are many variations of project configurations, but only a few cases have been tested. I want to write tests that check if variant groups created correctly. We currently use real files as the fixture but that makes hard to test many cases.

## Proposal 

We can change SourceGenerator to use virtual file tree (`enum File`) which is the snapshot of file paths. That looks like the following.

```swift
public indirect enum File {
    case directory(FilePath, [File]) // path, children
    case file(FilePath) // path
}
```

By doing this, we can write a test as follows for various edge cases.

```swift
// file tree
let dir: File = File("Src", [
    File("main.swift"),
    File("ViewController.swift"),
    File("Base.lproj", [File("Main.storyboard")]),
    File("en.lproj", [File("Main.strings")]),
    ])
// process the file tree
sourceGenerator.getFileGroups(in: dir)
try expect(sourceGenerator.knownRegions) == ["Base", "en"]
// and tests about generating groups, variant groups, SourceFile
```

I implemented it partially as an example in this PR and added the test about knownRegions. 

What do you think of this way?

I think that this kind of change may lead to the reduction of side effect and the introduction of immutability by making it possible to think of the part that generates the project structure from the file tree as a kind of map function.

I feel that name `enum File` as is not good.  Aside from that, scanning the file tree may cause performance problems if it contains very deep directories.