### PR TITLE
Rename ProjectSpec -> ProjectSpec.Project

### DIFF
--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -4,7 +4,7 @@ import PathKit
 import xcproj
 import Yams
 
-public struct ProjectSpec {
+public struct Project {
 
     public var basePath: Path
     public var name: String
@@ -85,7 +85,7 @@ public struct ProjectSpec {
             self.defaultConfig = defaultConfig
         }
 
-        public static func == (lhs: ProjectSpec.Options, rhs: ProjectSpec.Options) -> Bool {
+        public static func == (lhs: Project.Options, rhs: Project.Options) -> Bool {
             return lhs.carthageBuildPath == rhs.carthageBuildPath &&
                 lhs.carthageExecutablePath == rhs.carthageExecutablePath &&
                 lhs.bundleIdPrefix == rhs.bundleIdPrefix &&
@@ -136,7 +136,7 @@ public struct ProjectSpec {
     }
 }
 
-extension ProjectSpec: CustomDebugStringConvertible {
+extension Project: CustomDebugStringConvertible {
 
     public var debugDescription: String {
         var string = "Name: \(name)"
@@ -160,9 +160,9 @@ extension ProjectSpec: CustomDebugStringConvertible {
     }
 }
 
-extension ProjectSpec: Equatable {
+extension Project: Equatable {
 
-    public static func == (lhs: ProjectSpec, rhs: ProjectSpec) -> Bool {
+    public static func == (lhs: Project, rhs: Project) -> Bool {
         return lhs.name == rhs.name &&
             lhs.targets == rhs.targets &&
             lhs.settings == rhs.settings &&
@@ -176,11 +176,11 @@ extension ProjectSpec: Equatable {
     }
 }
 
-extension ProjectSpec {
+extension Project {
 
     public init(basePath: Path, jsonDictionary: JSONDictionary) throws {
         self.basePath = basePath
-        let jsonDictionary = try ProjectSpec.filterJSON(jsonDictionary: jsonDictionary)
+        let jsonDictionary = try Project.filterJSON(jsonDictionary: jsonDictionary)
         name = try jsonDictionary.json(atKeyPath: "name")
         settings = jsonDictionary.json(atKeyPath: "settings") ?? .empty
         settingGroups = jsonDictionary.json(atKeyPath: "settingGroups")
@@ -206,7 +206,7 @@ extension ProjectSpec {
     }
 }
 
-extension ProjectSpec.Options: JSONObjectConvertible {
+extension Project.Options: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
         carthageBuildPath = jsonDictionary.json(atKeyPath: "carthageBuildPath")

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -3,10 +3,10 @@ import JSONUtilities
 import PathKit
 import Yams
 
-extension ProjectSpec {
+extension Project {
 
     public init(path: Path) throws {
-        let dictionary = try ProjectSpec.loadDictionary(path: path)
+        let dictionary = try Project.loadDictionary(path: path)
         try self.init(basePath: path.parent(), jsonDictionary: dictionary)
     }
 

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PathKit
 
-extension ProjectSpec {
+extension Project {
 
     public enum ValidationType: String {
         case missingConfigs

--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -28,9 +28,9 @@ func generate(spec: String, project: String, isQuiet: Bool, justVersion: Bool) {
         fatalError("No project spec found at \(specPath.absolute())")
     }
 
-    let spec: ProjectSpec
+    let spec: ProjectSpec.Project
     do {
-        spec = try ProjectSpec(path: specPath)
+        spec = try ProjectSpec.Project(path: specPath)
         logger.info("📋  Loaded spec:\n  \(spec.debugDescription.replacingOccurrences(of: "\n", with: "\n  "))")
     } catch let error as JSONUtilities.DecodingError {
         fatalError("Parsing spec failed: \(error.description)")
@@ -40,7 +40,7 @@ func generate(spec: String, project: String, isQuiet: Bool, justVersion: Bool) {
 
     do {
         logger.info("⚙️  Generating project...")
-        let projectGenerator = ProjectGenerator(spec: spec)
+        let projectGenerator = ProjectGenerator(project: spec)
         let project = try projectGenerator.generateProject()
 
         logger.info("⚙️  Writing project...")

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -70,7 +70,7 @@ public class PBXProjGenerator {
             )
         }
 
-        let configName = spec.options.defaultConfig ?? buildConfigs.first?.object.name ?? ""
+        let configName = project.options.defaultConfig ?? buildConfigs.first?.object.name ?? ""
         let buildConfigList = createObject(
             id: project.name,
             XCConfigurationList(

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -7,23 +7,23 @@ import Yams
 
 public class ProjectGenerator {
 
-    let spec: ProjectSpec
+    let project: Project
 
-    public init(spec: ProjectSpec) {
-        self.spec = spec
+    public init(project: Project) {
+        self.project = project
     }
 
     var defaultDebugConfig: Config {
-        return spec.configs.first { $0.type == .debug }!
+        return project.configs.first { $0.type == .debug }!
     }
 
     var defaultReleaseConfig: Config {
-        return spec.configs.first { $0.type == .release }!
+        return project.configs.first { $0.type == .release }!
     }
 
     public func generateProject() throws -> XcodeProj {
-        try spec.validate()
-        let pbxProjGenerator = PBXProjGenerator(spec: spec)
+        try project.validate()
+        let pbxProjGenerator = PBXProjGenerator(project: project)
         let pbxProject = try pbxProjGenerator.generate()
         let workspace = try generateWorkspace()
         let sharedData = try generateSharedData(pbxProject: pbxProject)
@@ -41,9 +41,9 @@ public class ProjectGenerator {
         func getBuildEntry(_ buildTarget: Scheme.BuildTarget) -> XCScheme.BuildAction.Entry {
 
             let targetReference = pbxProject.objects.targets(named: buildTarget.target).first!
-            let target = spec.getTarget(buildTarget.target)!
+            let target = project.getTarget(buildTarget.target)!
             let buildableReference = XCScheme.BuildableReference(
-                referencedContainer: "container:\(spec.name).xcodeproj",
+                referencedContainer: "container:\(project.name).xcodeproj",
                 blueprintIdentifier: targetReference.reference,
                 buildableName: target.filename,
                 blueprintName: buildTarget.target
@@ -137,8 +137,8 @@ public class ProjectGenerator {
 
         return XCScheme(
             name: scheme.name,
-            lastUpgradeVersion: spec.xcodeVersion,
-            version: spec.schemeVersion,
+            lastUpgradeVersion: project.xcodeVersion,
+            version: project.schemeVersion,
             buildAction: buildAction,
             testAction: testAction,
             launchAction: launchAction,
@@ -151,19 +151,19 @@ public class ProjectGenerator {
     func generateSharedData(pbxProject: PBXProj) throws -> XCSharedData {
         var xcschemes: [XCScheme] = []
 
-        for scheme in spec.schemes {
+        for scheme in project.schemes {
             let xcscheme = try generateScheme(scheme, pbxProject: pbxProject)
             xcschemes.append(xcscheme)
         }
 
-        for target in spec.targets {
+        for target in project.targets {
             if let targetScheme = target.scheme {
 
                 if targetScheme.configVariants.isEmpty {
                     let schemeName = target.name
 
-                    let debugConfig = spec.configs.first { $0.type == .debug }!
-                    let releaseConfig = spec.configs.first { $0.type == .release }!
+                    let debugConfig = project.configs.first { $0.type == .debug }!
+                    let releaseConfig = project.configs.first { $0.type == .release }!
 
                     let scheme = Scheme(
                         name: schemeName,
@@ -179,9 +179,9 @@ public class ProjectGenerator {
 
                         let schemeName = "\(target.name) \(configVariant)"
 
-                        let debugConfig = spec.configs
+                        let debugConfig = project.configs
                             .first { $0.type == .debug && $0.name.contains(configVariant) }!
-                        let releaseConfig = spec.configs
+                        let releaseConfig = project.configs
                             .first { $0.type == .release && $0.name.contains(configVariant) }!
 
                         let scheme = Scheme(

--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -112,7 +112,7 @@ extension Project {
 
         if let configSettings = loadConfigFileBuildSettings(path: configPath) {
             for key in configSettings.keys {
-                // FIXME: Catch platform projectifier. e.g. LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]
+                // FIXME: Catch platform specifier. e.g. LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]
                 buildSettings.removeValue(forKey: key)
                 buildSettings.removeValue(forKey: key.quoted)
             }

--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -5,7 +5,7 @@ import ProjectSpec
 import xcproj
 import Yams
 
-extension ProjectSpec {
+extension Project {
 
     public func getProjectBuildSettings(config: Config) -> BuildSettings {
         var buildSettings: BuildSettings = [:]
@@ -112,7 +112,7 @@ extension ProjectSpec {
 
         if let configSettings = loadConfigFileBuildSettings(path: configPath) {
             for key in configSettings.keys {
-                // FIXME: Catch platform specifier. e.g. LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]
+                // FIXME: Catch platform projectifier. e.g. LD_RUNPATH_SEARCH_PATHS[sdk=iphone*]
                 buildSettings.removeValue(forKey: key)
                 buildSettings.removeValue(forKey: key.quoted)
             }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -17,7 +17,7 @@ class SourceGenerator {
     private var groupsByPath: [Path: ObjectReference<PBXGroup>] = [:]
     private var variantGroupsByPath: [Path: ObjectReference<PBXVariantGroup>] = [:]
 
-    private let spec: ProjectSpec
+    private let project: Project
     var addObjectClosure: (String, PBXObject) -> String
     var targetSourceExcludePaths: Set<Path> = []
     var defaultExcludedFiles = [
@@ -28,8 +28,8 @@ class SourceGenerator {
 
     private(set) var knownRegions: Set<String> = []
 
-    init(spec: ProjectSpec, addObjectClosure: @escaping (String, PBXObject) -> String) {
-        self.spec = spec
+    init(project: Project, addObjectClosure: @escaping (String, PBXObject) -> String) {
+        self.project = project
         self.addObjectClosure = addObjectClosure
     }
 
@@ -43,13 +43,13 @@ class SourceGenerator {
     }
 
     func getAllSourceFiles(sources: [TargetSource]) throws -> [SourceFile] {
-        return try sources.flatMap { try getSourceFiles(targetSource: $0, path: spec.basePath + $0.path) }
+        return try sources.flatMap { try getSourceFiles(targetSource: $0, path: project.basePath + $0.path) }
     }
 
     // get groups without build files. Use for Project.fileGroups
     func getFileGroups(path: String) throws {
         // TODO: call a seperate function that only creates groups not source files
-        _ = try getGroupSources(targetSource: TargetSource(path: path), path: spec.basePath + path, isBaseGroup: true)
+        _ = try getGroupSources(targetSource: TargetSource(path: path), path: project.basePath + path, isBaseGroup: true)
     }
 
     func generateSourceFile(targetSource: TargetSource, path: Path, buildPhase: BuildPhase? = nil) -> SourceFile {
@@ -86,7 +86,7 @@ class SourceGenerator {
     }
 
     func getContainedFileReference(path: Path) -> String {
-        let createIntermediateGroups = spec.options.createIntermediateGroups
+        let createIntermediateGroups = project.options.createIntermediateGroups
 
         let parentPath = path.parent()
         let fileReference = getFileReference(path: path, inPath: parentPath)
@@ -122,7 +122,7 @@ class SourceGenerator {
                     .sorted()
                     .map { path in
                         createObject(
-                            id: path.byRemovingBase(path: spec.basePath).string,
+                            id: path.byRemovingBase(path: project.basePath).string,
                             PBXFileReference(
                                 sourceTree: .group,
                                 lastKnownFileType: "wrapper.xcdatamodel",
@@ -141,7 +141,7 @@ class SourceGenerator {
                 return versionGroup
             } else {
                 let fileReference = createObject(
-                    id: path.byRemovingBase(path: spec.basePath).string,
+                    id: path.byRemovingBase(path: project.basePath).string,
                     PBXFileReference(
                         sourceTree: sourceTree,
                         name: fileReferenceName,
@@ -182,18 +182,18 @@ class SourceGenerator {
             groupReference = cachedGroup
         } else {
 
-            // lives outside the spec base path
-            let isOutOfBasePath = !path.absolute().string.contains(spec.basePath.absolute().string)
+            // lives outside the project base path
+            let isOutOfBasePath = !path.absolute().string.contains(project.basePath.absolute().string)
 
             // has no valid parent paths
-            let isRootPath = isOutOfBasePath || path.parent() == spec.basePath
+            let isRootPath = isOutOfBasePath || path.parent() == project.basePath
 
             // is a top level group in the project
             let isTopLevelGroup = (isBaseGroup && !createIntermediateGroups) || isRootPath
 
             let groupName = name ?? path.lastComponent
             let groupPath = isTopLevelGroup ?
-                path.byRemovingBase(path: spec.basePath).string :
+                path.byRemovingBase(path: project.basePath).string :
                 path.lastComponent
             let group = PBXGroup(
                 children: children,
@@ -201,7 +201,7 @@ class SourceGenerator {
                 name: groupName != groupPath ? groupName : nil,
                 path: groupPath
             )
-            groupReference = createObject(id: path.byRemovingBase(path: spec.basePath).string, group)
+            groupReference = createObject(id: path.byRemovingBase(path: project.basePath).string, group)
             groupsByPath[path] = groupReference
 
             if isTopLevelGroup {
@@ -222,7 +222,7 @@ class SourceGenerator {
                 name: path.lastComponent,
                 sourceTree: .group
             )
-            variantGroup = createObject(id: path.byRemovingBase(path: spec.basePath).string, group)
+            variantGroup = createObject(id: path.byRemovingBase(path: project.basePath).string, group)
             variantGroupsByPath[path] = variantGroup
         }
         return variantGroup
@@ -230,7 +230,7 @@ class SourceGenerator {
 
     /// Collects all the excluded paths within the targetSource
     private func getSourceExcludes(targetSource: TargetSource) -> Set<Path> {
-        let rootSourcePath = spec.basePath + targetSource.path
+        let rootSourcePath = project.basePath + targetSource.path
 
         return Set(
             targetSource.excludes.map {
@@ -316,7 +316,7 @@ class SourceGenerator {
                 return localisedDirectories.first { $0.lastComponent == "\(languageId).lproj" }
             }
             return findLocalisedDirectory(by: "Base") ??
-                findLocalisedDirectory(by: NSLocale.canonicalLanguageIdentifier(from: spec.options.developmentLanguage ?? "en"))
+                findLocalisedDirectory(by: NSLocale.canonicalLanguageIdentifier(from: project.options.developmentLanguage ?? "en"))
         }()
 
         knownRegions.formUnion(localisedDirectories.map { $0.lastComponentWithoutExtension })
@@ -385,10 +385,10 @@ class SourceGenerator {
         let group = getGroup(
             path: path,
             mergingChildren: groupChildren,
-            createIntermediateGroups: spec.options.createIntermediateGroups,
+            createIntermediateGroups: project.options.createIntermediateGroups,
             isBaseGroup: isBaseGroup
         )
-        if spec.options.createIntermediateGroups {
+        if project.options.createIntermediateGroups {
             createIntermediaGroups(for: group.reference, at: path)
         }
 
@@ -403,7 +403,7 @@ class SourceGenerator {
         targetSourceExcludePaths = getSourceExcludes(targetSource: targetSource)
 
         let type = targetSource.type ?? (path.isFile || path.extension != nil ? .file : .group)
-        let createIntermediateGroups = spec.options.createIntermediateGroups
+        let createIntermediateGroups = project.options.createIntermediateGroups
 
         var sourceFiles: [SourceFile] = []
         let sourceReference: String
@@ -413,7 +413,7 @@ class SourceGenerator {
             let folderPath = Path(targetSource.path)
             let fileReference = getFileReference(
                 path: folderPath,
-                inPath: spec.basePath,
+                inPath: project.basePath,
                 name: targetSource.name ?? folderPath.lastComponent,
                 sourceTree: .sourceRoot,
                 lastKnownFileType: "folder"
@@ -460,7 +460,7 @@ class SourceGenerator {
     private func createIntermediaGroups(for groupReference: String, at path: Path) {
 
         let parentPath = path.parent()
-        guard parentPath != spec.basePath && path.string.contains(spec.basePath.string) else {
+        guard parentPath != project.basePath && path.string.contains(project.basePath.string) else {
             // we've reached the top or are out of the root directory
             return
         }

--- a/Sources/XcodeGenKit/Version.swift
+++ b/Sources/XcodeGenKit/Version.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ProjectSpec
 
-extension ProjectSpec {
+extension Project {
 
     var xcodeVersion: String {
         return XCodeVersion.parse(options.xcodeVersion ?? "9.2")

--- a/Tests/XcodeGenKitTests/FixtureTests.swift
+++ b/Tests/XcodeGenKitTests/FixtureTests.swift
@@ -7,8 +7,8 @@ import xcproj
 let fixturePath = Path(#file).parent().parent() + "Fixtures"
 
 func generate(specPath: Path, projectPath: Path) throws -> XcodeProj {
-    let spec = try ProjectSpec(path: specPath)
-    let generator = ProjectGenerator(spec: spec)
+    let spec = try ProjectSpec.Project(path: specPath)
+    let generator = ProjectGenerator(project: spec)
     let project = try generator.generateProject()
     let oldProject = try XcodeProj(path: projectPath)
     let pbxProjPath = projectPath + XcodeProj.pbxprojPath(projectPath)

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -7,15 +7,15 @@ import Yams
 
 func projectGeneratorTests() {
 
-    func getProject(_ spec: ProjectSpec.Project) throws -> XcodeProj {
-        let generator = ProjectGenerator(project: spec)
+    func getProject(_ project: Project) throws -> XcodeProj {
+        let generator = ProjectGenerator(project: project)
         return try generator.generateProject()
     }
 
-    func getPbxProj(_ spec: ProjectSpec.Project) throws -> PBXProj {
-        let project = try getProject(spec).pbxproj
-        try project.validate()
-        return project
+    func getPbxProj(_ project: Project) throws -> PBXProj {
+        let pbxProject = try getProject(project).pbxproj
+        try pbxProject.validate()
+        return pbxProject
     }
 
     describe("Project Generator") {
@@ -48,32 +48,32 @@ func projectGeneratorTests() {
         $0.describe("Options") {
 
             $0.it("generates bundle id") {
-                let options = ProjectSpec.Project.Options(bundleIdPrefix: "com.test")
-                let spec = ProjectSpec.Project(basePath: "", name: "test", targets: [framework], options: options)
-                let project = try getProject(spec)
-                guard let target = project.pbxproj.objects.nativeTargets.first?.value,
+                let options = Project.Options(bundleIdPrefix: "com.test")
+                let project = Project(basePath: "", name: "test", targets: [framework], options: options)
+                let xcodeProject = try getProject(project)
+                guard let target = xcodeProject.pbxproj.objects.nativeTargets.first?.value,
                     let buildConfigList = target.buildConfigurationList,
-                    let buildConfigs = project.pbxproj.objects.configurationLists.getReference(buildConfigList),
+                    let buildConfigs = xcodeProject.pbxproj.objects.configurationLists.getReference(buildConfigList),
                     let buildConfigReference = buildConfigs.buildConfigurations.first,
-                    let buildConfig = project.pbxproj.objects.buildConfigurations.getReference(buildConfigReference) else {
+                    let buildConfig = xcodeProject.pbxproj.objects.buildConfigurations.getReference(buildConfigReference) else {
                     throw failure("Build Config not found")
                 }
                 try expect(buildConfig.buildSettings["PRODUCT_BUNDLE_IDENTIFIER"] as? String) == "com.test.MyFramework"
             }
 
             $0.it("clears setting presets") {
-                let options = ProjectSpec.Project.Options(settingPresets: .none)
-                let spec = ProjectSpec.Project(basePath: "", name: "test", targets: [framework], options: options)
-                let project = try getProject(spec)
-                let allSettings = project.pbxproj.objects.buildConfigurations.referenceValues.reduce([:]) { $0.merged($1.buildSettings) }.keys.sorted()
+                let options = Project.Options(settingPresets: .none)
+                let project = Project(basePath: "", name: "test", targets: [framework], options: options)
+                let xcodeProject = try getProject(project)
+                let allSettings = xcodeProject.pbxproj.objects.buildConfigurations.referenceValues.reduce([:]) { $0.merged($1.buildSettings) }.keys.sorted()
                 try expect(allSettings) == ["SETTING_2"]
             }
 
             $0.it("generates development language") {
-                let options = ProjectSpec.Project.Options(developmentLanguage: "de")
-                let spec = ProjectSpec.Project(basePath: "", name: "test", options: options)
-                let project = try getProject(spec)
-                guard let pbxProject = project.pbxproj.objects.projects.first?.value else {
+                let options = Project.Options(developmentLanguage: "de")
+                let project = Project(basePath: "", name: "test", options: options)
+                let xcodeProject = try getProject(project)
+                guard let pbxProject = xcodeProject.pbxproj.objects.projects.first?.value else {
                     throw failure("Could't find PBXProject")
                 }
                 try expect(pbxProject.developmentRegion) == "de"
@@ -98,12 +98,12 @@ func projectGeneratorTests() {
             }
 
             $0.it("uses the default configuration name") {
-                let options = ProjectSpec.Options(defaultConfig: "Bconfig")
-                let spec = ProjectSpec(basePath: "", name: "test", configs: [Config(name: "Aconfig"), Config(name: "Bconfig")], targets: [framework], options: options)
-                let pbxProject = try getPbxProj(spec)
+                let options = Project.Options(defaultConfig: "Bconfig")
+                let project = Project(basePath: "", name: "test", configs: [Config(name: "Aconfig"), Config(name: "Bconfig")], targets: [framework], options: options)
+                let xcodeProject = try getPbxProj(project)
 
-                guard let projectConfigListReference = pbxProject.objects.projects.values.first?.buildConfigurationList,
-                    let defaultConfigurationName = pbxProject.objects.configurationLists[projectConfigListReference]?.defaultConfigurationName
+                guard let projectConfigListReference = xcodeProject.objects.projects.values.first?.buildConfigurationList,
+                    let defaultConfigurationName = xcodeProject.objects.configurationLists[projectConfigListReference]?.defaultConfigurationName
                 else {
                     throw failure("Default configuration name not found")
                 }
@@ -115,47 +115,47 @@ func projectGeneratorTests() {
         $0.describe("Config") {
 
             $0.it("generates config defaults") {
-                let spec = ProjectSpec.Project(basePath: "", name: "test")
-                let project = try getProject(spec)
-                let configs = project.pbxproj.objects.buildConfigurations.referenceValues
+                let project = Project(basePath: "", name: "test")
+                let xcodeProject = try getProject(project)
+                let configs = xcodeProject.pbxproj.objects.buildConfigurations.referenceValues
                 try expect(configs.count) == 2
                 try expect(configs).contains(name: "Debug")
                 try expect(configs).contains(name: "Release")
             }
 
             $0.it("generates configs") {
-                let spec = ProjectSpec.Project(
+                let project = Project(
                     basePath: "",
                     name: "test",
                     configs: [Config(name: "config1"), Config(name: "config2")]
                 )
-                let project = try getProject(spec)
-                let configs = project.pbxproj.objects.buildConfigurations.referenceValues
+                let xcodeProject = try getProject(project)
+                let configs = xcodeProject.pbxproj.objects.buildConfigurations.referenceValues
                 try expect(configs.count) == 2
                 try expect(configs).contains(name: "config1")
                 try expect(configs).contains(name: "config2")
             }
 
             $0.it("clears config settings when missing type") {
-                let spec = ProjectSpec.Project(
+                let project = Project(
                     basePath: "",
                     name: "test",
                     configs: [Config(name: "config")]
                 )
-                let project = try getProject(spec)
-                guard let config = project.pbxproj.objects.buildConfigurations.first?.value else {
+                let xcodeProject = try getProject(project)
+                guard let config = xcodeProject.pbxproj.objects.buildConfigurations.first?.value else {
                     throw failure("configuration not found")
                 }
                 try expect(config.buildSettings.isEmpty).to.beTrue()
             }
 
             $0.it("merges settings") {
-                let spec = try ProjectSpec.Project(path: fixturePath + "settings_test.yml")
-                guard let config = spec.getConfig("config1") else { throw failure("Couldn't find config1") }
-                let debugProjectSettings = spec.getProjectBuildSettings(config: config)
+                let project = try Project(path: fixturePath + "settings_test.yml")
+                guard let config = project.getConfig("config1") else { throw failure("Couldn't find config1") }
+                let debugProjectSettings = project.getProjectBuildSettings(config: config)
 
-                guard let target = spec.getTarget("Target") else { throw failure("Couldn't find Target") }
-                let targetDebugSettings = spec.getTargetBuildSettings(target: target, config: config)
+                guard let target = project.getTarget("Target") else { throw failure("Couldn't find Target") }
+                let targetDebugSettings = project.getTargetBuildSettings(target: target, config: config)
 
                 var buildSettings = BuildSettings()
                 buildSettings += SettingsPresetFile.base.getBuildSettings()
@@ -178,7 +178,7 @@ func projectGeneratorTests() {
             }
 
             $0.it("applies partial config settings") {
-                let spec = ProjectSpec.Project(
+                let project = Project(
                     basePath: "",
                     name: "test",
                     configs: [
@@ -188,7 +188,7 @@ func projectGeneratorTests() {
                     settings: Settings(configSettings: ["staging": ["SETTING1": "VALUE1"], "debug": ["SETTING2": "VALUE2"]])
                 )
 
-                var buildSettings = spec.getProjectBuildSettings(config: spec.configs.first!)
+                var buildSettings = project.getProjectBuildSettings(config: project.configs.first!)
                 try expect(buildSettings["SETTING1"] as? String) == "VALUE1"
                 try expect(buildSettings["SETTING2"] as? String) == "VALUE2"
             }
@@ -196,10 +196,10 @@ func projectGeneratorTests() {
 
         $0.describe("Targets") {
 
-            let spec = ProjectSpec.Project(basePath: "", name: "test", targets: targets)
+            let project = Project(basePath: "", name: "test", targets: targets)
 
             $0.it("generates targets") {
-                let pbxProject = try getPbxProj(spec)
+                let pbxProject = try getPbxProj(project)
                 let nativeTargets = pbxProject.objects.nativeTargets.referenceValues
                 try expect(nativeTargets.count) == 3
                 try expect(nativeTargets.contains { $0.name == application.name }).beTrue()
@@ -209,7 +209,7 @@ func projectGeneratorTests() {
 
             $0.it("generates target attributes") {
 
-                let pbxProject = try getPbxProj(spec)
+                let pbxProject = try getPbxProj(project)
 
                 guard let targetAttributes = pbxProject.objects.projects.referenceValues.first?.attributes["TargetAttributes"] as? [String: [String: Any]] else {
                     throw failure("Couldn't find Project TargetAttributes")
@@ -228,9 +228,9 @@ func projectGeneratorTests() {
 
             $0.it("generates platform version") {
                 let target = Target(name: "Target", type: .application, platform: .watchOS, deploymentTarget: "2.0")
-                let spec = ProjectSpec.Project(basePath: "", name: "", targets: [target], options: .init(deploymentTarget: DeploymentTarget(iOS: "10.0", watchOS: "3.0")))
+                let project = Project(basePath: "", name: "", targets: [target], options: .init(deploymentTarget: DeploymentTarget(iOS: "10.0", watchOS: "3.0")))
 
-                let pbxProject = try getPbxProj(spec)
+                let pbxProject = try getPbxProj(project)
 
                 guard let projectConfigListReference = pbxProject.objects.projects.values.first?.buildConfigurationList,
                     let projectConfigReference = pbxProject.objects.configurationLists[projectConfigListReference]?.buildConfigurations.first,
@@ -256,7 +256,7 @@ func projectGeneratorTests() {
             }
 
             $0.it("generates dependencies") {
-                let pbxProject = try getPbxProj(spec)
+                let pbxProject = try getPbxProj(project)
 
                 let nativeTargets = pbxProject.objects.nativeTargets.objectReferences
                 let dependencies = pbxProject.objects.targetDependencies.objectReferences
@@ -266,7 +266,7 @@ func projectGeneratorTests() {
             }
 
             $0.it("generates run scripts") {
-                var scriptSpec = spec
+                var scriptSpec = project
                 scriptSpec.targets[0].prebuildScripts = [BuildScript(script: .script("script1"))]
                 scriptSpec.targets[0].postbuildScripts = [BuildScript(script: .script("script2"))]
                 let pbxProject = try getPbxProj(scriptSpec)
@@ -301,13 +301,13 @@ func projectGeneratorTests() {
                     platform: .iOS,
                     dependencies: [Dependency(type: .target, reference: "target1")]
                 )
-                let spec = ProjectSpec.Project(
+                let project = Project(
                     basePath: "",
                     name: "test",
                     targets: [target1, target2]
                 )
 
-                _ = try getPbxProj(spec)
+                _ = try getPbxProj(project)
             }
         }
 
@@ -320,18 +320,18 @@ func projectGeneratorTests() {
                     name: "MyScheme",
                     build: Scheme.Build(targets: [buildTarget], preActions: [preAction])
                 )
-                let spec = ProjectSpec.Project(
+                let project = Project(
                     basePath: "",
                     name: "test",
                     targets: [application, framework],
                     schemes: [scheme]
                 )
-                let project = try getProject(spec)
-                guard let target = project.pbxproj.objects.nativeTargets.objectReferences
+                let xcodeProject = try getProject(project)
+                guard let target = xcodeProject.pbxproj.objects.nativeTargets.objectReferences
                     .first(where: { $0.object.name == application.name }) else {
                     throw failure("Target not found")
                 }
-                guard let xcscheme = project.sharedData?.schemes.first else {
+                guard let xcscheme = xcodeProject.sharedData?.schemes.first else {
                     throw failure("Scheme not found")
                 }
                 try expect(scheme.name) == "MyScheme"
@@ -379,20 +379,20 @@ func projectGeneratorTests() {
                     test: Scheme.Test(config: "Debug"),
                     profile: Scheme.Profile(config: "Debug")
                 )
-                let spec = ProjectSpec.Project(
+                let project = Project(
                     basePath: "",
                     name: "test",
                     targets: [application, framework],
                     schemes: [scheme]
                 )
-                let project = try getProject(spec)
+                let pbxProject = try getProject(project)
 
-                guard let target = project.pbxproj.objects.nativeTargets.objectReferences
+                guard let target = pbxProject.pbxproj.objects.nativeTargets.objectReferences
                     .first(where: { $0.object.name == application.name }) else {
                     throw failure("Target not found")
                 }
 
-                guard let xcscheme = project.sharedData?.schemes.first else {
+                guard let xcscheme = pbxProject.sharedData?.schemes.first else {
                     throw failure("Scheme not found")
                 }
 
@@ -412,16 +412,16 @@ func projectGeneratorTests() {
                     Config(name: "Production Release", type: .release),
                 ]
 
-                let spec = ProjectSpec.Project(basePath: "", name: "test", configs: configs, targets: [target, framework])
-                let project = try getProject(spec)
+                let project = Project(basePath: "", name: "test", configs: configs, targets: [target, framework])
+                let xcodeProject = try getProject(project)
 
-                try expect(project.sharedData?.schemes.count) == 2
+                try expect(xcodeProject.sharedData?.schemes.count) == 2
 
-                guard let nativeTarget = project.pbxproj.objects.nativeTargets.objectReferences
+                guard let nativeTarget = xcodeProject.pbxproj.objects.nativeTargets.objectReferences
                     .first(where: { $0.object.name == application.name }) else {
                     throw failure("Target not found")
                 }
-                guard let xcscheme = project.sharedData?.schemes
+                guard let xcscheme = xcodeProject.sharedData?.schemes
                     .first(where: { $0.name == "\(target.name) Test" }) else {
                     throw failure("Scheme not found")
                 }
@@ -442,12 +442,12 @@ func projectGeneratorTests() {
                 var target = application
                 target.scheme = TargetScheme(environmentVariables: variables)
 
-                let spec = ProjectSpec.Project(basePath: "", name: "test", targets: [target, framework])
-                let project = try getProject(spec)
+                let project = Project(basePath: "", name: "test", targets: [target, framework])
+                let xcodeProject = try getProject(project)
 
-                try expect(project.sharedData?.schemes.count) == 1
+                try expect(xcodeProject.sharedData?.schemes.count) == 1
 
-                guard let xcscheme = project.sharedData?.schemes.first else {
+                guard let xcscheme = xcodeProject.sharedData?.schemes.first else {
                     throw failure("Scheme not found")
                 }
 
@@ -513,11 +513,11 @@ func projectGeneratorTests() {
                 try createDirectories(directories)
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: ["Sources"])
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
 
-                let project = try getPbxProj(spec)
-                try project.expectFile(paths: ["Sources", "A", "a.swift"], buildPhase: .sources)
-                try project.expectFile(paths: ["Sources", "A", "B", "b.swift"], buildPhase: .sources)
+                let pbxProject = try getPbxProj(project)
+                try pbxProject.expectFile(paths: ["Sources", "A", "a.swift"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["Sources", "A", "B", "b.swift"], buildPhase: .sources)
             }
 
             $0.it("generates core data models") {
@@ -529,13 +529,13 @@ func projectGeneratorTests() {
                 try createDirectories(directories)
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: ["Sources"])
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
 
-                let project = try getPbxProj(spec)
-                guard let fileReference = project.objects.fileReferences.first(where: { $0.value.nameOrPath == "model.xcdatamodel" }) else {
+                let pbxProject = try getPbxProj(project)
+                guard let fileReference = pbxProject.objects.fileReferences.first(where: { $0.value.nameOrPath == "model.xcdatamodel" }) else {
                     throw failure("Couldn't find model file reference")
                 }
-                guard let versionGroup = project.objects.versionGroups.values.first else {
+                guard let versionGroup = pbxProject.objects.versionGroups.values.first else {
                     throw failure("Couldn't find version group")
                 }
                 try expect(versionGroup.currentVersion) == fileReference.key
@@ -557,17 +557,17 @@ func projectGeneratorTests() {
                 try createDirectories(directories)
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: ["Sources"])
-                let spec = ProjectSpec.Project(
+                let project = Project(
                     basePath: directoryPath,
                     name: "Test",
                     targets: [target],
                     fileGroups: ["Sources"]
                 )
 
-                let project = try getPbxProj(spec)
-                try project.expectFile(paths: ["Sources", "a.swift"], buildPhase: .sources)
-                try project.expectFile(paths: ["Sources", "a", "a.swift"], buildPhase: .sources)
-                try project.expectFile(paths: ["Sources", "a", "a", "a.swift"], buildPhase: .sources)
+                let pbxProject = try getPbxProj(project)
+                try pbxProject.expectFile(paths: ["Sources", "a.swift"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["Sources", "a", "a.swift"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["Sources", "a", "a", "a.swift"], buildPhase: .sources)
             }
 
             $0.it("renames sources") {
@@ -583,11 +583,11 @@ func projectGeneratorTests() {
                     TargetSource(path: "Sources", name: "NewSource"),
                     TargetSource(path: "OtherSource/b.swift", name: "c.swift"),
                 ])
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
 
-                let project = try getPbxProj(spec)
-                try project.expectFile(paths: ["Sources", "a.swift"], names: ["NewSource", "a.swift"], buildPhase: .sources)
-                try project.expectFile(paths: ["OtherSource", "b.swift"], names: ["OtherSource", "c.swift"], buildPhase: .sources)
+                let pbxProject = try getPbxProj(project)
+                try pbxProject.expectFile(paths: ["Sources", "a.swift"], names: ["NewSource", "a.swift"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["OtherSource", "b.swift"], names: ["OtherSource", "c.swift"], buildPhase: .sources)
             }
 
             $0.it("excludes sources") {
@@ -646,28 +646,28 @@ func projectGeneratorTests() {
                 ]
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: [TargetSource(path: "Sources", excludes: excludes)])
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
 
-                let project = try getPbxProj(spec)
-                try project.expectFile(paths: ["Sources", "A", "a.swift"])
-                try project.expectFile(paths: ["Sources", "D", "d.h"])
-                try project.expectFile(paths: ["Sources", "D", "d.m"])
-                try project.expectFile(paths: ["Sources", "E", "e.jpg"])
-                try project.expectFile(paths: ["Sources", "E", "e.m"])
-                try project.expectFile(paths: ["Sources", "E", "e.h"])
-                try project.expectFile(paths: ["Sources", "types", "a.swift"])
-                try project.expectFile(paths: ["Sources", "numbers", "file1.a"])
-                try project.expectFile(paths: ["Sources", "numbers", "file4.a"])
-                try project.expectFileMissing(paths: ["Sources", "B", "b.swift"])
-                try project.expectFileMissing(paths: ["Sources", "E", "F", "f.swift"])
-                try project.expectFileMissing(paths: ["Sources", "G", "H", "h.swift"])
-                try project.expectFileMissing(paths: ["Sources", "types", "a.h"])
-                try project.expectFileMissing(paths: ["Sources", "types", "a.x"])
-                try project.expectFileMissing(paths: ["Sources", "numbers", "file2.a"])
-                try project.expectFileMissing(paths: ["Sources", "numbers", "file3.a"])
-                try project.expectFileMissing(paths: ["Sources", "partial", "file_part"])
-                try project.expectFileMissing(paths: ["Sources", "a.ignored"])
-                try project.expectFileMissing(paths: ["Sources", "ignore.file"])
+                let pbxProject = try getPbxProj(project)
+                try pbxProject.expectFile(paths: ["Sources", "A", "a.swift"])
+                try pbxProject.expectFile(paths: ["Sources", "D", "d.h"])
+                try pbxProject.expectFile(paths: ["Sources", "D", "d.m"])
+                try pbxProject.expectFile(paths: ["Sources", "E", "e.jpg"])
+                try pbxProject.expectFile(paths: ["Sources", "E", "e.m"])
+                try pbxProject.expectFile(paths: ["Sources", "E", "e.h"])
+                try pbxProject.expectFile(paths: ["Sources", "types", "a.swift"])
+                try pbxProject.expectFile(paths: ["Sources", "numbers", "file1.a"])
+                try pbxProject.expectFile(paths: ["Sources", "numbers", "file4.a"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "B", "b.swift"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "E", "F", "f.swift"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "G", "H", "h.swift"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "types", "a.h"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "types", "a.x"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "numbers", "file2.a"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "numbers", "file3.a"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "partial", "file_part"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "a.ignored"])
+                try pbxProject.expectFileMissing(paths: ["Sources", "ignore.file"])
             }
 
             $0.it("generates file sources") {
@@ -688,13 +688,13 @@ func projectGeneratorTests() {
                     "Sources/A/Assets.xcassets",
                     "Sources/A/B/c.jpg",
                 ])
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
 
-                let project = try getPbxProj(spec)
-                try project.expectFile(paths: ["Sources/A", "a.swift"], names: ["A", "a.swift"], buildPhase: .sources)
-                try project.expectFile(paths: ["Sources/A/B", "b.swift"], names: ["B", "b.swift"], buildPhase: .sources)
-                try project.expectFile(paths: ["Sources/A/B", "c.jpg"], names: ["B", "c.jpg"], buildPhase: .resources)
-                try project.expectFile(paths: ["Sources/A", "Assets.xcassets"], names: ["A", "Assets.xcassets"], buildPhase: .resources)
+                let pbxProject = try getPbxProj(project)
+                try pbxProject.expectFile(paths: ["Sources/A", "a.swift"], names: ["A", "a.swift"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["Sources/A/B", "b.swift"], names: ["B", "b.swift"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["Sources/A/B", "c.jpg"], names: ["B", "c.jpg"], buildPhase: .resources)
+                try pbxProject.expectFile(paths: ["Sources/A", "Assets.xcassets"], names: ["A", "Assets.xcassets"], buildPhase: .resources)
             }
 
             $0.it("generates shared sources") {
@@ -710,9 +710,9 @@ func projectGeneratorTests() {
 
                 let target1 = Target(name: "Test1", type: .framework, platform: .iOS, sources: ["Sources"])
                 let target2 = Target(name: "Test2", type: .framework, platform: .tvOS, sources: ["Sources"])
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target1, target2])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target1, target2])
 
-                _ = try getPbxProj(spec)
+                _ = try getPbxProj(project)
                 // TODO: check there are build files for both targets
             }
 
@@ -736,13 +736,13 @@ func projectGeneratorTests() {
                     "Sources/F/G/h.swift",
                     "../OtherDirectory/C/D/e.swift",
                 ])
-                let options = ProjectSpec.Project.Options(createIntermediateGroups: true)
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target], options: options)
+                let options = Project.Options(createIntermediateGroups: true)
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target], options: options)
 
-                let project = try getPbxProj(spec)
-                try project.expectFile(paths: ["Sources", "A", "b.swift"], buildPhase: .sources)
-                try project.expectFile(paths: ["Sources", "F", "G", "h.swift"], buildPhase: .sources)
-                try project.expectFile(paths: [(outOfRootPath + "C/D").string, "e.swift"], names: ["D", "e.swift"], buildPhase: .sources)
+                let pbxProject = try getPbxProj(project)
+                try pbxProject.expectFile(paths: ["Sources", "A", "b.swift"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["Sources", "F", "G", "h.swift"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: [(outOfRootPath + "C/D").string, "e.swift"], names: ["D", "e.swift"], buildPhase: .sources)
             }
 
             $0.it("generates folder references") {
@@ -757,11 +757,11 @@ func projectGeneratorTests() {
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: [
                     TargetSource(path: "Sources/A", type: .folder),
                 ])
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
 
-                let project = try getPbxProj(spec)
-                try project.expectFile(paths: ["Sources/A"], names: ["A"], buildPhase: .resources)
-                try project.expectFileMissing(paths: ["Sources", "A", "a.swift"])
+                let pbxProject = try getPbxProj(project)
+                try pbxProject.expectFile(paths: ["Sources/A"], names: ["A"], buildPhase: .resources)
+                try pbxProject.expectFileMissing(paths: ["Sources", "A", "a.swift"])
             }
 
             $0.it("adds files to correct build phase") {
@@ -807,44 +807,44 @@ func projectGeneratorTests() {
                     TargetSource(path: "B", buildPhase: .none),
                     TargetSource(path: "C", buildPhase: nil),
                 ])
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
 
-                let project = try getPbxProj(spec)
-                try project.expectFile(paths: ["A", "file.swift"], buildPhase: .resources)
-                try project.expectFile(paths: ["A", "file.xcassets"], buildPhase: .resources)
-                try project.expectFile(paths: ["A", "file.h"], buildPhase: .resources)
-                try project.expectFile(paths: ["A", "Info.plist"], buildPhase: .none)
-                try project.expectFile(paths: ["A", "file.xcconfig"], buildPhase: .resources)
+                let pbxProject = try getPbxProj(project)
+                try pbxProject.expectFile(paths: ["A", "file.swift"], buildPhase: .resources)
+                try pbxProject.expectFile(paths: ["A", "file.xcassets"], buildPhase: .resources)
+                try pbxProject.expectFile(paths: ["A", "file.h"], buildPhase: .resources)
+                try pbxProject.expectFile(paths: ["A", "Info.plist"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["A", "file.xcconfig"], buildPhase: .resources)
 
-                try project.expectFile(paths: ["B", "file.swift"], buildPhase: .none)
-                try project.expectFile(paths: ["B", "file.xcassets"], buildPhase: .none)
-                try project.expectFile(paths: ["B", "file.h"], buildPhase: .none)
-                try project.expectFile(paths: ["B", "Info.plist"], buildPhase: .none)
-                try project.expectFile(paths: ["B", "file.xcconfig"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["B", "file.swift"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["B", "file.xcassets"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["B", "file.h"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["B", "Info.plist"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["B", "file.xcconfig"], buildPhase: .none)
 
-                try project.expectFile(paths: ["C", "file.swift"], buildPhase: .sources)
-                try project.expectFile(paths: ["C", "file.m"], buildPhase: .sources)
-                try project.expectFile(paths: ["C", "file.mm"], buildPhase: .sources)
-                try project.expectFile(paths: ["C", "file.cpp"], buildPhase: .sources)
-                try project.expectFile(paths: ["C", "file.c"], buildPhase: .sources)
-                try project.expectFile(paths: ["C", "file.S"], buildPhase: .sources)
-                try project.expectFile(paths: ["C", "file.h"], buildPhase: .headers)
-                try project.expectFile(paths: ["C", "file.hh"], buildPhase: .headers)
-                try project.expectFile(paths: ["C", "file.hpp"], buildPhase: .headers)
-                try project.expectFile(paths: ["C", "file.ipp"], buildPhase: .headers)
-                try project.expectFile(paths: ["C", "file.tpp"], buildPhase: .headers)
-                try project.expectFile(paths: ["C", "file.hxx"], buildPhase: .headers)
-                try project.expectFile(paths: ["C", "file.def"], buildPhase: .headers)
-                try project.expectFile(paths: ["C", "file.xcconfig"], buildPhase: .none)
-                try project.expectFile(paths: ["C", "file.entitlements"], buildPhase: .none)
-                try project.expectFile(paths: ["C", "file.gpx"], buildPhase: .none)
-                try project.expectFile(paths: ["C", "file.apns"], buildPhase: .none)
-                try project.expectFile(paths: ["C", "file.xcconfig"], buildPhase: .none)
-                try project.expectFile(paths: ["C", "file.xcconfig"], buildPhase: .none)
-                try project.expectFile(paths: ["C", "file.xcconfig"], buildPhase: .none)
-                try project.expectFile(paths: ["C", "file.xcassets"], buildPhase: .resources)
-                try project.expectFile(paths: ["C", "file.123"], buildPhase: .resources)
-                try project.expectFile(paths: ["C", "Info.plist"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["C", "file.swift"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["C", "file.m"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["C", "file.mm"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["C", "file.cpp"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["C", "file.c"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["C", "file.S"], buildPhase: .sources)
+                try pbxProject.expectFile(paths: ["C", "file.h"], buildPhase: .headers)
+                try pbxProject.expectFile(paths: ["C", "file.hh"], buildPhase: .headers)
+                try pbxProject.expectFile(paths: ["C", "file.hpp"], buildPhase: .headers)
+                try pbxProject.expectFile(paths: ["C", "file.ipp"], buildPhase: .headers)
+                try pbxProject.expectFile(paths: ["C", "file.tpp"], buildPhase: .headers)
+                try pbxProject.expectFile(paths: ["C", "file.hxx"], buildPhase: .headers)
+                try pbxProject.expectFile(paths: ["C", "file.def"], buildPhase: .headers)
+                try pbxProject.expectFile(paths: ["C", "file.xcconfig"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["C", "file.entitlements"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["C", "file.gpx"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["C", "file.apns"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["C", "file.xcconfig"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["C", "file.xcconfig"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["C", "file.xcconfig"], buildPhase: .none)
+                try pbxProject.expectFile(paths: ["C", "file.xcassets"], buildPhase: .resources)
+                try pbxProject.expectFile(paths: ["C", "file.123"], buildPhase: .resources)
+                try pbxProject.expectFile(paths: ["C", "Info.plist"], buildPhase: .none)
             }
 
             $0.it("duplicate TargetSource is included once in sources build phase") {
@@ -859,12 +859,12 @@ func projectGeneratorTests() {
                     "Sources/A/a.swift",
                     "Sources/A/a.swift",
                 ])
-                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
 
-                let project = try getPbxProj(spec)
-                try project.expectFile(paths: ["Sources/A", "a.swift"], names: ["A", "a.swift"], buildPhase: .sources)
+                let pbxProject = try getPbxProj(project)
+                try pbxProject.expectFile(paths: ["Sources/A", "a.swift"], names: ["A", "a.swift"], buildPhase: .sources)
 
-                let sourcesBuildPhase = project.objects.buildPhases
+                let sourcesBuildPhase = pbxProject.objects.buildPhases
                     .first(where: { $0.1.buildPhase == BuildPhase.sources })!
                     .value
 
@@ -941,17 +941,17 @@ extension PBXProj {
     }
 
     func getFileReference(paths: [String], names: [String]) -> ObjectReference<PBXFileReference>? {
-        guard let project = objects.projects.first?.value else { return nil }
-        guard let mainGroup = objects.groups.getReference(project.mainGroup) else { return nil }
+        guard let pbxProject = objects.projects.first?.value else { return nil }
+        guard let mainGroup = objects.groups.getReference(pbxProject.mainGroup) else { return nil }
 
         return getFileReference(group: mainGroup, paths: paths, names: names)
     }
 
     func getMainGroup() throws -> PBXGroup {
-        guard let project = objects.projects.first?.value else {
-            throw failure("Couldn't find project")
+        guard let pbxProject = objects.projects.first?.value else {
+            throw failure("Couldn't find pbxProject")
         }
-        guard let mainGroup = objects.groups.getReference(project.mainGroup) else {
+        guard let mainGroup = objects.groups.getReference(pbxProject.mainGroup) else {
             throw failure("Couldn't find main group")
         }
         return mainGroup

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -7,12 +7,12 @@ import Yams
 
 func projectGeneratorTests() {
 
-    func getProject(_ spec: ProjectSpec) throws -> XcodeProj {
-        let generator = ProjectGenerator(spec: spec)
+    func getProject(_ spec: ProjectSpec.Project) throws -> XcodeProj {
+        let generator = ProjectGenerator(project: spec)
         return try generator.generateProject()
     }
 
-    func getPbxProj(_ spec: ProjectSpec) throws -> PBXProj {
+    func getPbxProj(_ spec: ProjectSpec.Project) throws -> PBXProj {
         let project = try getProject(spec).pbxproj
         try project.validate()
         return project
@@ -48,8 +48,8 @@ func projectGeneratorTests() {
         $0.describe("Options") {
 
             $0.it("generates bundle id") {
-                let options = ProjectSpec.Options(bundleIdPrefix: "com.test")
-                let spec = ProjectSpec(basePath: "", name: "test", targets: [framework], options: options)
+                let options = ProjectSpec.Project.Options(bundleIdPrefix: "com.test")
+                let spec = ProjectSpec.Project(basePath: "", name: "test", targets: [framework], options: options)
                 let project = try getProject(spec)
                 guard let target = project.pbxproj.objects.nativeTargets.first?.value,
                     let buildConfigList = target.buildConfigurationList,
@@ -62,16 +62,16 @@ func projectGeneratorTests() {
             }
 
             $0.it("clears setting presets") {
-                let options = ProjectSpec.Options(settingPresets: .none)
-                let spec = ProjectSpec(basePath: "", name: "test", targets: [framework], options: options)
+                let options = ProjectSpec.Project.Options(settingPresets: .none)
+                let spec = ProjectSpec.Project(basePath: "", name: "test", targets: [framework], options: options)
                 let project = try getProject(spec)
                 let allSettings = project.pbxproj.objects.buildConfigurations.referenceValues.reduce([:]) { $0.merged($1.buildSettings) }.keys.sorted()
                 try expect(allSettings) == ["SETTING_2"]
             }
 
             $0.it("generates development language") {
-                let options = ProjectSpec.Options(developmentLanguage: "de")
-                let spec = ProjectSpec(basePath: "", name: "test", options: options)
+                let options = ProjectSpec.Project.Options(developmentLanguage: "de")
+                let spec = ProjectSpec.Project(basePath: "", name: "test", options: options)
                 let project = try getProject(spec)
                 guard let pbxProject = project.pbxproj.objects.projects.first?.value else {
                     throw failure("Could't find PBXProject")
@@ -115,7 +115,7 @@ func projectGeneratorTests() {
         $0.describe("Config") {
 
             $0.it("generates config defaults") {
-                let spec = ProjectSpec(basePath: "", name: "test")
+                let spec = ProjectSpec.Project(basePath: "", name: "test")
                 let project = try getProject(spec)
                 let configs = project.pbxproj.objects.buildConfigurations.referenceValues
                 try expect(configs.count) == 2
@@ -124,7 +124,7 @@ func projectGeneratorTests() {
             }
 
             $0.it("generates configs") {
-                let spec = ProjectSpec(
+                let spec = ProjectSpec.Project(
                     basePath: "",
                     name: "test",
                     configs: [Config(name: "config1"), Config(name: "config2")]
@@ -137,7 +137,7 @@ func projectGeneratorTests() {
             }
 
             $0.it("clears config settings when missing type") {
-                let spec = ProjectSpec(
+                let spec = ProjectSpec.Project(
                     basePath: "",
                     name: "test",
                     configs: [Config(name: "config")]
@@ -150,7 +150,7 @@ func projectGeneratorTests() {
             }
 
             $0.it("merges settings") {
-                let spec = try ProjectSpec(path: fixturePath + "settings_test.yml")
+                let spec = try ProjectSpec.Project(path: fixturePath + "settings_test.yml")
                 guard let config = spec.getConfig("config1") else { throw failure("Couldn't find config1") }
                 let debugProjectSettings = spec.getProjectBuildSettings(config: config)
 
@@ -178,7 +178,7 @@ func projectGeneratorTests() {
             }
 
             $0.it("applies partial config settings") {
-                let spec = ProjectSpec(
+                let spec = ProjectSpec.Project(
                     basePath: "",
                     name: "test",
                     configs: [
@@ -196,7 +196,7 @@ func projectGeneratorTests() {
 
         $0.describe("Targets") {
 
-            let spec = ProjectSpec(basePath: "", name: "test", targets: targets)
+            let spec = ProjectSpec.Project(basePath: "", name: "test", targets: targets)
 
             $0.it("generates targets") {
                 let pbxProject = try getPbxProj(spec)
@@ -228,7 +228,7 @@ func projectGeneratorTests() {
 
             $0.it("generates platform version") {
                 let target = Target(name: "Target", type: .application, platform: .watchOS, deploymentTarget: "2.0")
-                let spec = ProjectSpec(basePath: "", name: "", targets: [target], options: .init(deploymentTarget: DeploymentTarget(iOS: "10.0", watchOS: "3.0")))
+                let spec = ProjectSpec.Project(basePath: "", name: "", targets: [target], options: .init(deploymentTarget: DeploymentTarget(iOS: "10.0", watchOS: "3.0")))
 
                 let pbxProject = try getPbxProj(spec)
 
@@ -301,7 +301,7 @@ func projectGeneratorTests() {
                     platform: .iOS,
                     dependencies: [Dependency(type: .target, reference: "target1")]
                 )
-                let spec = ProjectSpec(
+                let spec = ProjectSpec.Project(
                     basePath: "",
                     name: "test",
                     targets: [target1, target2]
@@ -320,7 +320,7 @@ func projectGeneratorTests() {
                     name: "MyScheme",
                     build: Scheme.Build(targets: [buildTarget], preActions: [preAction])
                 )
-                let spec = ProjectSpec(
+                let spec = ProjectSpec.Project(
                     basePath: "",
                     name: "test",
                     targets: [application, framework],
@@ -379,7 +379,7 @@ func projectGeneratorTests() {
                     test: Scheme.Test(config: "Debug"),
                     profile: Scheme.Profile(config: "Debug")
                 )
-                let spec = ProjectSpec(
+                let spec = ProjectSpec.Project(
                     basePath: "",
                     name: "test",
                     targets: [application, framework],
@@ -412,7 +412,7 @@ func projectGeneratorTests() {
                     Config(name: "Production Release", type: .release),
                 ]
 
-                let spec = ProjectSpec(basePath: "", name: "test", configs: configs, targets: [target, framework])
+                let spec = ProjectSpec.Project(basePath: "", name: "test", configs: configs, targets: [target, framework])
                 let project = try getProject(spec)
 
                 try expect(project.sharedData?.schemes.count) == 2
@@ -442,7 +442,7 @@ func projectGeneratorTests() {
                 var target = application
                 target.scheme = TargetScheme(environmentVariables: variables)
 
-                let spec = ProjectSpec(basePath: "", name: "test", targets: [target, framework])
+                let spec = ProjectSpec.Project(basePath: "", name: "test", targets: [target, framework])
                 let project = try getProject(spec)
 
                 try expect(project.sharedData?.schemes.count) == 1
@@ -513,7 +513,7 @@ func projectGeneratorTests() {
                 try createDirectories(directories)
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: ["Sources"])
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target])
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
 
                 let project = try getPbxProj(spec)
                 try project.expectFile(paths: ["Sources", "A", "a.swift"], buildPhase: .sources)
@@ -529,7 +529,7 @@ func projectGeneratorTests() {
                 try createDirectories(directories)
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: ["Sources"])
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target])
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
 
                 let project = try getPbxProj(spec)
                 guard let fileReference = project.objects.fileReferences.first(where: { $0.value.nameOrPath == "model.xcdatamodel" }) else {
@@ -557,7 +557,7 @@ func projectGeneratorTests() {
                 try createDirectories(directories)
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: ["Sources"])
-                let spec = ProjectSpec(
+                let spec = ProjectSpec.Project(
                     basePath: directoryPath,
                     name: "Test",
                     targets: [target],
@@ -583,7 +583,7 @@ func projectGeneratorTests() {
                     TargetSource(path: "Sources", name: "NewSource"),
                     TargetSource(path: "OtherSource/b.swift", name: "c.swift"),
                 ])
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target])
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
 
                 let project = try getPbxProj(spec)
                 try project.expectFile(paths: ["Sources", "a.swift"], names: ["NewSource", "a.swift"], buildPhase: .sources)
@@ -646,7 +646,7 @@ func projectGeneratorTests() {
                 ]
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: [TargetSource(path: "Sources", excludes: excludes)])
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target])
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
 
                 let project = try getPbxProj(spec)
                 try project.expectFile(paths: ["Sources", "A", "a.swift"])
@@ -688,7 +688,7 @@ func projectGeneratorTests() {
                     "Sources/A/Assets.xcassets",
                     "Sources/A/B/c.jpg",
                 ])
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target])
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
 
                 let project = try getPbxProj(spec)
                 try project.expectFile(paths: ["Sources/A", "a.swift"], names: ["A", "a.swift"], buildPhase: .sources)
@@ -710,7 +710,7 @@ func projectGeneratorTests() {
 
                 let target1 = Target(name: "Test1", type: .framework, platform: .iOS, sources: ["Sources"])
                 let target2 = Target(name: "Test2", type: .framework, platform: .tvOS, sources: ["Sources"])
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target1, target2])
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target1, target2])
 
                 _ = try getPbxProj(spec)
                 // TODO: check there are build files for both targets
@@ -736,8 +736,8 @@ func projectGeneratorTests() {
                     "Sources/F/G/h.swift",
                     "../OtherDirectory/C/D/e.swift",
                 ])
-                let options = ProjectSpec.Options(createIntermediateGroups: true)
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target], options: options)
+                let options = ProjectSpec.Project.Options(createIntermediateGroups: true)
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target], options: options)
 
                 let project = try getPbxProj(spec)
                 try project.expectFile(paths: ["Sources", "A", "b.swift"], buildPhase: .sources)
@@ -757,7 +757,7 @@ func projectGeneratorTests() {
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: [
                     TargetSource(path: "Sources/A", type: .folder),
                 ])
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target])
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
 
                 let project = try getPbxProj(spec)
                 try project.expectFile(paths: ["Sources/A"], names: ["A"], buildPhase: .resources)
@@ -807,7 +807,7 @@ func projectGeneratorTests() {
                     TargetSource(path: "B", buildPhase: .none),
                     TargetSource(path: "C", buildPhase: nil),
                 ])
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target])
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
 
                 let project = try getPbxProj(spec)
                 try project.expectFile(paths: ["A", "file.swift"], buildPhase: .resources)
@@ -859,7 +859,7 @@ func projectGeneratorTests() {
                     "Sources/A/a.swift",
                     "Sources/A/a.swift",
                 ])
-                let spec = ProjectSpec(basePath: directoryPath, name: "Test", targets: [target])
+                let spec = ProjectSpec.Project(basePath: directoryPath, name: "Test", targets: [target])
 
                 let project = try getPbxProj(spec)
                 try project.expectFile(paths: ["Sources/A", "a.swift"], names: ["A", "a.swift"], buildPhase: .sources)

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -27,7 +27,7 @@ func projectSpecTests() {
             settings: Settings(buildSettings: ["SETTING_2": "VALUE"])
         )
 
-        func expectValidationError(_ spec: ProjectSpec.Project, _ expectedError: SpecValidationError.ValidationError) throws {
+        func expectValidationError(_ spec: Project, _ expectedError: SpecValidationError.ValidationError) throws {
             do {
                 try spec.validate()
             } catch let error as SpecValidationError {
@@ -80,7 +80,7 @@ func projectSpecTests() {
 
         $0.describe("Validation") {
 
-            let baseSpec = ProjectSpec.Project(basePath: "", name: "", configs: [Config(name: "invalid")])
+            let baseSpec = Project(basePath: "", name: "", configs: [Config(name: "invalid")])
             let invalidSettings = Settings(
                 configSettings: ["invalidConfig": [:]],
                 groups: ["invalidSettingGroup"]
@@ -106,7 +106,7 @@ func projectSpecTests() {
 
             $0.it("allows non-existent configurations") {
                 var spec = baseSpec
-                spec.options = ProjectSpec.Project.Options(disabledValidations: [.missingConfigs])
+                spec.options = Project.Options(disabledValidations: [.missingConfigs])
                 let configPath = fixturePath + "test.xcconfig"
                 spec.configFiles = ["missingConfiguration": configPath.string]
                 try spec.validate()
@@ -170,7 +170,7 @@ func projectSpecTests() {
 
             $0.it("validates missing default configurations") {
                 var spec = baseSpec
-                spec.options = ProjectSpec.Options(defaultConfig: "foo")
+                spec.options = Project.Options(defaultConfig: "foo")
                 try expectValidationError(spec, .missingDefaultConfig(configName: "foo"))
             }
         }

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -27,7 +27,7 @@ func projectSpecTests() {
             settings: Settings(buildSettings: ["SETTING_2": "VALUE"])
         )
 
-        func expectValidationError(_ spec: ProjectSpec, _ expectedError: SpecValidationError.ValidationError) throws {
+        func expectValidationError(_ spec: ProjectSpec.Project, _ expectedError: SpecValidationError.ValidationError) throws {
             do {
                 try spec.validate()
             } catch let error as SpecValidationError {
@@ -80,7 +80,7 @@ func projectSpecTests() {
 
         $0.describe("Validation") {
 
-            let baseSpec = ProjectSpec(basePath: "", name: "", configs: [Config(name: "invalid")])
+            let baseSpec = ProjectSpec.Project(basePath: "", name: "", configs: [Config(name: "invalid")])
             let invalidSettings = Settings(
                 configSettings: ["invalidConfig": [:]],
                 groups: ["invalidSettingGroup"]
@@ -106,7 +106,7 @@ func projectSpecTests() {
 
             $0.it("allows non-existent configurations") {
                 var spec = baseSpec
-                spec.options = ProjectSpec.Options(disabledValidations: [.missingConfigs])
+                spec.options = ProjectSpec.Project.Options(disabledValidations: [.missingConfigs])
                 let configPath = fixturePath + "test.xcconfig"
                 spec.configFiles = ["missingConfiguration": configPath.string]
                 try spec.validate()

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -8,12 +8,12 @@ import xcproj
 func specLoadingTests() {
 
     @discardableResult
-    func getProjectSpec(_ spec: [String: Any]) throws -> ProjectSpec {
+    func getProjectSpec(_ spec: [String: Any]) throws -> ProjectSpec.Project {
         var specDictionary: [String: Any] = ["name": "test"]
         for (key, value) in spec {
             specDictionary[key] = value
         }
-        return try ProjectSpec(basePath: "", jsonDictionary: specDictionary)
+        return try ProjectSpec.Project(basePath: "", jsonDictionary: specDictionary)
     }
 
     func expectProjectSpecError(_ spec: [String: Any], _ expectedError: SpecParsingError) throws {
@@ -34,7 +34,7 @@ func specLoadingTests() {
     describe("Spec Loader") {
         $0.it("merges includes") {
             let path = fixturePath + "include_test.yml"
-            let spec = try ProjectSpec(path: path)
+            let spec = try ProjectSpec.Project(path: path)
 
             try expect(spec.name) == "NewName"
             try expect(spec.settingGroups) == [
@@ -80,7 +80,7 @@ func specLoadingTests() {
     describe("Spec Loader JSON") {
         $0.it("merges includes") {
             let path = fixturePath + "include_test.json"
-            let spec = try ProjectSpec(path: path)
+            let spec = try ProjectSpec.Project(path: path)
 
             try expect(spec.name) == "NewName"
             try expect(spec.settingGroups) == [
@@ -286,7 +286,7 @@ func specLoadingTests() {
         }
 
         $0.it("parses settings") {
-            let spec = try ProjectSpec(path: fixturePath + "settings_test.yml")
+            let spec = try ProjectSpec.Project(path: fixturePath + "settings_test.yml")
             let buildSettings: BuildSettings = ["SETTING": "value"]
             let configSettings: [String: Settings] = ["config1": Settings(buildSettings: ["SETTING1": "value"])]
             let groups = ["preset1"]
@@ -331,7 +331,7 @@ func specLoadingTests() {
         }
 
         $0.it("parses options") {
-            let options = ProjectSpec.Options(
+            let options = ProjectSpec.Project.Options(
                 carthageBuildPath: "../Carthage/Build",
                 carthageExecutablePath: "../bin/carthage",
                 createIntermediateGroups: true,
@@ -344,7 +344,7 @@ func specLoadingTests() {
                     macOS: "10.12.1"
                 )
             )
-            let expected = ProjectSpec(basePath: "", name: "test", options: options)
+            let expected = ProjectSpec.Project(basePath: "", name: "test", options: options)
             let dictionary: [String: Any] = ["options": [
                 "carthageBuildPath": "../Carthage/Build",
                 "carthageExecutablePath": "../bin/carthage",


### PR DESCRIPTION
I've started using the XcodeGen data structures in a large project, and
its been awesome so far!

The problem I'm running into is I can't import types from the
`ProjectSpec` module. This caused by a naming collision between the struct
`ProjectSpec` and the module `ProjectSpec`.

To remedy the issue, this patch renames the struct to `Project`. This is
an overall improvement, since all of the types are now nicely namespaced
and can be imported as expected.

i.e.
```
import ProjectSpec

let projectSpec: ProjectSpec.Project
let targetSpec: ProjectSpec.Target
```

This makes it easier to differentiate in the code when we are dealing
with types of similar names, like `PBXProject`.

Any feedback is welcome 👍 