### PR TITLE
Scan for Info.plist lazily

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -160,7 +160,7 @@ public class PBXProjGenerator {
             // automatically set INFOPLIST_FILE path
             if !spec.targetHasBuildSetting("INFOPLIST_FILE", basePath: spec.basePath, target: target, config: config) {
                 if searchForPlist {
-                    plistPath = getInfoPlist(spec, target.sources)
+                    plistPath = getInfoPlist(target.sources)
                     searchForPlist = false
                 }
                 if let plistPath = plistPath {
@@ -458,10 +458,10 @@ public class PBXProjGenerator {
         return pbxtarget
     }
 
-    func getInfoPlist(_ spec: ProjectSpec, _ sources: [TargetSource]) -> Path? {
+    func getInfoPlist(_ sources: [TargetSource]) -> Path? {
         return sources
             .lazy
-            .map { spec.basePath + $0.path }
+            .map { self.spec.basePath + $0.path }
             .flatMap { (path) -> Path? in
                 if path.isFile {
                     return path.lastComponent == "Info.plist" ? path : nil

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -151,27 +151,21 @@ public class PBXProjGenerator {
 
         let sourceFiles = try sourceGenerator.getAllSourceFiles(sources: target.sources)
 
-        // find all Info.plist files
-        let infoPlists: [Path] = target.sources.map { spec.basePath + $0.path }.flatMap { (path) -> [Path] in
-            if path.isFile {
-                if path.lastComponent == "Info.plist" {
-                    return [path]
-                }
-            } else {
-                if let children = try? path.recursiveChildren() {
-                    return children.filter { $0.lastComponent == "Info.plist" }
-                }
-            }
-            return []
-        }
+        var plistPath: Path? = nil
+        var searchForPlist = true
 
         let configs: [XCBuildConfiguration] = spec.configs.map { config in
             var buildSettings = spec.getTargetBuildSettings(target: target, config: config)
 
             // automatically set INFOPLIST_FILE path
-            if let plistPath = infoPlists.first,
-                !spec.targetHasBuildSetting("INFOPLIST_FILE", basePath: spec.basePath, target: target, config: config) {
-                buildSettings["INFOPLIST_FILE"] = plistPath.byRemovingBase(path: spec.basePath)
+            if !spec.targetHasBuildSetting("INFOPLIST_FILE", basePath: spec.basePath, target: target, config: config) {
+                if searchForPlist {
+                    plistPath = getInfoPlist(spec, target.sources)
+                    searchForPlist = false
+                }
+                if let plistPath = plistPath {
+                    buildSettings["INFOPLIST_FILE"] = plistPath.byRemovingBase(path: spec.basePath)
+                }
             }
 
             // automatically calculate bundle id
@@ -462,6 +456,20 @@ public class PBXProjGenerator {
         }
         addObject(pbxtarget)
         return pbxtarget
+    }
+
+    func getInfoPlist(_ spec: ProjectSpec, _ sources: [TargetSource]) -> Path? {
+        return sources
+            .lazy
+            .map { spec.basePath + $0.path }
+            .flatMap { (path) -> Path? in
+                if path.isFile {
+                    return path.lastComponent == "Info.plist" ? path : nil
+                } else {
+                    return path.first(where: { $0.lastComponent == "Info.plist" })
+                }
+            }
+            .first
     }
 
     func getCarthageBuildPath(platform: Platform) -> String {


### PR DESCRIPTION
Prevent unnecessary work from being done while searching for an Info.plist file. For the project I tested with (which specifies `INFOPLIST_FILE` in most cases) this change results in:

* A >50mb reduction in cumulative memory allocated
* A 3-5% time reduction for project generation

This changes the behavior from:

1. Scan to find the Info.plist path for every target, regardless of whether the found path is used
2. Build an array containing every source file, and from that, take the first Info.plist

To:

1. Defer scanning for Info.plist to the time it's needed
2. Stop recursive scanning upon finding the first Info.plist

For number 1, if a config defines `INFOPLIST_FILE`, then there's no need to scan the file system for an Info.plist.

For number 2, since the behavior is to take the first found Info.plist, then there's no need to generate an array containing every descendent file, for all sources, for every target. The search can stop as soon as an Info.plist is found.