### PR TITLE
Automatically set DevelopmentTeam and ProvisioningStyle TargetAttributes

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -165,7 +165,10 @@ Settings are merged in the following order: groups, base, configs.
 - [ ] **dependencies**: **[[Dependency](#dependency)]** - Dependencies for the target
 - [ ] **scheme**: **[Target Scheme](#target-scheme)** - Generated scheme with tests or config variants
 - [ ] **legacy**: **[Legacy Target](#legacy-target)** - When present, opt-in to make an Xcode "External Build System" legacy target instead.
-- [ ] **attributes**: **[String: Any]** - This sets values in the project `TargetAttributes`. It is merged with `attributes` from the project and anything automatically added by XcodeGen, with any duplicate values being override by values specified here. This is for advanced use only.
+- [ ] **attributes**: **[String: Any]** - This sets values in the project `TargetAttributes`. It is merged with `attributes` from the project and anything automatically added by XcodeGen, with any duplicate values being override by values specified here. This is for advanced use only. Properties that are already set include:
+	- `DevelopmentTeam`: if all configurations have the same `DEVELOPMENT_TEAM` setting
+	- `ProvisioningStyle`: if all configurations have the same `CODE_SIGN_STYLE` setting
+	- `TestTargetID`: if all configurations have the same `TEST_TARGET_NAME` setting
 
 ### Product Type
 

--- a/Sources/ProjectSpec/Settings.swift
+++ b/Sources/ProjectSpec/Settings.swift
@@ -5,9 +5,9 @@ import xcproj
 
 public struct Settings: Equatable, JSONObjectConvertible, CustomStringConvertible {
 
-    public let buildSettings: BuildSettings
-    public let configSettings: [String: Settings]
-    public let groups: [String]
+    public var buildSettings: BuildSettings
+    public var configSettings: [String: Settings]
+    public var groups: [String]
 
     public init(buildSettings: BuildSettings = [:], configSettings: [String: Settings] = [:], groups: [String] = []) {
         self.buildSettings = buildSettings

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -209,10 +209,11 @@ func projectGeneratorTests() {
 
             $0.it("generates target attributes") {
                 var appTargetWithAttributes = application
+                appTargetWithAttributes.settings.buildSettings["DEVELOPMENT_TEAM"] = "123"
                 appTargetWithAttributes.attributes = ["ProvisioningStyle": "Automatic"]
                 
                 var testTargetWithAttributes = uiTest
-                testTargetWithAttributes.attributes = ["ProvisioningStyle": "Manual"]
+                testTargetWithAttributes.settings.buildSettings["CODE_SIGN_STYLE"] = "Manual"
                 var spec = ProjectSpec(basePath: "", name: "test", targets: [appTargetWithAttributes, framework, testTargetWithAttributes])
                 let pbxProject = try getPbxProj(spec)
 
@@ -231,6 +232,7 @@ func projectGeneratorTests() {
                 try expect(targetAttributes[uiTestTarget.reference]?["TestTargetID"] as? String) == appTarget.reference
                 try expect(targetAttributes[uiTestTarget.reference]?["ProvisioningStyle"] as? String) == "Manual"
                 try expect(targetAttributes[appTarget.reference]?["ProvisioningStyle"] as? String) == "Automatic"
+                try expect(targetAttributes[appTarget.reference]?["DevelopmentTeam"] as? String) == "123"
             }
 
             $0.it("generates platform version") {


### PR DESCRIPTION
This automatically sets `DevelopmentTeam` and `ProvisioningStyle` within the project `TargetAtributes` if their relevant build settings have the same value in all configurations.

This fixes an issue with Bitrise expecting `TargetAttributes` to define code signing style instead of build settings bitrise-steplib/steps-ios-auto-provision#21