### PR TITLE
Add LD_RUNPATH_SEARCH_PATHS to app-extension preset

### DIFF
--- a/SettingPresets/Products/app-extension.yml
+++ b/SettingPresets/Products/app-extension.yml
@@ -1,0 +1,1 @@
+LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"


### PR DESCRIPTION
This was added to the iMessage extensions, but it seems that it's required for an action extension to work as well.