### PR TITLE
Fixed test/profile command line args not being passed

### DIFF
--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -71,6 +71,7 @@ public class ProjectGenerator {
         let testAction = XCScheme.TestAction(buildConfiguration: scheme.test?.config ?? defaultDebugConfig.name,
                                              macroExpansion: buildableReference,
                                              testables: testables,
+                                             shouldUseLaunchSchemeArgsEnv: scheme.test?.commandLineArguments.isEmpty ?? true,
                                              codeCoverageEnabled: scheme.test?.gatherCoverageData ?? false,
                                              commandlineArguments: testCommandLineArgs)
 
@@ -80,6 +81,7 @@ public class ProjectGenerator {
 
         let profileAction = XCScheme.ProfileAction(buildableProductRunnable: productRunable,
                                                    buildConfiguration: scheme.profile?.config ?? defaultReleaseConfig.name,
+                                                   shouldUseLaunchSchemeArgsEnv: scheme.profile?.commandLineArguments.isEmpty ?? true,
                                                    commandlineArguments: profileCommandLineArgs)
 
         let analyzeAction = XCScheme.AnalyzeAction(buildConfiguration: scheme.analyze?.config ?? defaultDebugConfig.name)


### PR DESCRIPTION
It's not enough just set command line arguments - there is a separate
flag in scheme, which allows them to overwrite default launch arguments.

Now that flag is automatically set if there are any args provided.

Fixes #198