### PR TITLE
Add parallelizeBuildables and buildImplicitDependencies flags to the …

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -418,10 +418,19 @@ Schemes allows for more control than the convenience [Target Scheme](#target-sch
 	- `analyze` or `analyzing`
 	- `archive` or `archiving`
 
+- [ ] **parallelizeBuild**: **Bool** - Whether or not your targets should be built in parallel.
+  - `true`: Build targets in parallel
+  - `false`: Build targets serially
+- [ ] **buildImplicitDependencies**: **Bool** - Flag to determine if Xcode should be implicit dependencies of this scheme. 
+  - `true`: Discover implicit dependencies of this scheme
+  - `false`: Only build explicit dependencies of this scheme
+
 ```yaml
 targets:
   myTarget: all
   myTarget2: [test, run]
+parallelizeBuild: true
+buildImplicitDependencies: true
 ```
 
 ### Common Build Action options

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -418,10 +418,11 @@ Schemes allows for more control than the convenience [Target Scheme](#target-sch
 	- `analyze` or `analyzing`
 	- `archive` or `archiving`
 
-- [ ] **parallelizeBuild**: **Bool** - Whether or not your targets should be built in parallel.
+- [ ] **parallelizeBuild**: **Bool** - Whether or not your targets should be built in parallel. By default this is `true` if not set.
   - `true`: Build targets in parallel
   - `false`: Build targets serially
-- [ ] **buildImplicitDependencies**: **Bool** - Flag to determine if Xcode should be implicit dependencies of this scheme. 
+- [ ] **buildImplicitDependencies**: **Bool** - Flag to determine if Xcode should be implicit dependencies of this scheme. By default this is `true` if not set.
+
   - `true`: Discover implicit dependencies of this scheme
   - `false`: Only build explicit dependencies of this scheme
 

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -51,19 +51,19 @@ public struct Scheme: Equatable {
 
     public struct Build: Equatable {
         public var targets: [BuildTarget]
-        public var parallelizeBuildables: Bool
+        public var parallelizeBuild: Bool
         public var buildImplicitDependencies: Bool
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
         public init(
             targets: [BuildTarget],
-            parallelizeBuildables: Bool = true,
+            parallelizeBuild: Bool = true,
             buildImplicitDependencies: Bool = true,
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = []
         ) {
             self.targets = targets
-            self.parallelizeBuildables = parallelizeBuildables
+            self.parallelizeBuild = parallelizeBuild
             self.buildImplicitDependencies = buildImplicitDependencies
             self.preActions = preActions
             self.postActions = postActions
@@ -316,7 +316,7 @@ extension Scheme.Build: JSONObjectConvertible {
         self.targets = targets.sorted { $0.target < $1.target }
         preActions = try jsonDictionary.json(atKeyPath: "preActions")?.map(Scheme.ExecutionAction.init) ?? []
         postActions = try jsonDictionary.json(atKeyPath: "postActions")?.map(Scheme.ExecutionAction.init) ?? []
-        parallelizeBuildables = jsonDictionary.json(atKeyPath: "parallelizeBuildables") ?? true
+        parallelizeBuild = jsonDictionary.json(atKeyPath: "parallelizeBuild") ?? true
         buildImplicitDependencies = jsonDictionary.json(atKeyPath: "buildImplicitDependencies") ?? true
     }
 }

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -51,14 +51,20 @@ public struct Scheme: Equatable {
 
     public struct Build: Equatable {
         public var targets: [BuildTarget]
+        public var parallelizeBuildables: Bool
+        public var buildImplicitDependencies: Bool
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
         public init(
             targets: [BuildTarget],
+            parallelizeBuildables: Bool = true,
+            buildImplicitDependencies: Bool = true,
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = []
         ) {
             self.targets = targets
+            self.parallelizeBuildables = parallelizeBuildables
+            self.buildImplicitDependencies = buildImplicitDependencies
             self.preActions = preActions
             self.postActions = postActions
         }
@@ -310,6 +316,8 @@ extension Scheme.Build: JSONObjectConvertible {
         self.targets = targets.sorted { $0.target < $1.target }
         preActions = try jsonDictionary.json(atKeyPath: "preActions")?.map(Scheme.ExecutionAction.init) ?? []
         postActions = try jsonDictionary.json(atKeyPath: "postActions")?.map(Scheme.ExecutionAction.init) ?? []
+        parallelizeBuildables = jsonDictionary.json(atKeyPath: "parallelizeBuildables") ?? true
+        buildImplicitDependencies = jsonDictionary.json(atKeyPath: "buildImplicitDependencies") ?? true
     }
 }
 

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -78,7 +78,7 @@ public class ProjectGenerator {
             buildActionEntries: buildActionEntries,
             preActions: scheme.build.preActions.map(getExecutionAction),
             postActions: scheme.build.postActions.map(getExecutionAction),
-            parallelizeBuild: scheme.build.parallelizeBuildables,
+            parallelizeBuild: scheme.build.parallelizeBuild,
             buildImplicitDependencies: scheme.build.buildImplicitDependencies
         )
 

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -31,7 +31,7 @@ public class ProjectGenerator {
     }
 
     func generateWorkspace() throws -> XCWorkspace {
-        let dataElement: XCWorkspaceDataElement = .file(XCWorkspaceDataFileRef(location: .`self`("")))
+        let dataElement: XCWorkspaceDataElement = .file(XCWorkspaceDataFileRef(location: .self("")))
         let workspaceData = XCWorkspaceData(children: [dataElement])
         return XCWorkspace(data: workspaceData)
     }
@@ -78,8 +78,8 @@ public class ProjectGenerator {
             buildActionEntries: buildActionEntries,
             preActions: scheme.build.preActions.map(getExecutionAction),
             postActions: scheme.build.postActions.map(getExecutionAction),
-            parallelizeBuild: true,
-            buildImplicitDependencies: true
+            parallelizeBuild: scheme.build.parallelizeBuildables,
+            buildImplicitDependencies: scheme.build.buildImplicitDependencies
         )
 
         let testables = testBuildTargetEntries.map {

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <PreActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/Tests/Fixtures/TestProject/spec.yml
+++ b/Tests/Fixtures/TestProject/spec.yml
@@ -101,6 +101,8 @@ targets:
 schemes:
   Framework:
     build:
+      parallelizeBuild: false 
+      buildImplicitDependencies: false
       targets:
         Framework_iOS: all
       preActions:

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -321,6 +321,8 @@ func projectGeneratorTests() {
                     throw failure("Scheme not found")
                 }
                 try expect(scheme.name) == "MyScheme"
+                try expect(xcscheme.buildAction?.buildImplicitDependencies) == true
+                try expect(xcscheme.buildAction?.parallelizeBuild) == true
                 try expect(xcscheme.buildAction?.preActions.first?.title) == "Script"
                 try expect(xcscheme.buildAction?.preActions.first?.scriptText) == "echo Starting"
                 try expect(xcscheme.buildAction?.preActions.first?.environmentBuildable?.buildableName) == "MyApp.app"

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -156,20 +156,25 @@ func specLoadingTests() {
 
         $0.it("parses schemes") {
             let schemeDictionary: [String: Any] = [
-                "build": ["targets": [
-                    "Target1": "all",
-                    "Target2": "testing",
-                    "Target3": "none",
-                    "Target4": ["testing": true],
-                    "Target5": ["testing": false],
-                    "Target6": ["test", "analyze"],
-                ], "preActions": [
-                    [
-                        "script": "echo Before Build",
-                        "name": "Before Build",
-                        "settingsTarget": "Target1",
+                "build": [
+                    "parallelizeBuildables": false,
+                    "buildImplicitDependencies": false,
+                    "targets": [
+                        "Target1": "all",
+                        "Target2": "testing",
+                        "Target3": "none",
+                        "Target4": ["testing": true],
+                        "Target5": ["testing": false],
+                        "Target6": ["test", "analyze"],
                     ],
-                ]],
+                    "preActions": [
+                        [
+                            "script": "echo Before Build",
+                            "name": "Before Build",
+                            "settingsTarget": "Target1",
+                        ],
+                    ]
+                ],
             ]
             let scheme = try Scheme(name: "Scheme", jsonDictionary: schemeDictionary)
             let expectedTargets: [Scheme.BuildTarget] = [
@@ -185,6 +190,9 @@ func specLoadingTests() {
             try expect(scheme.build.preActions.first?.script) == "echo Before Build"
             try expect(scheme.build.preActions.first?.name) == "Before Build"
             try expect(scheme.build.preActions.first?.settingsTarget) == "Target1"
+
+            try expect(scheme.build.parallelizeBuildables) == false
+            try expect(scheme.build.buildImplicitDependencies) == false
         }
 
         $0.it("parses settings") {

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -157,7 +157,7 @@ func specLoadingTests() {
         $0.it("parses schemes") {
             let schemeDictionary: [String: Any] = [
                 "build": [
-                    "parallelizeBuildables": false,
+                    "parallelizeBuild": false,
                     "buildImplicitDependencies": false,
                     "targets": [
                         "Target1": "all",
@@ -191,7 +191,7 @@ func specLoadingTests() {
             try expect(scheme.build.preActions.first?.name) == "Before Build"
             try expect(scheme.build.preActions.first?.settingsTarget) == "Target1"
 
-            try expect(scheme.build.parallelizeBuildables) == false
+            try expect(scheme.build.parallelizeBuild) == false
             try expect(scheme.build.buildImplicitDependencies) == false
         }
 


### PR DESCRIPTION
…build

scheme settings

We have a few scenarios where we'd like to control if these are enabled or disabled. I've set the default values to "true" for both properties to ensure we don't change existing behavior.