### PR TITLE
Add Xcode version

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -74,6 +74,7 @@ Note that target names can also be changed by adding a `name` property to a targ
 - ⚪️ **usesTabs**: `Bool` - If this is specified, the Xcode project will override the user's setting determining whether or not tabs or spaces should be used in the project.
 - ⚪️ **indentWidth**: `Int` - If this is specified, the Xcode project will override the user's setting for indent width in number of spaces.
 - ⚪️ **tabWidth**: `Int` - If this is specified, the Xcode project will override the user's setting for indent width in number of spaces.
+- ⚪️ **xcodeVersion**: `String` - The version of Xcode. This defaults to the latest version periodically. You can specify it in the format `0910` or `9.1`
 
 ### Configs
 Each config maps to a build type of either `debug` or `release` which will then apply default build settings to the project. Any value other than `debug` or `release` (for example `none`), will mean no default build settings will be applied to the project.
@@ -374,4 +375,3 @@ By providing a legacy target, you are opting in to the "Legacy Target" mode. Thi
 - ⚪️ **arguments**: String - Build arguments used for the build tool in the legacy target
 - ⚪️ **passSettings**: Bool - Whether or not to pass build settings down to the build tool in the legacy target.
 - ⚪️ **workingDirectory**: String - The working directory under which the build tool will be invoked in the legacy target.
-

--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -19,7 +19,7 @@ public struct ProjectSpec {
     public var configFiles: [String: String]
     public var include: [String] = []
 
-    public struct Options {
+    public struct Options: Equatable {
         public var carthageBuildPath: String?
         public var createIntermediateGroups: Bool
         public var bundleIdPrefix: String?
@@ -28,6 +28,7 @@ public struct ProjectSpec {
         public var usesTabs: Bool?
         public var tabWidth: Int?
         public var indentWidth: Int?
+        public var xcodeVersion: String?
 
         public enum SettingPresets: String {
             case all
@@ -50,7 +51,7 @@ public struct ProjectSpec {
             }
         }
 
-        public init(carthageBuildPath: String? = nil, createIntermediateGroups: Bool = false, bundleIdPrefix: String? = nil, settingPresets: SettingPresets = .all, developmentLanguage: String? = nil, indentWidth: Int? = nil, tabWidth: Int? = nil, usesTabs: Bool? = nil) {
+        public init(carthageBuildPath: String? = nil, createIntermediateGroups: Bool = false, bundleIdPrefix: String? = nil, settingPresets: SettingPresets = .all, developmentLanguage: String? = nil, indentWidth: Int? = nil, tabWidth: Int? = nil, usesTabs: Bool? = nil, xcodeVersion: String? = nil) {
             self.carthageBuildPath = carthageBuildPath
             self.createIntermediateGroups = createIntermediateGroups
             self.bundleIdPrefix = bundleIdPrefix
@@ -59,6 +60,19 @@ public struct ProjectSpec {
             self.tabWidth = tabWidth
             self.indentWidth = indentWidth
             self.usesTabs = usesTabs
+            self.xcodeVersion = xcodeVersion
+        }
+
+        public static func == (lhs: ProjectSpec.Options, rhs: ProjectSpec.Options) -> Bool {
+            return lhs.carthageBuildPath == rhs.carthageBuildPath &&
+            lhs.bundleIdPrefix == rhs.bundleIdPrefix &&
+            lhs.settingPresets == rhs.settingPresets &&
+            lhs.createIntermediateGroups == rhs.createIntermediateGroups &&
+            lhs.developmentLanguage == rhs.developmentLanguage &&
+            lhs.tabWidth == rhs.tabWidth &&
+            lhs.indentWidth == rhs.indentWidth &&
+            lhs.usesTabs == rhs.usesTabs &&
+            lhs.xcodeVersion == rhs.xcodeVersion
         }
     }
 
@@ -119,17 +133,6 @@ extension ProjectSpec: Equatable {
             lhs.configFiles == rhs.configFiles &&
             lhs.options == rhs.options &&
             NSDictionary(dictionary: lhs.attributes).isEqual(to: rhs.attributes)
-    }
-}
-
-extension ProjectSpec.Options: Equatable {
-
-    public static func == (lhs: ProjectSpec.Options, rhs: ProjectSpec.Options) -> Bool {
-        return lhs.carthageBuildPath == rhs.carthageBuildPath &&
-            lhs.bundleIdPrefix == rhs.bundleIdPrefix &&
-            lhs.settingPresets == rhs.settingPresets &&
-            lhs.createIntermediateGroups == rhs.createIntermediateGroups &&
-            lhs.developmentLanguage == rhs.developmentLanguage
     }
 }
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -8,7 +8,6 @@ import ProjectSpec
 public class PBXProjGenerator {
 
     let spec: ProjectSpec
-    let currentXcodeVersion: String
 
     let proj: PBXProj
     let sourceGenerator: SourceGenerator
@@ -27,8 +26,7 @@ public class PBXProjGenerator {
         return spec.options.carthageBuildPath ?? "Carthage/Build"
     }
 
-    public init(spec: ProjectSpec, currentXcodeVersion: String) {
-        self.currentXcodeVersion = currentXcodeVersion
+    public init(spec: ProjectSpec) {
         self.spec = spec
         proj = PBXProj(objectVersion: 46, rootObject: referenceGenerator.generate(PBXProject.self, spec.name))
         sourceGenerator = SourceGenerator(spec: spec, referenceGenerator: referenceGenerator) { _ in }
@@ -111,7 +109,7 @@ public class PBXProjGenerator {
 
         sortGroups(group: mainGroup)
 
-        let projectAttributes: [String: Any] = ["LastUpgradeCheck": currentXcodeVersion].merged(spec.attributes)
+        let projectAttributes: [String: Any] = ["LastUpgradeCheck": spec.xcodeVersion].merged(spec.attributes)
         let root = PBXProject(name: spec.name,
                               reference: proj.rootObject,
                               buildConfigurationList: buildConfigList.reference,

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -8,7 +8,6 @@ import ProjectSpec
 public class ProjectGenerator {
 
     let spec: ProjectSpec
-    let currentXcodeVersion = "0900"
 
     public init(spec: ProjectSpec) {
         self.spec = spec
@@ -24,7 +23,7 @@ public class ProjectGenerator {
 
     public func generateProject() throws -> XcodeProj {
         try spec.validate()
-        let pbxProjGenerator = PBXProjGenerator(spec: spec, currentXcodeVersion: currentXcodeVersion)
+        let pbxProjGenerator = PBXProjGenerator(spec: spec)
         let pbxProject = try pbxProjGenerator.generate()
         let workspace = try generateWorkspace()
         let sharedData = try generateSharedData(pbxProject: pbxProject)
@@ -87,7 +86,7 @@ public class ProjectGenerator {
         let archiveAction = XCScheme.ArchiveAction(buildConfiguration: scheme.archive?.config ?? defaultReleaseConfig.name, revealArchiveInOrganizer: true)
 
         return XCScheme(name: scheme.name,
-                        lastUpgradeVersion: currentXcodeVersion,
+                        lastUpgradeVersion: spec.xcodeVersion,
                         version: "1.3",
                         buildAction: buildAction,
                         testAction: testAction,

--- a/Sources/XcodeGenKit/Version.swift
+++ b/Sources/XcodeGenKit/Version.swift
@@ -4,7 +4,7 @@ import ProjectSpec
 extension ProjectSpec {
 
     var xcodeVersion: String {
-        return XCodeVersion.parse(options.xcodeVersion ?? "9.0")
+        return XCodeVersion.parse(options.xcodeVersion ?? "9.2")
     }
 }
 

--- a/Sources/XcodeGenKit/Version.swift
+++ b/Sources/XcodeGenKit/Version.swift
@@ -1,0 +1,42 @@
+import Foundation
+import ProjectSpec
+
+extension ProjectSpec {
+
+    var xcodeVersion: String {
+        return XCodeVersion.parse(options.xcodeVersion ?? "9.0")
+    }
+}
+
+public struct XCodeVersion {
+
+    public static func parse(_ version: String) -> String {
+        if version.contains(".") {
+            let parts = version.split(separator: ".").map(String.init)
+            var string = ""
+            let major = parts[0]
+            if major.count == 1 {
+                string = "0\(major)"
+            } else {
+                string = major
+            }
+
+            let minor = parts[1]
+            string += minor
+
+            if parts.count > 2 {
+                let patch = parts[2]
+                string += patch
+            } else {
+                string += "0"
+            }
+            return string
+        } else if version.count == 2 {
+            return "\(version)00"
+        } else if version.count == 1 {
+            return "0\(version)00"
+        } else {
+            return version
+        }
+    }
+}

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -506,7 +506,7 @@
 		P_8448771205358 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0920;
 			};
 			buildConfigurationList = CL_844877120535 /* Build configuration list for PBXProject "Project" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS.xcscheme
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
-<Scheme LastUpgradeVersion="0900" version="1.3">
+<Scheme LastUpgradeVersion="0920" version="1.3">
 	<AnalyzeAction buildConfiguration="Production Debug" />
 	<ArchiveAction buildConfiguration="Production Release" revealArchiveInOrganizer="YES" />
 	<TestAction selectedDebuggerIdentifier="Xcode.DebuggerFoundation.Debugger.LLDB" selectedLauncherIdentifier="Xcode.DebuggerFoundation.Launcher.LLDB" codeCoverageEnabled="YES" shouldUseLaunchSchemeArgsEnv="YES" buildConfiguration="Production Debug">

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -62,6 +62,24 @@ func projectGeneratorTests() {
                 }
                 try expect(pbxProject.developmentRegion) == "de"
             }
+
+            $0.it("formats xcode version") {
+                let versions: [String: String] = [
+                    "0900": "0900",
+                    "1010": "1010",
+                    "9": "0900",
+                    "9.0": "0900",
+                    "9.1": "0910",
+                    "9.1.1": "0911",
+                    "10": "1000",
+                    "10.1": "1010",
+                    "10.1.2": "1012",
+                ]
+
+                for (version, expected) in versions {
+                    try expect(XCodeVersion.parse(version)) == expected
+                }
+            }
         }
 
         $0.describe("Config") {


### PR DESCRIPTION
Resolves #179 

This adds `xcodeVersion` to `spec.options`, which supports 2 formats: `0910` and `9.1`.
It also updates the default to 9.2 and includes parsing tests and documentation.