### PR TITLE
Add TargetSource.buildPhase for overriding build phase

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -216,6 +216,11 @@ A source can be provided via a string (the path) or an object of the form:
 - [ ] **name**: **String** - Can be used to override the name of the source file or directory. By default the last component of the path is used for the name
 - [ ] **compilerFlags**: **[String]** or **String** - A list of compilerFlags to add to files under this specific path provided as a list or a space delimitted string. Defaults to empty.
 - [ ] **excludes**: **[String]** or **String** - A list of global patterns representing the files to exclude.
+- [ ] **buildPhase**: **String** - This manually sets the build phase this file or files in this directory will be added to, otherwise XcodeGen will guess based on the file extension. Note that `Info.plist` files will never be added to any build phases, no matter what this setting is. Possible values are:
+	- `sources` - Compile Sources phase
+	- `resources` - Copy Bundle Resources phase
+	- `headers` - Headers Phase
+	- `none` - Will not be added to any build phases
 - [ ] **type**: **String**: This can be one of the following values
 	- `file`: a file reference with a parent group will be created (Default for files or directories with extensions)
 	- `group`: a group with all it's containing files. (Default for directories without extensions)

--- a/Sources/ProjectSpec/SpecParsingError.swift
+++ b/Sources/ProjectSpec/SpecParsingError.swift
@@ -4,12 +4,14 @@ public enum SpecParsingError: Error, CustomStringConvertible {
     case unknownTargetType(String)
     case unknownTargetPlatform(String)
     case invalidDependency([String: Any])
+    case unknownSourceBuildPhase(String)
 
     public var description: String {
         switch self {
         case let .unknownTargetType(type): return "Unknown Target type: \(type)"
         case let .unknownTargetPlatform(platform): return "Unknown Target platform: \(platform)"
         case let .invalidDependency(dependency): return "Unknown Target dependency: \(dependency)"
+        case let .unknownSourceBuildPhase(buildPhase): return "Unknown Source Build Phase: \(buildPhase)"
         }
     }
 }


### PR DESCRIPTION
This lets you override the build phase for a source file or all the files in a directory.
This is useful if XcodeGen makes the wrong guesses based off the file extension. 

I think we have a pretty stable list of files right now, but this gives us more flexibility. Especially as we are treating all unknown file types as resources by default, which may not be the desired behaviour.
