### PR TITLE
Added workaround for brew & Xcode 9.3 compatibility

### DIFF
--- a/Formula/xcodegen.rb
+++ b/Formula/xcodegen.rb
@@ -8,7 +8,26 @@ class Xcodegen < Formula
   depends_on :xcode
 
   def install
+    # libxml2 has to be included in ISYSTEM_PATH for building one of
+    # dependencies. It didn't happen automatically before Xcode 9.3
+    # so homebrew patched environment variable to get it work.
+    # But since Xcode 9.3 includes it already, the build will fail
+    # because of redefinition of libxml2 module.
+    # It's a bug of homebrew but before it's fixed, it's easier
+    # to provide in-place workaround for now.
+    # Please remove this once homebrew is patched.
+
+    # step 1: capture old value and patch environment
+    if OS::Mac::Xcode.version >= Version.new("9.3") then
+      old_isystem_paths = ENV["HOMEBREW_ISYSTEM_PATHS"]
+      ENV["HOMEBREW_ISYSTEM_PATHS"] = old_isystem_paths.gsub("/usr/include/libxml2", "")
+    end
+
+    # step 2: usual build
     system "make", "install", "PREFIX=#{prefix}"
+
+    # step 3: restoring environment to pristine state
+    ENV["HOMEBREW_ISYSTEM_PATHS"] = old_isystem_paths if defined? old_isystem_paths
   end
 
   test do


### PR DESCRIPTION
`libxml2` has to be included in `ISYSTEM_PATH` for building one of
dependencies. It didn't happen automatically before Xcode 9.3
so `homebrew` patched environment variable to get it work.

But since Xcode 9.3 includes it already, the build will fail
because of redefinition of `libxml2` module.

It's a bug of `homebrew` but before it's fixed, it's easier
to provide in-place workaround for now.

Fixes #283