### PR TITLE
Transform input spec path to absolute path

### DIFF
--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -21,7 +21,7 @@ func generate(spec: String, project: String, isQuiet: Bool, justVersion: Bool) {
         exit(1)
     }
 
-    let specPath = Path(URL(fileURLWithPath: spec).path).normalize()
+    let specPath = Path(spec).absolute()
     let projectPath = Path(project).normalize()
 
     if !specPath.exists {

--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -21,7 +21,7 @@ func generate(spec: String, project: String, isQuiet: Bool, justVersion: Bool) {
         exit(1)
     }
 
-    let specPath = Path(spec).normalize()
+    let specPath = Path(URL(fileURLWithPath: spec).path).normalize()
     let projectPath = Path(project).normalize()
 
     if !specPath.exists {


### PR DESCRIPTION
Fixes #183

As mentioned in #183, `createIntermediateGroups` fails to work as expected under certain conditions. Specifically, project generation works when the `--spec` path is absolute, but breaks when using a relative path. The solution in this change is to convert the spec path to be absolute, at the beginning of project generation.