### PR TITLE
Add quiet option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ This will look for a project spec in the current directory called `project.yml`
 
 Use `xcodegen --help` to see the list of options:
 
-- **--spec**: An optional path to a `.yml` or `.json` project spec
-- **--project**: An optional path to a directory where the project will be generated. By default this is the current directory
+- **--spec**: An optional path to a `.yml` or `.json` project spec.
+- **--project**: An optional path to a directory where the project will be generated. By default this is the current directory.
+- **--quiet**: Suppress informational and success messages. By default this is disabled.
 
 ## Editing
 ```

--- a/Sources/XcodeGen/Logger.swift
+++ b/Sources/XcodeGen/Logger.swift
@@ -1,23 +1,15 @@
 import Foundation
 import Rainbow
 
-/// Mechanism for logging informational, success, and fatal messages.
 struct Logger {
 
     // MARK: - Properties
 
-    /// Should informational and success messages be suppressed
     let isQuiet: Bool
-
-    /// Should the output be colored
     let isColored: Bool
 
     // MARK: - Initializers
 
-    /// Initialize a logger
-    ///
-    /// - parameter isQuiet: should informational and success messages be suppressed
-    /// - parameter isColored: should the output be colored
     init(isQuiet: Bool = false, isColored: Bool = true) {
         self.isQuiet = isQuiet
         self.isColored = isColored
@@ -25,16 +17,10 @@ struct Logger {
 
     // MARK: - Logging
 
-    /// Log a fatal message and exit with status code 1
-    ///
-    /// - parameter message: the message to log
     func fatal(_ message: String) {
         print(isColored ? message.red : message)
     }
 
-    /// Log an informational message
-    ///
-    /// - parameter message: the message to log
     func info(_ message: String) {
         if isQuiet {
             return
@@ -43,9 +29,6 @@ struct Logger {
         print(message)
     }
 
-    /// Log a success message and exit with status code 0
-    ///
-    /// - parameter message: the message to log
     func success(_ message: String) {
         if isQuiet {
             return

--- a/Sources/XcodeGen/Logger.swift
+++ b/Sources/XcodeGen/Logger.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Rainbow
+
+/// Mechanism for logging informational, success, and fatal messages.
+struct Logger {
+
+    // MARK: - Properties
+
+    /// Should informational and success messages be suppressed
+    let isQuiet: Bool
+
+    /// Should the output be colored
+    let isColored: Bool
+
+    // MARK: - Initializers
+
+    /// Initialize a logger
+    ///
+    /// - parameter isQuiet: should informational and success messages be suppressed
+    /// - parameter isColored: should the output be colored
+    init(isQuiet: Bool = false, isColored: Bool = true) {
+        self.isQuiet = isQuiet
+        self.isColored = isColored
+    }
+
+    // MARK: - Logging
+
+    /// Log a fatal message and exit with status code 1
+    ///
+    /// - parameter message: the message to log
+    func fatal(_ message: String) {
+        print(isColored ? message.red : message)
+    }
+
+    /// Log an informational message
+    ///
+    /// - parameter message: the message to log
+    func info(_ message: String) {
+        if isQuiet {
+            return
+        }
+
+        print(message)
+    }
+
+    /// Log a success message and exit with status code 0
+    ///
+    /// - parameter message: the message to log
+    func success(_ message: String) {
+        if isQuiet {
+            return
+        }
+
+        print(isColored ? message.green : message)
+    }
+}


### PR DESCRIPTION
This option will suppress success messages. A new `Logger` struct is added to the `XcodeGen` target that encapsulates printing, exiting, and the Rainbow logic.

I only added a Commander flag for `--quiet`. If we added a Commander interface, it would be trivial to remove colored output too if that is desired. I didn't do this since I couldn't decide on a name. Also, I figured if you were in a situation where you didn't want colored output, you might also want to suppress emojis.