### PR TITLE
Make the spec directory the default for --project argument 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Given a very simple project spec file like this:
 
 ```yaml
 name: My Project
-options: 
+options:
   bundleIdPrefix: com.myapp
 targets:
   MyApp:
@@ -117,7 +117,7 @@ This will look for a project spec in the current directory called `project.yml`
 Use `xcodegen --help` to see the list of options:
 
 - **--spec**: An optional path to a `.yml` or `.json` project spec.
-- **--project**: An optional path to a directory where the project will be generated. By default this is the current directory.
+- **--project**: An optional path to a directory where the project will be generated. By default this is the directory the spec lives in.
 - **--quiet**: Suppress informational and success messages. By default this is disabled.
 
 ## Editing

--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -22,7 +22,7 @@ func generate(spec: String, project: String, isQuiet: Bool, justVersion: Bool) {
     }
 
     let specPath = Path(spec).absolute()
-    let projectPath = Path(project).normalize()
+    let projectPath = project == "" ? specPath.parent() : Path(project).absolute()
 
     if !specPath.exists {
         fatalError("No project spec found at \(specPath.absolute())")


### PR DESCRIPTION
This makes the default for the `--project` argument default to the directory the spec lives in. This means if you specify a `--path`, in most cases you won't have to specify the `--project` argument.
This is technically a breaking change, though I think there are seperate issues of having a project file generated outside the spec directory anyway