### PR TITLE
Allow allocation of LegacyTarget

### DIFF
--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -7,6 +7,18 @@ public struct LegacyTarget {
     public var arguments: String?
     public var passSettings: Bool
     public var workingDirectory: String?
+
+    public init(
+        toolPath: String,
+        passSettings: Bool = false,
+        arguments: String? = nil,
+        workingDirectory: String? = nil
+    ) {
+        self.toolPath = toolPath
+        self.arguments = arguments
+        self.passSettings = passSettings
+        self.workingDirectory = workingDirectory
+    }
 }
 
 extension LegacyTarget: Equatable {


### PR DESCRIPTION
I'm now using XcodeGen data structures directly, which is awesome.

I need to allocate `LegacyTarget` in my code, so this method makes it
public.