### PR TITLE
Stop validating missing configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+#### Changed
+- stop validating configurations that do not exist the project
+
 ## 1.5.0
 
 #### Added

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -36,9 +36,6 @@ extension ProjectSpec {
             if !(basePath + configFile).exists {
                 errors.append(.invalidConfigFile(configFile: configFile, config: config))
             }
-            if getConfig(config) == nil {
-                errors.append(.invalidConfigFileConfig(config))
-            }
         }
 
         for settings in settingGroups.values {
@@ -55,9 +52,6 @@ extension ProjectSpec {
             for (config, configFile) in target.configFiles {
                 if !(basePath + configFile).exists {
                     errors.append(.invalidTargetConfigFile(target: target.name, configFile: configFile, config: config))
-                }
-                if getConfig(config) == nil {
-                    errors.append(.invalidConfigFileConfig(config))
                 }
             }
 

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -17,7 +17,6 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidSettingsGroup(String)
         case invalidBuildScriptPath(target: String, name: String?, path: String)
         case invalidFileGroup(String)
-        case invalidConfigFileConfig(String)
         case missingConfigForTargetScheme(target: String, configType: ConfigType)
 
         public var description: String {
@@ -46,8 +45,6 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Target \(target.quoted) has a script \(name != nil ? "\(name!.quoted) which has a " : "")path that doesn't exist \(path.quoted)"
             case let .invalidFileGroup(group):
                 return "Invalid file group \(group.quoted)"
-            case let .invalidConfigFileConfig(config):
-                return "Config file has invalid config \(config.quoted)"
             case let .missingConfigForTargetScheme(target, configType):
                 return "Target \(target.quoted) is missing a config of type \(configType.rawValue) to generate its scheme"
             }

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -1,6 +1,7 @@
 import Spectre
 import XcodeGenKit
 import xcproj
+import PathKit
 import ProjectSpec
 
 func projectSpecTests() {
@@ -92,13 +93,19 @@ func projectSpecTests() {
                     groups: ["invalidSettingGroupSettingGroup"]
                 )]
 
-                try expectValidationError(spec, .invalidConfigFileConfig("invalidConfig"))
                 try expectValidationError(spec, .invalidBuildSettingConfig("invalidConfig"))
                 try expectValidationError(spec, .invalidConfigFile(configFile: "invalidConfigFile", config: "invalidConfig"))
                 try expectValidationError(spec, .invalidSettingsGroup("invalidSettingGroup"))
                 try expectValidationError(spec, .invalidFileGroup("invalidFileGroup"))
                 try expectValidationError(spec, .invalidSettingsGroup("invalidSettingGroupSettingGroup"))
                 try expectValidationError(spec, .invalidBuildSettingConfig("invalidSettingGroupConfig"))
+            }
+
+            $0.it("allows non-existent configurations") {
+                var spec = baseSpec
+                let configPath = fixturePath + "test.xcconfig"
+                spec.configFiles = ["missingConfiguration": configPath.string]
+                try spec.validate()
             }
 
             $0.it("fails with invalid target") {


### PR DESCRIPTION
Previously if you had a XcodeGen definition file that has multiple
project.yml consumers where one project has one set of configurations,
and the other project has different configurations, you could not
generate the project unless the configurations overlapped perfectly.

For example if `project1.yml` has configurations Debug and Release, but
`project2.yml` has configurations Debug, Alpha, and Release, you want
your shared dependency to have xcconfig files for Debug, Alpha, and
Release, even though project1 will not consume the Alpha configuration.

The downside to this change is that typos such as `Deubg` would no
longer trigger a validation error.