### PR TITLE
Added support for testables in `Scheme`

### DIFF
--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -24,12 +24,12 @@ public struct Scheme: Equatable {
         self.archive = archive
     }
 
-    public init(name: String, targets: [BuildTarget], debugConfig: String, releaseConfig: String, gatherCoverageData: Bool = false, commandLineArguments: [String: Bool] = [:]) {
+    public init(name: String, targets: [BuildTarget], debugConfig: String, releaseConfig: String, gatherCoverageData: Bool = false, commandLineArguments: [String: Bool] = [:], testables: [String] = []) {
         self.init(
             name: name,
             build: .init(targets: targets),
             run: .init(config: debugConfig, commandLineArguments: commandLineArguments),
-            test: .init(config: debugConfig, gatherCoverageData: gatherCoverageData, commandLineArguments: commandLineArguments),
+            test: .init(config: debugConfig, gatherCoverageData: gatherCoverageData, commandLineArguments: commandLineArguments, targets: testables),
             profile: .init(config: releaseConfig, commandLineArguments: commandLineArguments),
             analyze: .init(config: debugConfig),
             archive: .init(config: releaseConfig)
@@ -65,16 +65,20 @@ public struct Scheme: Equatable {
         public var config: String
         public var gatherCoverageData: Bool
         public var commandLineArguments: [String: Bool]
-        public init(config: String, gatherCoverageData: Bool = false, commandLineArguments: [String: Bool] = [:]) {
+        public var targets: [String]
+
+        public init(config: String, gatherCoverageData: Bool = false, commandLineArguments: [String: Bool] = [:], targets: [String] = []) {
             self.config = config
             self.gatherCoverageData = gatherCoverageData
             self.commandLineArguments = commandLineArguments
+            self.targets = targets
         }
 
         public static func == (lhs: Test, rhs: Test) -> Bool {
             return lhs.config == rhs.config &&
                 lhs.commandLineArguments == rhs.commandLineArguments &&
-                lhs.gatherCoverageData == rhs.gatherCoverageData
+                lhs.gatherCoverageData == rhs.gatherCoverageData &&
+                lhs.targets == rhs.targets
         }
     }
 
@@ -155,6 +159,7 @@ extension Scheme.Test: JSONObjectConvertible {
         config = try jsonDictionary.json(atKeyPath: "config")
         gatherCoverageData = jsonDictionary.json(atKeyPath: "gatherCoverageData") ?? false
         commandLineArguments = jsonDictionary.json(atKeyPath: "commandLineArguments") ?? [:]
+        targets = jsonDictionary.json(atKeyPath: "targets") ?? []
     }
 }
 

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -24,12 +24,12 @@ public struct Scheme: Equatable {
         self.archive = archive
     }
 
-    public init(name: String, targets: [BuildTarget], debugConfig: String, releaseConfig: String, gatherCoverageData: Bool = false, commandLineArguments: [String: Bool] = [:], testables: [String] = []) {
+    public init(name: String, targets: [BuildTarget], debugConfig: String, releaseConfig: String, gatherCoverageData: Bool = false, commandLineArguments: [String: Bool] = [:], testTargets: [String] = []) {
         self.init(
             name: name,
             build: .init(targets: targets),
             run: .init(config: debugConfig, commandLineArguments: commandLineArguments),
-            test: .init(config: debugConfig, gatherCoverageData: gatherCoverageData, commandLineArguments: commandLineArguments, targets: testables),
+            test: .init(config: debugConfig, gatherCoverageData: gatherCoverageData, commandLineArguments: commandLineArguments, targets: testTargets),
             profile: .init(config: releaseConfig, commandLineArguments: commandLineArguments),
             analyze: .init(config: debugConfig),
             archive: .init(config: releaseConfig)

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -116,7 +116,7 @@ public class ProjectGenerator {
                     let debugConfig = spec.configs.first { $0.type == .debug }!
                     let releaseConfig = spec.configs.first { $0.type == .release }!
 
-                    let specScheme = Scheme(name: schemeName, targets: [Scheme.BuildTarget(target: target.name)], debugConfig: debugConfig.name, releaseConfig: releaseConfig.name, gatherCoverageData: scheme.gatherCoverageData, commandLineArguments: scheme.commandLineArguments, testables: scheme.testTargets)
+                    let specScheme = Scheme(name: schemeName, targets: [Scheme.BuildTarget(target: target.name)], debugConfig: debugConfig.name, releaseConfig: releaseConfig.name, gatherCoverageData: scheme.gatherCoverageData, commandLineArguments: scheme.commandLineArguments, testTargets: scheme.testTargets)
                     let scheme = try generateScheme(specScheme, pbxProject: pbxProject)
                     xcschemes.append(scheme)
                 } else {
@@ -127,7 +127,7 @@ public class ProjectGenerator {
                         let debugConfig = spec.configs.first { $0.type == .debug && $0.name.contains(configVariant) }!
                         let releaseConfig = spec.configs.first { $0.type == .release && $0.name.contains(configVariant) }!
 
-                        let specScheme = Scheme(name: schemeName, targets: [Scheme.BuildTarget(target: target.name)], debugConfig: debugConfig.name, releaseConfig: releaseConfig.name, gatherCoverageData: scheme.gatherCoverageData, commandLineArguments: scheme.commandLineArguments, testables: scheme.testTargets)
+                        let specScheme = Scheme(name: schemeName, targets: [Scheme.BuildTarget(target: target.name)], debugConfig: debugConfig.name, releaseConfig: releaseConfig.name, gatherCoverageData: scheme.gatherCoverageData, commandLineArguments: scheme.commandLineArguments, testTargets: scheme.testTargets)
                         let scheme = try generateScheme(specScheme, pbxProject: pbxProject)
                         xcschemes.append(scheme)
                     }

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -36,7 +36,7 @@ public class ProjectGenerator {
         return XCWorkspace(data: workspaceData)
     }
 
-    func generateScheme(_ scheme: Scheme, pbxProject: PBXProj, tests: [String] = []) throws -> XCScheme {
+    func generateScheme(_ scheme: Scheme, pbxProject: PBXProj) throws -> XCScheme {
 
         func getBuildEntry(_ buildTarget: Scheme.BuildTarget) -> XCScheme.BuildAction.Entry {
 
@@ -48,13 +48,14 @@ public class ProjectGenerator {
             return XCScheme.BuildAction.Entry(buildableReference: buildableReference, buildFor: buildTarget.buildTypes)
         }
 
-        let testBuildTargets = tests.map {
+        let testTargetNames = scheme.test?.targets ?? []
+        let testBuildTargets = testTargetNames.map {
             Scheme.BuildTarget(target: $0, buildTypes: BuildType.testOnly)
         }
 
         let testBuildTargetEntries = testBuildTargets.map(getBuildEntry)
 
-        let buildActionEntries: [XCScheme.BuildAction.Entry] = scheme.build.targets.map(getBuildEntry) + testBuildTargetEntries
+        let buildActionEntries: [XCScheme.BuildAction.Entry] = scheme.build.targets.map(getBuildEntry)
 
         let buildableReference = buildActionEntries.first!.buildableReference
         let productRunable = XCScheme.BuildableProductRunnable(buildableReference: buildableReference)
@@ -115,8 +116,8 @@ public class ProjectGenerator {
                     let debugConfig = spec.configs.first { $0.type == .debug }!
                     let releaseConfig = spec.configs.first { $0.type == .release }!
 
-                    let specScheme = Scheme(name: schemeName, targets: [Scheme.BuildTarget(target: target.name)], debugConfig: debugConfig.name, releaseConfig: releaseConfig.name, gatherCoverageData: scheme.gatherCoverageData, commandLineArguments: scheme.commandLineArguments)
-                    let scheme = try generateScheme(specScheme, pbxProject: pbxProject, tests: scheme.testTargets)
+                    let specScheme = Scheme(name: schemeName, targets: [Scheme.BuildTarget(target: target.name)], debugConfig: debugConfig.name, releaseConfig: releaseConfig.name, gatherCoverageData: scheme.gatherCoverageData, commandLineArguments: scheme.commandLineArguments, testables: scheme.testTargets)
+                    let scheme = try generateScheme(specScheme, pbxProject: pbxProject)
                     xcschemes.append(scheme)
                 } else {
                     for configVariant in scheme.configVariants {
@@ -126,8 +127,8 @@ public class ProjectGenerator {
                         let debugConfig = spec.configs.first { $0.type == .debug && $0.name.contains(configVariant) }!
                         let releaseConfig = spec.configs.first { $0.type == .release && $0.name.contains(configVariant) }!
 
-                        let specScheme = Scheme(name: schemeName, targets: [Scheme.BuildTarget(target: target.name)], debugConfig: debugConfig.name, releaseConfig: releaseConfig.name, gatherCoverageData: scheme.gatherCoverageData, commandLineArguments: scheme.commandLineArguments)
-                        let scheme = try generateScheme(specScheme, pbxProject: pbxProject, tests: scheme.testTargets)
+                        let specScheme = Scheme(name: schemeName, targets: [Scheme.BuildTarget(target: target.name)], debugConfig: debugConfig.name, releaseConfig: releaseConfig.name, gatherCoverageData: scheme.gatherCoverageData, commandLineArguments: scheme.commandLineArguments, testables: scheme.testTargets)
+                        let scheme = try generateScheme(specScheme, pbxProject: pbxProject)
                         xcschemes.append(scheme)
                     }
                 }


### PR DESCRIPTION
Fixes #193

This addresses the issue that it was impossible to test targets if
custom scheme was used by providing array of testables to `Test` action.

Now it should be possible using the following syntax:

```yaml
STCore:
  build:
    targets:
      - target: STCore
        buildTypes: all
  test:
    testables: [STCoreTests]
    config: Staging-Debug
```

Note that original example in #193 has to be modified for this change
as it causes a confusion in Xcode: if we have 2 targets `STCore` and
`STCoreTests`, if `STCoreTests` is also added as testable Xcode
duplicates test target in build actions (i.e. `STCore`, `STCoreTests`,
`STCoreTests` are shown).