### PR TITLE
Change Scheme.Build.targets spec

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -396,14 +396,12 @@ Schemes allows for more control than the convenience [Target Scheme](#target-sch
 - [ ] ***archive***: The archive action
 
 ### Build
-- [x] **targets**: **[Build Target]** - A list of targets to build
- - [x] **name**: **String** - the name of the target
- - [ ] **buildTypes**: **[String]** - A list of build types for this target. The default is all types. The build types are:
-		- `run`
-		- `test`
-		- `profile`
-		- `analyze`
-		- `archive`
+- [x] **targets**: **String** or **[String]** - A map of target names to build and which build types they should be enabled for. The buildTypes can either be `all`, `none` or an array of the following types:
+	- `run`
+	- `test`
+	- `profile`
+	- `analyze`
+	- `archive`
 
 ### Common Build Action options
 The different actions share some properties:
@@ -422,9 +420,8 @@ scheme:
   Production:
     build:
       targets:
-        - name: MyTarget1
-        - name: MyTarget2
-          buildTypes: [run, archive]
+        MyTarget1: all
+        MyTarget2: [run, archive]
     run:
       config: prod-debug
       commandLineArguments: "--option value"

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -157,24 +157,22 @@ func specLoadingTests() {
         $0.it("parses schemes") {
             let schemeDictionary: [String: Any] = [
                 "build": ["targets": [
-                    ["target": "Target"],
-                    ["target": "Target", "buildTypes": "testing"],
-                    ["target": "Target", "buildTypes": "none"],
-                    ["target": "Target", "buildTypes": "all"],
-                    ["target": "Target", "buildTypes": ["testing": true]],
-                    ["target": "Target", "buildTypes": ["testing": false]],
-                    ["target": "Target", "buildTypes": ["test", "analyze"]],
+                    "Target1": "all",
+                    "Target2": "testing",
+                    "Target3": "none",
+                    "Target4": ["testing": true],
+                    "Target5": ["testing": false],
+                    "Target6": ["test", "analyze"],
                 ]],
             ]
             let scheme = try Scheme(name: "Scheme", jsonDictionary: schemeDictionary)
             let expectedTargets: [Scheme.BuildTarget] = [
-                Scheme.BuildTarget(target: "Target", buildTypes: BuildType.all),
-                Scheme.BuildTarget(target: "Target", buildTypes: [.testing, .analyzing]),
-                Scheme.BuildTarget(target: "Target", buildTypes: []),
-                Scheme.BuildTarget(target: "Target", buildTypes: BuildType.all),
-                Scheme.BuildTarget(target: "Target", buildTypes: [.testing]),
-                Scheme.BuildTarget(target: "Target", buildTypes: []),
-                Scheme.BuildTarget(target: "Target", buildTypes: [.testing, .analyzing]),
+                Scheme.BuildTarget(target: "Target1", buildTypes: BuildType.all),
+                Scheme.BuildTarget(target: "Target2", buildTypes: [.testing, .analyzing]),
+                Scheme.BuildTarget(target: "Target3", buildTypes: []),
+                Scheme.BuildTarget(target: "Target4", buildTypes: [.testing]),
+                Scheme.BuildTarget(target: "Target5", buildTypes: []),
+                Scheme.BuildTarget(target: "Target6", buildTypes: [.testing, .analyzing]),
             ]
             try expect(scheme.name) == "Scheme"
             try expect(scheme.build.targets) == expectedTargets


### PR DESCRIPTION
I've just learned that the order of targets in a Scheme's build settings has no affect, and in fact when you reorder them, nothing gets changed in the project.

Within this in mind, this tweaks the Scheme.build.targets to be a bit simpler and mirrors the changes in #54. The change can be seen in the documentation diffs.

As a dictionary wouldn't be in a stable order for diffs, the targets are sorted by name.

Technically this is a breaking change, which is the reason I didn't document Schemes until now, so the format could be locked down.

Any thoughts?