### PR TITLE
Fix shouldUseLaunchSchemeArgsEnv disabling logic

### DIFF
--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -140,6 +140,10 @@ public struct Scheme: Equatable {
                 lhs.postActions == rhs.postActions &&
                 lhs.environmentVariables == rhs.environmentVariables
         }
+
+        public var shouldUseLaunchSchemeArgsEnv: Bool {
+            return commandLineArguments.isEmpty && environmentVariables.isEmpty
+        }
     }
 
     public struct Analyze: BuildAction {
@@ -179,6 +183,10 @@ public struct Scheme: Equatable {
                 lhs.preActions == rhs.postActions &&
                 lhs.postActions == rhs.postActions &&
                 lhs.environmentVariables == rhs.environmentVariables
+        }
+
+        public var shouldUseLaunchSchemeArgsEnv: Bool {
+            return commandLineArguments.isEmpty && environmentVariables.isEmpty
         }
     }
 

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -100,7 +100,7 @@ public class ProjectGenerator {
             testables: testables,
             preActions: scheme.test?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.test?.postActions.map(getExecutionAction) ?? [],
-            shouldUseLaunchSchemeArgsEnv: testCommandLineArgs == nil && testVariables == nil,
+            shouldUseLaunchSchemeArgsEnv: scheme.test?.shouldUseLaunchSchemeArgsEnv ?? true,
             codeCoverageEnabled: scheme.test?.gatherCoverageData ?? false,
             commandlineArguments: testCommandLineArgs,
             environmentVariables: testVariables,
@@ -121,7 +121,7 @@ public class ProjectGenerator {
             buildConfiguration: scheme.profile?.config ?? defaultReleaseConfig.name,
             preActions: scheme.profile?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.profile?.postActions.map(getExecutionAction) ?? [],
-            shouldUseLaunchSchemeArgsEnv: profileCommandLineArgs == nil && profileVariables == nil,
+            shouldUseLaunchSchemeArgsEnv: scheme.profile?.shouldUseLaunchSchemeArgsEnv ?? true,
             commandlineArguments: profileCommandLineArgs,
             environmentVariables: profileVariables
         )

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -94,13 +94,14 @@ public class ProjectGenerator {
         let launchVariables = scheme.run.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
         let profileVariables = scheme.profile.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
 
+
         let testAction = XCScheme.TestAction(
             buildConfiguration: scheme.test?.config ?? defaultDebugConfig.name,
             macroExpansion: buildableReference,
             testables: testables,
             preActions: scheme.test?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.test?.postActions.map(getExecutionAction) ?? [],
-            shouldUseLaunchSchemeArgsEnv: scheme.test?.commandLineArguments.isEmpty ?? true,
+            shouldUseLaunchSchemeArgsEnv: testCommandLineArgs == nil && testVariables == nil,
             codeCoverageEnabled: scheme.test?.gatherCoverageData ?? false,
             commandlineArguments: testCommandLineArgs,
             environmentVariables: testVariables,
@@ -121,7 +122,7 @@ public class ProjectGenerator {
             buildConfiguration: scheme.profile?.config ?? defaultReleaseConfig.name,
             preActions: scheme.profile?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.profile?.postActions.map(getExecutionAction) ?? [],
-            shouldUseLaunchSchemeArgsEnv: scheme.profile?.commandLineArguments.isEmpty ?? true,
+            shouldUseLaunchSchemeArgsEnv: profileCommandLineArgs == nil && profileVariables == nil,
             commandlineArguments: profileCommandLineArgs,
             environmentVariables: profileVariables
         )

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -94,7 +94,6 @@ public class ProjectGenerator {
         let launchVariables = scheme.run.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
         let profileVariables = scheme.profile.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
 
-
         let testAction = XCScheme.TestAction(
             buildConfiguration: scheme.test?.config ?? defaultDebugConfig.name,
             macroExpansion: buildableReference,


### PR DESCRIPTION
Adding `environmentVariables` was not disabling the `shouldUseLaunchSchemeArgsEnv` flag.
Therefore the process could not read the variables.