### PR TITLE
Fix handling of scheme target build type

### DIFF
--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -212,7 +212,7 @@ extension Scheme.Build: JSONObjectConvertible {
                 case "none": buildTypes = []
                 case "testing": buildTypes = [.testing, .analyzing]
                 case "indexing": buildTypes = [.testing, .analyzing, .archiving]
-                default: buildTypes = BuildType.all
+                default: buildTypes = BuildType.from(jsonValue: string).map { [$0] } ?? BuildType.all
                 }
             } else if let enabledDictionary = possibleBuildTypes as? [String: Bool] {
                 buildTypes = enabledDictionary.filter { $0.value }.flatMap { BuildType.from(jsonValue: $0.key) }


### PR DESCRIPTION
While looking into #229, I noticed what looks to be a bug in build type handling for the `String` case.

An example project could look like:

```yaml
schemes:
  Foo:
    build:
      targets:
        SomeTarget: test
```

But the `test` value would be ignored, instead it would the build types would be set to `.all`.