### PR TITLE
Make file reference caching case insensitive

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -13,7 +13,7 @@ struct SourceFile {
 class SourceGenerator {
 
     var rootGroups: Set<String> = []
-    private var fileReferencesByPath: [Path: String] = [:]
+    private var fileReferencesByPath: [String: String] = [:]
     private var groupsByPath: [Path: PBXGroup] = [:]
     private var variantGroupsByPath: [Path: PBXVariantGroup] = [:]
 
@@ -42,7 +42,7 @@ class SourceGenerator {
     }
 
     func generateSourceFile(targetSource: TargetSource, path: Path, buildPhase: BuildPhase? = nil) -> SourceFile {
-        let fileReference = fileReferencesByPath[path]!
+        let fileReference = fileReferencesByPath[path.string.lowercased()]!
         var settings: [String: Any] = [:]
         let chosenBuildPhase: BuildPhase?
 
@@ -95,7 +95,7 @@ class SourceGenerator {
     }
 
     func getFileReference(path: Path, inPath: Path, name: String? = nil, sourceTree: PBXSourceTree = .group) -> String {
-        if let fileReference = fileReferencesByPath[path] {
+        if let fileReference = fileReferencesByPath[path.string.lowercased()] {
             return fileReference
         } else {
             let fileReferencePath = path.byRemovingBase(path: inPath)
@@ -110,7 +110,7 @@ class SourceGenerator {
                 path: fileReferencePath.string
             )
             addObject(fileReference)
-            fileReferencesByPath[path] = fileReference.reference
+            fileReferencesByPath[path.string.lowercased()] = fileReference.reference
             return fileReference.reference
         }
     }


### PR DESCRIPTION
Fixes #210 

This caches the file references already generated case insensitively. That means if the sources are described twice with different casings in the spec, they won't get duplicated.

This would cause issues on case sensitive file systems, but xcode projects aren't read on anything than macOS.
If Xcode for Linux launches, this would have to be revisited 😄 