### PR TITLE
Add Support for ResourceBundles

### DIFF
--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -30,6 +30,7 @@ public struct Dependency: Equatable {
         case target
         case framework
         case carthage
+        case resourceBundle
     }
 
     public static func == (lhs: Dependency, rhs: Dependency) -> Bool {
@@ -65,6 +66,9 @@ extension Dependency: JSONObjectConvertible {
         } else if let carthage: String = jsonDictionary.json(atKeyPath: "carthage") {
             type = .carthage
             reference = carthage
+        } else if let resourceBundle: String = jsonDictionary.json(atKeyPath: "resourceBundle") {
+            type = .resourceBundle
+            reference = resourceBundle
         } else {
             throw SpecParsingError.invalidDependency(jsonDictionary)
         }

--- a/Sources/ProjectSpec/XCProjExtensions.swift
+++ b/Sources/ProjectSpec/XCProjExtensions.swift
@@ -21,6 +21,10 @@ extension PBXProductType {
     public var isLibrary: Bool {
         return self == .staticLibrary || self == .dynamicLibrary
     }
+    
+    public var isBundle: Bool {
+        return self == .bundle
+    }
 
     public var isExtension: Bool {
         return fileExtension == "appex"

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -347,6 +347,8 @@ public class PBXProjGenerator {
                         copyFrameworksReferences.append(embedFile.reference)
                     } else if dependencyTarget.type.isApp && dependencyTarget.platform == .watchOS {
                         copyWatchReferences.append(embedFile.reference)
+                    } else if dependencyTarget.type.isBundle {
+                        copyResourceBundleReferences.append(embedFile.reference)
                     } else {
                         copyResourcesReferences.append(embedFile.reference)
                     }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -141,6 +141,17 @@ public class PBXProjGenerator {
             addObject(group)
             topLevelGroups.insert(group.reference)
         }
+        
+        if !resourceBundleFiles.isEmpty {
+            let group = PBXGroup(
+                reference: referenceGenerator.generate(PBXGroup.self, "Resources"),
+                children: resourceBundleFiles,
+                sourceTree: .group,
+                name: "Resources"
+            )
+            addObject(group)
+            topLevelGroups.insert(group.reference)
+        }
 
         for rootGroup in sourceGenerator.rootGroups {
             topLevelGroups.insert(rootGroup)

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -552,7 +552,7 @@ public class PBXProjGenerator {
                 reference: referenceGenerator.generate(PBXCopyFilesBuildPhase.self, "embed resource bundles" + target.name),
                 dstPath: "",
                 dstSubfolderSpec: .resources,
-                files: copyFrameworksReferences
+                files: copyResourceBundleReferences
             )
             
             addObject(copyFilesPhase)

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -19,6 +19,7 @@ public class PBXProjGenerator {
     var topLevelGroups: Set<String> = []
     var carthageFrameworksByPlatform: [String: Set<String>] = [:]
     var frameworkFiles: [String] = []
+    var resourceBundleFiles: [String] = []
 
     var generated = false
 
@@ -353,18 +354,18 @@ public class PBXProjGenerator {
                         inPath: spec.basePath
                     )
                 }
-
+                
                 let buildFile = PBXBuildFile(
                     reference: referenceGenerator.generate(PBXBuildFile.self, fileReference + target.name),
                     fileRef: fileReference
                 )
                 addObject(buildFile)
-
+                
                 targetFrameworkBuildFiles.append(buildFile.reference)
                 if !frameworkFiles.contains(fileReference) {
                     frameworkFiles.append(fileReference)
                 }
-
+                
                 if embed {
                     let embedFile = PBXBuildFile(
                         reference: referenceGenerator.generate(PBXBuildFile.self, fileReference + target.name),
@@ -373,6 +374,35 @@ public class PBXProjGenerator {
                     )
                     addObject(embedFile)
                     copyFrameworksReferences.append(embedFile.reference)
+                }
+                
+            case .resourceBundle:
+                let fileReference: String
+                if dependency.implicit {
+                    fileReference = sourceGenerator.getFileReference(
+                        path: Path(dependency.reference),
+                        inPath: spec.basePath,
+                        sourceTree: .buildProductsDir
+                    )
+                } else {
+                    fileReference = sourceGenerator.getFileReference(
+                        path: Path(dependency.reference),
+                        inPath: spec.basePath
+                    )
+                }
+                
+                if !resourceBundleFiles.contains(fileReference) {
+                    resourceBundleFiles.append(fileReference)
+                }
+                
+                if embed {
+                    let embedFile = PBXBuildFile(
+                        reference: referenceGenerator.generate(PBXBuildFile.self, fileReference + target.name),
+                        fileRef: fileReference,
+                        settings: dependency.buildSettings
+                    )
+                    addObject(embedFile)
+                    copyResourcesReferences.append(embedFile.reference)
                 }
             case .carthage:
                 var platformPath = Path(getCarthageBuildPath(platform: target.platform))

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -539,6 +539,7 @@ public class PBXProjGenerator {
                 reference: referenceGenerator.generate(PBXCopyFilesBuildPhase.self, "embed frameworks" + target.name),
                 dstPath: "",
                 dstSubfolderSpec: .frameworks,
+                name: "Embed Frameworks",
                 files: copyFrameworksReferences
             )
             
@@ -552,6 +553,7 @@ public class PBXProjGenerator {
                 reference: referenceGenerator.generate(PBXCopyFilesBuildPhase.self, "embed resource bundles" + target.name),
                 dstPath: "",
                 dstSubfolderSpec: .resources,
+                name: "Embed Resource Bundles",
                 files: copyResourceBundleReferences
             )
             

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -289,6 +289,7 @@ public class PBXProjGenerator {
         var dependencies: [String] = []
         var targetFrameworkBuildFiles: [String] = []
         var copyFrameworksReferences: [String] = []
+        var copyResourceBundleReferences: [String] = []
         var copyResourcesReferences: [String] = []
         var copyWatchReferences: [String] = []
         var extensions: [String] = []
@@ -413,7 +414,7 @@ public class PBXProjGenerator {
                         settings: dependency.buildSettings
                     )
                     addObject(embedFile)
-                    copyResourcesReferences.append(embedFile.reference)
+                    copyResourceBundleReferences.append(embedFile.reference)
                 }
             case .carthage:
                 var platformPath = Path(getCarthageBuildPath(platform: target.platform))
@@ -533,17 +534,32 @@ public class PBXProjGenerator {
         }
 
         if !copyFrameworksReferences.isEmpty {
-
+            
             let copyFilesPhase = PBXCopyFilesBuildPhase(
                 reference: referenceGenerator.generate(PBXCopyFilesBuildPhase.self, "embed frameworks" + target.name),
                 dstPath: "",
                 dstSubfolderSpec: .frameworks,
                 files: copyFrameworksReferences
             )
-
+            
             addObject(copyFilesPhase)
             buildPhases.append(copyFilesPhase.reference)
         }
+        
+        if !copyResourceBundleReferences.isEmpty {
+            
+            let copyFilesPhase = PBXCopyFilesBuildPhase(
+                reference: referenceGenerator.generate(PBXCopyFilesBuildPhase.self, "embed resource bundles" + target.name),
+                dstPath: "",
+                dstSubfolderSpec: .resources,
+                files: copyFrameworksReferences
+            )
+            
+            addObject(copyFilesPhase)
+            buildPhases.append(copyFilesPhase.reference)
+        }
+        
+        
 
         if !copyWatchReferences.isEmpty {
 

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 		BF_860391087135 /* StandaloneAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_408537768279 /* StandaloneAssets.xcassets */; };
 		BF_892119987440 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_854336462818 /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		BF_901390118565 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_172952167809 /* FrameworkFile.swift */; };
-		BF_905038616071 /* Framework_iOS.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_472296042419 /* Framework_iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BF_905038616071 /* Framework_iOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_472296042419 /* Framework_iOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -71,14 +71,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		CFBP_6493932244 /* CopyFiles */ = {
+		CFBP_6493932244 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_905038616071 /* Framework_iOS.framework in CopyFiles */,
+				BF_905038616071 /* Framework_iOS.framework in Embed Frameworks */,
 			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -491,7 +492,7 @@
 				SBP_82523211050 /* Sources */,
 				RBP_82523211050 /* Resources */,
 				FBP_82523211050 /* Frameworks */,
-				CFBP_6493932244 /* CopyFiles */,
+				CFBP_6493932244 /* Embed Frameworks */,
 				SSBP_8106229290 /* Carthage */,
 				SSBP_5106020372 /* Strip Unused Architectures from Frameworks */,
 				SSBP_8706434794 /* MyScript */,

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -25,7 +25,10 @@ func projectGeneratorTests() {
             type: .application,
             platform: .iOS,
             settings: Settings(buildSettings: ["SETTING_1": "VALUE"]),
-            dependencies: [Dependency(type: .target, reference: "MyFramework")]
+            dependencies: [
+                Dependency(type: .target, reference: "MyFramework"),
+                Dependency(type: .resourceBundle, reference: "MyResourceBundle", embed: true)
+            ]
         )
 
         let framework = Target(
@@ -35,7 +38,14 @@ func projectGeneratorTests() {
             settings: Settings(buildSettings: ["SETTING_2": "VALUE"])
         )
 
-        let targets = [application, framework]
+        let resourceBundle = Target(
+            name: "MyResourceBundle",
+            type: .framework,
+            platform: .iOS,
+            settings: .empty
+        )
+
+        let targets = [application, framework, resourceBundle]
 
         $0.describe("Options") {
 
@@ -179,9 +189,10 @@ func projectGeneratorTests() {
             $0.it("generates targets") {
                 let pbxProject = try getPbxProj(spec)
                 let nativeTargets = pbxProject.objects.nativeTargets.referenceValues
-                try expect(nativeTargets.count) == 2
+                try expect(nativeTargets.count) == 3
                 try expect(nativeTargets.contains { $0.name == application.name }).beTrue()
                 try expect(nativeTargets.contains { $0.name == framework.name }).beTrue()
+                try expect(nativeTargets.contains { $0.name == resourceBundle.name }).beTrue()
             }
 
             $0.it("generates platform version") {
@@ -219,6 +230,16 @@ func projectGeneratorTests() {
                 let dependencies = pbxProject.objects.targetDependencies.referenceValues
                 try expect(dependencies.count) == 1
                 try expect(dependencies.first!.target) == nativeTargets.first { $0.name == framework.name }!.reference
+            }
+            
+            
+            $0.it("generates embeds resource bundle") {
+                let pbxProject = try getPbxProj(spec)
+                
+                let scripts = pbxProject.objects.copyFilesBuildPhases.referenceValues
+                    .filter { $0.dstSubfolderSpec == .resources }
+                
+                try expect(scripts.count) == 1
             }
 
             $0.it("generates run scripts") {

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -27,7 +27,7 @@ func projectGeneratorTests() {
             settings: Settings(buildSettings: ["SETTING_1": "VALUE"]),
             dependencies: [
                 Dependency(type: .target, reference: "MyFramework"),
-                Dependency(type: .resourceBundle, reference: "MyResourceBundle", embed: true)
+                Dependency(type: .target, reference: "MyResourceBundle", embed: true)
             ]
         )
 
@@ -40,7 +40,7 @@ func projectGeneratorTests() {
 
         let resourceBundle = Target(
             name: "MyResourceBundle",
-            type: .framework,
+            type: .bundle,
             platform: .iOS,
             settings: .empty
         )
@@ -228,7 +228,7 @@ func projectGeneratorTests() {
                 let pbxProject = try getPbxProj(spec)
                 let nativeTargets = pbxProject.objects.nativeTargets.referenceValues
                 let dependencies = pbxProject.objects.targetDependencies.referenceValues
-                try expect(dependencies.count) == 1
+                try expect(dependencies.count) == 2
                 try expect(dependencies.first!.target) == nativeTargets.first { $0.name == framework.name }!.reference
             }
             
@@ -299,7 +299,7 @@ func projectGeneratorTests() {
                 let spec = ProjectSpec(
                     basePath: "",
                     name: "test",
-                    targets: [application, framework],
+                    targets: [application, framework, resourceBundle],
                     schemes: [scheme]
                 )
                 let project = try getProject(spec)
@@ -347,7 +347,7 @@ func projectGeneratorTests() {
                     Config(name: "Production Release", type: .release),
                 ]
 
-                let spec = ProjectSpec(basePath: "", name: "test", configs: configs, targets: [target, framework])
+                let spec = ProjectSpec(basePath: "", name: "test", configs: configs, targets: [target, framework, resourceBundle])
                 let project = try getProject(spec)
 
                 try expect(project.sharedData?.schemes.count) == 2

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -125,12 +125,14 @@ func specLoadingTests() {
                 ["target": "name", "embed": false],
                 ["carthage": "name"],
                 ["framework": "path"],
+                ["resourceBundle": "path", "embed": true],
             ]
             let target = try Target(name: "test", jsonDictionary: targetDictionary)
-            try expect(target.dependencies.count) == 3
+            try expect(target.dependencies.count) == 4
             try expect(target.dependencies[0]) == Dependency(type: .target, reference: "name", embed: false)
             try expect(target.dependencies[1]) == Dependency(type: .carthage, reference: "name")
             try expect(target.dependencies[2]) == Dependency(type: .framework, reference: "path")
+            try expect(target.dependencies[3]) == Dependency(type: .resourceBundle, reference: "path", embed: true)
         }
 
         $0.it("parses cross platform targets") {


### PR DESCRIPTION
Swift now allows static-libraries which have one drawback when compared to Frameworks.
They cannot inlcude Resources (Images, xibs, storyboards, ...).
To workaround this issue its possible to use resource-bundles.

This PR adds another type of Dependency: __ResourceBundles__

They can be included in two ways:

Embed ResourceBundle Target (When in same xcodeproj)
`Dependency(type: .target, reference: "MyResourceBundle")`

or add from another project embedded in the same xcworkspace
`Dependency(type: .resourceBundle, reference: "MyResourceBundle.bundle", implicit: true)`

