### PR TITLE
Make scheme `config` optional, relying on defaults

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -427,7 +427,7 @@ targets:
 ### Common Build Action options
 The different actions share some properties:
 
-- [ ] **config**: **String** - All build actions can be set to use a certain config. If this is not set the first configuration found of a certain type will be used, depending on the type:
+- [x] **config**: **String** - All build actions can be set to use a certain config. If this is not set the first configuration found of a certain type will be used, depending on the type:
 	- `debug`: run, test, analyze
 	- `release`: profile, archive
 - [ ] **commandLineArguments**: **[String:Bool]** - `run`, `test` and `profile` actions have a map of command line arguments to whether they are enabled

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -427,7 +427,7 @@ targets:
 ### Common Build Action options
 The different actions share some properties:
 
-- [x] **config**: **String** - All build actions can be set to use a certain config. If this is not set the first configuration found of a certain type will be used, depending on the type:
+- [ ] **config**: **String** - All build actions can be set to use a certain config. If a config, or the build action itself, is not defined the first configuration found of a certain type will be used, depending on the type:
 	- `debug`: run, test, analyze
 	- `release`: profile, archive
 - [ ] **commandLineArguments**: **[String:Bool]** - `run`, `test` and `profile` actions have a map of command line arguments to whether they are enabled

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -71,7 +71,7 @@ public struct Scheme: Equatable {
     }
 
     public struct Run: BuildAction {
-        public var config: String
+        public var config: String?
         public var commandLineArguments: [String: Bool]
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
@@ -96,7 +96,7 @@ public struct Scheme: Equatable {
     }
 
     public struct Test: BuildAction {
-        public var config: String
+        public var config: String?
         public var gatherCoverageData: Bool
         public var commandLineArguments: [String: Bool]
         public var targets: [String]
@@ -129,7 +129,7 @@ public struct Scheme: Equatable {
     }
 
     public struct Analyze: BuildAction {
-        public var config: String
+        public var config: String?
         public init(config: String) {
             self.config = config
         }
@@ -140,7 +140,7 @@ public struct Scheme: Equatable {
     }
 
     public struct Profile: BuildAction {
-        public var config: String
+        public var config: String?
         public var commandLineArguments: [String: Bool]
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
@@ -165,7 +165,7 @@ public struct Scheme: Equatable {
     }
 
     public struct Archive: BuildAction {
-        public var config: String
+        public var config: String?
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
         public init(
@@ -210,7 +210,7 @@ public struct Scheme: Equatable {
 }
 
 protocol BuildAction: Equatable {
-    var config: String { get }
+    var config: String? { get }
 }
 
 extension Scheme.ExecutionAction: JSONObjectConvertible {
@@ -225,7 +225,7 @@ extension Scheme.ExecutionAction: JSONObjectConvertible {
 extension Scheme.Run: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
-        config = try jsonDictionary.json(atKeyPath: "config")
+        config = jsonDictionary.json(atKeyPath: "config")
         commandLineArguments = jsonDictionary.json(atKeyPath: "commandLineArguments") ?? [:]
         preActions = try jsonDictionary.json(atKeyPath: "preActions")?.map(Scheme.ExecutionAction.init) ?? []
         postActions = try jsonDictionary.json(atKeyPath: "postActions")?.map(Scheme.ExecutionAction.init) ?? []
@@ -235,7 +235,7 @@ extension Scheme.Run: JSONObjectConvertible {
 extension Scheme.Test: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
-        config = try jsonDictionary.json(atKeyPath: "config")
+        config = jsonDictionary.json(atKeyPath: "config")
         gatherCoverageData = jsonDictionary.json(atKeyPath: "gatherCoverageData") ?? false
         commandLineArguments = jsonDictionary.json(atKeyPath: "commandLineArguments") ?? [:]
         targets = jsonDictionary.json(atKeyPath: "targets") ?? []
@@ -247,7 +247,7 @@ extension Scheme.Test: JSONObjectConvertible {
 extension Scheme.Profile: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
-        config = try jsonDictionary.json(atKeyPath: "config")
+        config = jsonDictionary.json(atKeyPath: "config")
         commandLineArguments = jsonDictionary.json(atKeyPath: "commandLineArguments") ?? [:]
         preActions = try jsonDictionary.json(atKeyPath: "preActions")?.map(Scheme.ExecutionAction.init) ?? []
         postActions = try jsonDictionary.json(atKeyPath: "postActions")?.map(Scheme.ExecutionAction.init) ?? []
@@ -257,14 +257,14 @@ extension Scheme.Profile: JSONObjectConvertible {
 extension Scheme.Analyze: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
-        config = try jsonDictionary.json(atKeyPath: "config")
+        config = jsonDictionary.json(atKeyPath: "config")
     }
 }
 
 extension Scheme.Archive: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
-        config = try jsonDictionary.json(atKeyPath: "config")
+        config = jsonDictionary.json(atKeyPath: "config")
         preActions = try jsonDictionary.json(atKeyPath: "preActions")?.map(Scheme.ExecutionAction.init) ?? []
         postActions = try jsonDictionary.json(atKeyPath: "postActions")?.map(Scheme.ExecutionAction.init) ?? []
     }

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -128,20 +128,20 @@ extension ProjectSpec {
                     errors.append(.invalidSchemeTarget(scheme: scheme.name, target: buildTarget.target))
                 }
             }
-            if let buildAction = scheme.run, getConfig(buildAction.config) == nil {
-                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: buildAction.config))
+            if let action = scheme.run, let config = action.config, getConfig(config) == nil {
+                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: config))
             }
-            if let buildAction = scheme.test, getConfig(buildAction.config) == nil {
-                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: buildAction.config))
+            if let action = scheme.test, let config = action.config, getConfig(config) == nil {
+                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: config))
             }
-            if let buildAction = scheme.profile, getConfig(buildAction.config) == nil {
-                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: buildAction.config))
+            if let action = scheme.profile, let config = action.config, getConfig(config) == nil {
+                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: config))
             }
-            if let buildAction = scheme.analyze, getConfig(buildAction.config) == nil {
-                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: buildAction.config))
+            if let action = scheme.analyze, let config = action.config, getConfig(config) == nil {
+                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: config))
             }
-            if let buildAction = scheme.archive, getConfig(buildAction.config) == nil {
-                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: buildAction.config))
+            if let action = scheme.archive, let config = action.config, getConfig(config) == nil {
+                errors.append(.invalidSchemeConfig(scheme: scheme.name, config: config))
             }
         }
 


### PR DESCRIPTION
Change the `config` field in scheme actions to optional. When not specified, a default will be used. This updates the spec to reflect this change.