### PR TITLE
Add carthageCopyScript as an option.

### DIFF
--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -21,6 +21,7 @@ public struct ProjectSpec {
 
     public struct Options {
         public var carthageBuildPath: String?
+        public var carthageCopyScript: Bool
         public var createIntermediateGroups: Bool
         public var bundleIdPrefix: String?
         public var settingPresets: SettingPresets
@@ -47,8 +48,9 @@ public struct ProjectSpec {
             }
         }
 
-        public init(carthageBuildPath: String? = nil, createIntermediateGroups: Bool = false, bundleIdPrefix: String? = nil, settingPresets: SettingPresets = .all, developmentLanguage: String? = nil) {
+        public init(carthageBuildPath: String? = nil, carthageCopyScript: Bool = true, createIntermediateGroups: Bool = false, bundleIdPrefix: String? = nil, settingPresets: SettingPresets = .all, developmentLanguage: String? = nil) {
             self.carthageBuildPath = carthageBuildPath
+            self.carthageCopyScript = carthageCopyScript
             self.createIntermediateGroups = createIntermediateGroups
             self.bundleIdPrefix = bundleIdPrefix
             self.settingPresets = settingPresets
@@ -120,6 +122,7 @@ extension ProjectSpec.Options: Equatable {
 
     public static func == (lhs: ProjectSpec.Options, rhs: ProjectSpec.Options) -> Bool {
         return lhs.carthageBuildPath == rhs.carthageBuildPath &&
+            lhs.carthageCopyScript == rhs.carthageCopyScript &&
             lhs.bundleIdPrefix == rhs.bundleIdPrefix &&
             lhs.settingPresets == rhs.settingPresets &&
             lhs.createIntermediateGroups == rhs.createIntermediateGroups &&
@@ -159,6 +162,7 @@ extension ProjectSpec.Options: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
         carthageBuildPath = jsonDictionary.json(atKeyPath: "carthageBuildPath")
+        carthageCopyScript = jsonDictionary.json(atKeyPath: "carthageCopyScript") ?? true
         bundleIdPrefix = jsonDictionary.json(atKeyPath: "bundleIdPrefix")
         settingPresets = jsonDictionary.json(atKeyPath: "settingPresets") ?? .all
         createIntermediateGroups = jsonDictionary.json(atKeyPath: "createIntermediateGroups") ?? false

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -420,7 +420,7 @@ public class PBXProjGenerator {
 
         if !carthageFrameworksToEmbed.isEmpty {
 
-            if target.type.isApp && target.platform != .macOS {
+            if target.type.isApp && spec.options.carthageCopyScript && target.platform != .macOS {
                 let inputPaths = carthageFrameworksToEmbed.map { "$(SRCROOT)/\(carthageBuildPath)/\(target.platform)/\($0)\($0.contains(".") ? "" : ".framework")" }
                 let outputPaths = carthageFrameworksToEmbed.map { "$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/\($0)\($0.contains(".") ? "" : ".framework")" }
                 let carthageScript = PBXShellScriptBuildPhase(reference: referenceGenerator.generate(PBXShellScriptBuildPhase.self, "Carthage" + target.name), files: [], name: "Carthage", inputPaths: inputPaths, outputPaths: outputPaths, shellPath: "/bin/sh", shellScript: "/usr/local/bin/carthage copy-frameworks\n")


### PR DESCRIPTION
Hi @yonaskolb,

This is a good option to have since not all Carthage frameworks such as Fabric, Crashlytics, should be copied.

Let me know your thoughts.