### PR TITLE
Add defaultConfigurationName to options

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -80,6 +80,7 @@ Note that target names can also be changed by adding a `name` property to a targ
 - [ ] **deploymentTarget**: **[[Platform](#platform): String]** - A project wide deployment target can be specified for each platform otherwise the default SDK version in Xcode will be used. This will be overridden by any custom build settings that set the deployment target eg `IPHONEOS_DEPLOYMENT_TARGET`. Target specific deployment targets can also be set with [Target](#target).deploymentTarget.
 - [ ] **disabledValidations**: **[String]** - A list of validations that can be disabled if they're too strict for your use case. By default this is set to an empty array. Currently these are the available options:
   - `missingConfigs`: Disable errors for configurations in yaml files that don't exist in the project itself. This can be useful if you include the same yaml file in different projects
+- [ ] **defaultConfigurationName**: **String** - The default configuration for command line builds from Xcode. If the configuration provided here doesn't match one in your [configs](#configs) key, XcodeGen will fail. If you don't set this, the first configuration alphabetically will be chosen.
 
 ```yaml
 options:

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -80,7 +80,7 @@ Note that target names can also be changed by adding a `name` property to a targ
 - [ ] **deploymentTarget**: **[[Platform](#platform): String]** - A project wide deployment target can be specified for each platform otherwise the default SDK version in Xcode will be used. This will be overridden by any custom build settings that set the deployment target eg `IPHONEOS_DEPLOYMENT_TARGET`. Target specific deployment targets can also be set with [Target](#target).deploymentTarget.
 - [ ] **disabledValidations**: **[String]** - A list of validations that can be disabled if they're too strict for your use case. By default this is set to an empty array. Currently these are the available options:
   - `missingConfigs`: Disable errors for configurations in yaml files that don't exist in the project itself. This can be useful if you include the same yaml file in different projects
-- [ ] **defaultConfigurationName**: **String** - The default configuration for command line builds from Xcode. If the configuration provided here doesn't match one in your [configs](#configs) key, XcodeGen will fail. If you don't set this, the first configuration alphabetically will be chosen.
+- [ ] **defaultConfig**: **String** - The default configuration for command line builds from Xcode. If the configuration provided here doesn't match one in your [configs](#configs) key, XcodeGen will fail. If you don't set this, the first configuration alphabetically will be chosen.
 
 ```yaml
 options:

--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -32,6 +32,7 @@ public struct ProjectSpec {
         public var indentWidth: UInt?
         public var xcodeVersion: String?
         public var deploymentTarget: DeploymentTarget
+        public var defaultConfigurationName: String?
 
         public enum SettingPresets: String {
             case all
@@ -66,7 +67,8 @@ public struct ProjectSpec {
             usesTabs: Bool? = nil,
             xcodeVersion: String? = nil,
             deploymentTarget: DeploymentTarget = .init(),
-            disabledValidations: [ValidationType] = []
+            disabledValidations: [ValidationType] = [],
+            defaultConfigurationName: String? = nil
         ) {
             self.carthageBuildPath = carthageBuildPath
             self.carthageExecutablePath = carthageExecutablePath
@@ -80,6 +82,7 @@ public struct ProjectSpec {
             self.xcodeVersion = xcodeVersion
             self.deploymentTarget = deploymentTarget
             self.disabledValidations = disabledValidations
+            self.defaultConfigurationName = defaultConfigurationName
         }
 
         public static func == (lhs: ProjectSpec.Options, rhs: ProjectSpec.Options) -> Bool {
@@ -217,5 +220,6 @@ extension ProjectSpec.Options: JSONObjectConvertible {
         tabWidth = (jsonDictionary.json(atKeyPath: "tabWidth") as Int?).flatMap(UInt.init)
         deploymentTarget = jsonDictionary.json(atKeyPath: "deploymentTarget") ?? DeploymentTarget()
         disabledValidations = jsonDictionary.json(atKeyPath: "disabledValidations") ?? []
+        defaultConfigurationName = jsonDictionary.json(atKeyPath: "defaultConfigurationName")
     }
 }

--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -32,7 +32,7 @@ public struct ProjectSpec {
         public var indentWidth: UInt?
         public var xcodeVersion: String?
         public var deploymentTarget: DeploymentTarget
-        public var defaultConfigurationName: String?
+        public var defaultConfig: String?
 
         public enum SettingPresets: String {
             case all
@@ -68,7 +68,7 @@ public struct ProjectSpec {
             xcodeVersion: String? = nil,
             deploymentTarget: DeploymentTarget = .init(),
             disabledValidations: [ValidationType] = [],
-            defaultConfigurationName: String? = nil
+            defaultConfig: String? = nil
         ) {
             self.carthageBuildPath = carthageBuildPath
             self.carthageExecutablePath = carthageExecutablePath
@@ -82,7 +82,7 @@ public struct ProjectSpec {
             self.xcodeVersion = xcodeVersion
             self.deploymentTarget = deploymentTarget
             self.disabledValidations = disabledValidations
-            self.defaultConfigurationName = defaultConfigurationName
+            self.defaultConfig = defaultConfig
         }
 
         public static func == (lhs: ProjectSpec.Options, rhs: ProjectSpec.Options) -> Bool {
@@ -220,6 +220,6 @@ extension ProjectSpec.Options: JSONObjectConvertible {
         tabWidth = (jsonDictionary.json(atKeyPath: "tabWidth") as Int?).flatMap(UInt.init)
         deploymentTarget = jsonDictionary.json(atKeyPath: "deploymentTarget") ?? DeploymentTarget()
         disabledValidations = jsonDictionary.json(atKeyPath: "disabledValidations") ?? []
-        defaultConfigurationName = jsonDictionary.json(atKeyPath: "defaultConfigurationName")
+        defaultConfig = jsonDictionary.json(atKeyPath: "defaultConfig")
     }
 }

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -47,6 +47,12 @@ extension ProjectSpec {
             }
         }
 
+        if let configName = options.defaultConfigurationName {
+            if !configs.contains(where: { $0.name == configName }) {
+                errors.append(.missingDefaultConfigurationName(configName: configName))
+            }
+        }
+
         for settings in settingGroups.values {
             errors += validateSettings(settings)
         }

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -47,9 +47,9 @@ extension ProjectSpec {
             }
         }
 
-        if let configName = options.defaultConfigurationName {
+        if let configName = options.defaultConfig {
             if !configs.contains(where: { $0.name == configName }) {
-                errors.append(.missingDefaultConfigurationName(configName: configName))
+                errors.append(.missingDefaultConfig(configName: configName))
             }
         }
 

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -19,6 +19,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidFileGroup(String)
         case invalidConfigFileConfig(String)
         case missingConfigForTargetScheme(target: String, configType: ConfigType)
+        case missingDefaultConfigurationName(configName: String)
 
         public var description: String {
             switch self {
@@ -50,6 +51,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Config file has invalid config \(config.quoted)"
             case let .missingConfigForTargetScheme(target, configType):
                 return "Target \(target.quoted) is missing a config of type \(configType.rawValue) to generate its scheme"
+            case let .missingDefaultConfigurationName(name):
+                return "Default configuration \(name) doesn't exist"
             }
         }
     }

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -19,7 +19,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidFileGroup(String)
         case invalidConfigFileConfig(String)
         case missingConfigForTargetScheme(target: String, configType: ConfigType)
-        case missingDefaultConfigurationName(configName: String)
+        case missingDefaultConfig(configName: String)
 
         public var description: String {
             switch self {
@@ -51,7 +51,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Config file has invalid config \(config.quoted)"
             case let .missingConfigForTargetScheme(target, configType):
                 return "Target \(target.quoted) is missing a config of type \(configType.rawValue) to generate its scheme"
-            case let .missingDefaultConfigurationName(name):
+            case let .missingDefaultConfig(name):
                 return "Default configuration \(name) doesn't exist"
             }
         }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -70,7 +70,7 @@ public class PBXProjGenerator {
             )
         }
 
-        let configName = spec.options.defaultConfigurationName ?? buildConfigs.first?.object.name ?? ""
+        let configName = spec.options.defaultConfig ?? buildConfigs.first?.object.name ?? ""
         let buildConfigList = createObject(
             id: spec.name,
             XCConfigurationList(

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -70,11 +70,12 @@ public class PBXProjGenerator {
             )
         }
 
+        let configName = spec.options.defaultConfigurationName ?? buildConfigs.first?.object.name ?? ""
         let buildConfigList = createObject(
             id: spec.name,
             XCConfigurationList(
                 buildConfigurations: buildConfigs.map { $0.reference },
-                defaultConfigurationName: buildConfigs.first?.object.name ?? ""
+                defaultConfigurationName: configName
             )
         )
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -98,7 +98,7 @@ func projectGeneratorTests() {
             }
 
             $0.it("uses the default configuration name") {
-                let options = ProjectSpec.Options(defaultConfigurationName: "Bconfig")
+                let options = ProjectSpec.Options(defaultConfig: "Bconfig")
                 let spec = ProjectSpec(basePath: "", name: "test", configs: [Config(name: "Aconfig"), Config(name: "Bconfig")], targets: [framework], options: options)
                 let pbxProject = try getPbxProj(spec)
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -96,6 +96,20 @@ func projectGeneratorTests() {
                     try expect(XCodeVersion.parse(version)) == expected
                 }
             }
+
+            $0.it("uses the default configuration name") {
+                let options = ProjectSpec.Options(defaultConfigurationName: "Bconfig")
+                let spec = ProjectSpec(basePath: "", name: "test", configs: [Config(name: "Aconfig"), Config(name: "Bconfig")], targets: [framework], options: options)
+                let pbxProject = try getPbxProj(spec)
+
+                guard let projectConfigListReference = pbxProject.objects.projects.values.first?.buildConfigurationList,
+                    let defaultConfigurationName = pbxProject.objects.configurationLists[projectConfigListReference]?.defaultConfigurationName
+                else {
+                    throw failure("Default configuration name not found")
+                }
+
+                try expect(defaultConfigurationName) == "Bconfig"
+            }
         }
 
         $0.describe("Config") {

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -170,8 +170,8 @@ func projectSpecTests() {
 
             $0.it("validates missing default configurations") {
                 var spec = baseSpec
-                spec.options = ProjectSpec.Options(defaultConfigurationName: "foo")
-                try expectValidationError(spec, .missingDefaultConfigurationName(configName: "foo"))
+                spec.options = ProjectSpec.Options(defaultConfig: "foo")
+                try expectValidationError(spec, .missingDefaultConfig(configName: "foo"))
             }
         }
     }

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -167,6 +167,12 @@ func projectSpecTests() {
                 )]
                 try spec.validate()
             }
+
+            $0.it("validates missing default configurations") {
+                var spec = baseSpec
+                spec.options = ProjectSpec.Options(defaultConfigurationName: "foo")
+                try expectValidationError(spec, .missingDefaultConfigurationName(configName: "foo"))
+            }
         }
     }
 }


### PR DESCRIPTION
This allows users to set the defaultConfigurationName project wide. This
setting corresponds to the drop down in the project settings that says
"Use CONFIG for command line builds". This affects which configuration
Xcode looks in for some settings, even if you pass `-configuration FOO`.