### PR TITLE
Add ProjectSpec product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,6 +7,7 @@ let package = Package(
     products: [
         .executable(name: "XcodeGen", targets: ["XcodeGen"]),
         .library(name: "XcodeGenKit", targets: ["XcodeGenKit"]),
+        .library(name: "ProjectSpec", targets: ["ProjectSpec"]),
     ],
     dependencies: [
         .package(url: "https://github.com/kylef/PathKit.git", from: "0.8.0"),


### PR DESCRIPTION
This exposes ProjectSpec.framework to packages that depend on XcodeGen. I'm using this to do some introspection of the project structure in a command line tool. It would be great if this was public. Thanks for your consideration!