### PR TITLE
Update Yams to fix quoted values

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "de06b2c819bb12e95bcdf75075b3336a8890e67c",
-          "version": "0.6.0"
+          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
+          "version": "0.7.0"
         }
       },
       {

--- a/Tests/Fixtures/yaml.yml
+++ b/Tests/Fixtures/yaml.yml
@@ -7,7 +7,7 @@ noQuote: "NO"
 int: 1
 intQuote: "1"
 float: 3.2
-floatQuote: !!str "10.10"
+floatQuote: "10.10"
 string: hello
 stringQuote: "hello"
 space: " "

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -56,10 +56,10 @@ func specLoadingTests() {
                 "false": false,
                 "yes": true,
                 "no": false,
-                "yesQuote": true,
-                "noQuote": false,
+                "yesQuote": "YES",
+                "noQuote": "NO",
                 "int": 1,
-                "intQuote": 1,
+                "intQuote": "1",
                 "float": 3.2,
                 "floatQuote": "10.10",
                 "string": "hello",
@@ -71,9 +71,16 @@ func specLoadingTests() {
                 "arrayLiteral": [1, 2],
                 "arrayList": [1, 2],
             ]
-
+            for (key, expectedValue) in expectedDictionary {
+                guard let parsedValue = dictionary[key] else {
+                    throw failure("\(key) does not exist")
+                }
+                if String(describing: expectedValue) != String(describing: parsedValue) {
+                    throw failure("\(key): \(parsedValue) does not equal \(expectedValue)")
+                }
+            }
             if !(dictionary as NSDictionary).isEqual(expectedDictionary) {
-                throw failure("parsed yaml types don't match")
+                throw failure("parsed yaml types don't match:\n\nParsed:\n\t\(dictionary.map { "\($0.key): \($0.value)" }.joined(separator: "\n\t"))\nExpected:\n\t\(expectedDictionary.map { "\($0.key): \($0.value)" }.joined(separator: "\n\t"))")
             }
         }
     }


### PR DESCRIPTION
If a value is in quotes it will now be parsed as a string:
```
bool: YES // true
boolString: "YES" // "YES"
floatString: "10.10" // "10.10
```
Fixes #268
Fixes #253 in another way