### PR TITLE
Only parse true and false as bools

### DIFF
--- a/Tests/Fixtures/yaml.yml
+++ b/Tests/Fixtures/yaml.yml
@@ -1,0 +1,19 @@
+true: true
+false: false
+yes: YES
+no: NO
+yesQuote: "YES"
+noQuote: "NO"
+int: 1
+intQuote: "1"
+float: 3.2
+string: hello
+stringQuote: "hello"
+space: " "
+empty:
+emptyQuote: ""
+emptyDictionary: {}
+arrayLiteral: [1,2]
+arrayList:
+  - 1
+  - 2

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -3,6 +3,7 @@ import ProjectSpec
 import Spectre
 import XcodeGenKit
 import xcproj
+import Foundation
 
 func specLoadingTests() {
 
@@ -45,6 +46,34 @@ func specLoadingTests() {
                 Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"]),
                 Target(name: "NewTarget", type: .application, platform: .iOS),
             ]
+        }
+
+        $0.it("parses yaml types") {
+            let path = fixturePath + "yaml.yml"
+            let dictionary = try loadYamlDictionary(path: path)
+            let expectedDictionary: [String: Any] = [
+                "true": true,
+                "false": false,
+                "yes": "YES",
+                "no": "NO",
+                "yesQuote": "YES",
+                "noQuote": "NO",
+                "int": 1,
+                "intQuote": 1,
+                "float": 3.2,
+                "string": "hello",
+                "stringQuote": "hello",
+                "space": " ",
+                "empty": "",
+                "emptyQuote": "",
+                "emptyDictionary": [String: Any](),
+                "arrayLiteral": [1,2],
+                "arrayList": [1,2],
+            ]
+
+            if !(dictionary as NSDictionary).isEqual(expectedDictionary) {
+                throw failure("parsed yaml types don't match")
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #253 

This uses the new customizable `Resolver` in Yams, to disable inferring strings like `YES` to bools from yaml files.

```diff
- ^(?:yes|Yes|YES|no|No|NO\|true|True|TRUE|false|False|FALSE\|on|On|ON|off|Off|OFF)$
+ ^(?:true|false)$
```

This is technically a breaking change if someone was using these strings to define bools. I can't see any other way to fix #253 though.
Thoughts?