### PR TITLE
Possibility to change the visibility of headres in case of a framework

### DIFF
--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -67,7 +67,22 @@ extension ProjectSpec {
                     errors.append(.invalidTargetSource(target: target.name, source: sourcePath.string))
                 }
             }
-
+            
+            if target.headerMap != nil && target.type != .framework {
+                errors.append(.invalidHeaderMapForTarget(target: target.name))
+            } else if let map = target.headerMap {
+                let allHeaders = map.privateHeaders + map.publicHeaders
+            
+                let allPossiblePath = allHeaders.flatMap { Path.glob("\(basePath.string)/\($0)")}.map { $0.string }
+                for header in allPossiblePath {
+                    
+                    let path = basePath + Path(header)
+                    if !path.exists {
+                        errors.append(.invalidHeaderPathForTarget(target: target.name, path: header))
+                    }
+                }
+            }
+            
             if let scheme = target.scheme {
 
                 for configVariant in scheme.configVariants {

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -19,6 +19,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidFileGroup(String)
         case invalidConfigFileConfig(String)
         case missingConfigTypeForGeneratedTargetScheme(target: String, configType: ConfigType)
+        case invalidHeaderMapForTarget(target: String)
+        case invalidHeaderPathForTarget(target: String, path: String)
 
         public var description: String {
             switch self {
@@ -36,6 +38,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
             case let .invalidFileGroup(group): return "Invalid file group \(group.quoted)"
             case let .invalidConfigFileConfig(config): return "Config file has invalid config \(config.quoted)"
             case let .missingConfigTypeForGeneratedTargetScheme(target, configType): return "Target \(target.quoted) is missing a config of type \(configType.rawValue) to generate its scheme"
+            case let .invalidHeaderMapForTarget(target): return "Target \(target.quoted) can not define one header map if it is not a framework"
+            case let .invalidHeaderPathForTarget(target, path): return "Target \(target.quoted) declares a header at invalid path \(path.quoted)"
             }
         }
     }

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -13,7 +13,19 @@ public struct Target {
     public var postbuildScripts: [BuildScript]
     public var configFiles: [String: String]
     public var scheme: TargetScheme?
+    public var headerMap: HeaderVisibilityMap?
 
+    public struct HeaderVisibilityMap {
+        public var publicHeaders: [String]
+        public var privateHeaders: [String]
+        
+        public init(publicHeaders: [String] = [], privateHeaders:[String] = []) {
+            self.publicHeaders = publicHeaders
+            self.privateHeaders = privateHeaders
+        }
+    }
+    
+    
     public var filename: String {
         var name = self.name
         if let fileExtension = type.fileExtension {
@@ -22,7 +34,7 @@ public struct Target {
         return name
     }
 
-    public init(name: String, type: PBXProductType, platform: Platform, settings: Settings = .empty, configFiles: [String: String] = [:], sources: [TargetSource] = [], dependencies: [Dependency] = [], prebuildScripts: [BuildScript] = [], postbuildScripts: [BuildScript] = [], scheme: TargetScheme? = nil) {
+    public init(name: String, type: PBXProductType, platform: Platform, settings: Settings = .empty, configFiles: [String: String] = [:], sources: [TargetSource] = [], dependencies: [Dependency] = [], prebuildScripts: [BuildScript] = [], postbuildScripts: [BuildScript] = [], scheme: TargetScheme? = nil, headerMap: HeaderVisibilityMap? = nil) {
         self.name = name
         self.type = type
         self.platform = platform
@@ -33,6 +45,7 @@ public struct Target {
         self.prebuildScripts = prebuildScripts
         self.postbuildScripts = postbuildScripts
         self.scheme = scheme
+        self.headerMap = headerMap
     }
 }
 
@@ -122,7 +135,8 @@ extension Target: Equatable {
             lhs.dependencies == rhs.dependencies &&
             lhs.prebuildScripts == rhs.prebuildScripts &&
             lhs.postbuildScripts == rhs.postbuildScripts &&
-            lhs.scheme == rhs.scheme
+            lhs.scheme == rhs.scheme &&
+            lhs.headerMap == rhs.headerMap
     }
 }
 
@@ -199,5 +213,23 @@ extension Target: NamedJSONDictionaryConvertible {
         prebuildScripts = jsonDictionary.json(atKeyPath: "prebuildScripts") ?? []
         postbuildScripts = jsonDictionary.json(atKeyPath: "postbuildScripts") ?? []
         scheme = jsonDictionary.json(atKeyPath: "scheme")
+        headerMap = jsonDictionary.json(atKeyPath: "headers")
     }
 }
+
+// Mark: - Visibility map
+extension Target.HeaderVisibilityMap: Equatable {
+    public static func ==(lhs: Target.HeaderVisibilityMap, rhs: Target.HeaderVisibilityMap) -> Bool {
+        return lhs.privateHeaders == rhs.privateHeaders &&
+            lhs.publicHeaders == rhs.publicHeaders
+    }
+}
+
+extension Target.HeaderVisibilityMap: JSONObjectConvertible {
+    public init(jsonDictionary: JSONDictionary) throws {
+        self.publicHeaders = jsonDictionary.json(atKeyPath: "public") ?? []
+        self.privateHeaders = jsonDictionary.json(atKeyPath: "private") ?? []
+    }
+}
+
+

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -45,10 +45,7 @@ class SourceGenerator {
         let fileReference = fileReferencesByPath[path]!
         var settings: [String: Any] = [:]
         let buildPhase = buildPhase ?? getDefaultBuildPhase(for: path)
-
-        if buildPhase == .headers {
-            settings = ["ATTRIBUTES": ["Public"]]
-        }
+  
         if targetSource.compilerFlags.count > 0 {
             settings["COMPILER_FLAGS"] = targetSource.compilerFlags.joined(separator: " ")
         }

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -8,7 +8,7 @@ func projectSpecTests() {
     describe("ProjectSpec") {
 
         let framework = Target(name: "MyFramework", type: .framework, platform: .iOS,
-                               settings: Settings(buildSettings: ["SETTING_2": "VALUE"]))
+                               settings: Settings(buildSettings: ["SETTING_2": "VALUE"]), headerMap: Target.HeaderVisibilityMap(publicHeaders: ["Some"]))
         let staticLibrary = Target(name: "MyStaticLibrary", type: .staticLibrary, platform: .iOS,
                                    settings: Settings(buildSettings: ["SETTING_2": "VALUE"]))
         let dynamicLibrary = Target(name: "MyDynamicLibrary", type: .dynamicLibrary, platform: .iOS,
@@ -71,7 +71,8 @@ func projectSpecTests() {
                                        dependencies: [Dependency(type: .target, reference: "invalidDependency")],
                                        prebuildScripts: [BuildScript(script: .path("invalidPrebuildScript"), name: "prebuildScript1")],
                                        postbuildScripts: [BuildScript(script: .path("invalidPostbuildScript"))],
-                                       scheme: TargetScheme(testTargets: ["invalidTarget"])
+                                       scheme: TargetScheme(testTargets: ["invalidTarget"]),
+                                       headerMap: Target.HeaderVisibilityMap(publicHeaders: ["Some"])
                 )]
 
                 try expectValidationError(spec, .invalidTargetDependency(target: "target1", dependency: "invalidDependency"))
@@ -85,7 +86,8 @@ func projectSpecTests() {
 
                 try expectValidationError(spec, .missingConfigTypeForGeneratedTargetScheme(target: "target1", configType: .debug))
                 try expectValidationError(spec, .missingConfigTypeForGeneratedTargetScheme(target: "target1", configType: .release))
-
+                try expectValidationError(spec, .invalidHeaderMapForTarget(target: "target1"))
+                
                 spec.targets[0].scheme?.configVariants = ["invalidVariant"]
                 try expectValidationError(spec, .invalidTargetSchemeConfigVariant(target: "target1", configVariant: "invalidVariant", configType: .debug))
             }


### PR DESCRIPTION
Add the possibility to specify the visibility of the header in case of a framework target.

You can use the `headers` property for that:
```yaml
name: TestProj
targets:
  MyTarget:
    type: framework
    platform: iOS
    sources:
      - path: some_path
    headers:
      public:
        - generated-src/objc/*.h
      private:
        - somefile.hpp
```
If a non framework target uses this property, a `invalidHeaderMapForTarget` error is thrown during the validation pass.
If one of the provided files does not exist, an `invalidHeaderPathForTarget` error is thrown during the validation pass.

Some basics tests have been added for the parsing.

The default behaviour for headers has changed: all headers will be considerated as `Project` by default, unless `headers` tells something else.