### PR TITLE
Remove file/product reference for legacy targets

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -129,22 +129,24 @@ public class PBXProjGenerator {
                 lastKnownFileType = fileType
             }
 
-            let fileReference = createObject(
-                id: target.name,
-                PBXFileReference(
-                    sourceTree: .buildProductsDir,
-                    explicitFileType: explicitFileType,
-                    lastKnownFileType: lastKnownFileType,
-                    path: target.filename,
-                    includeInIndex: false
+            if !target.isLegacy {
+                let fileReference = createObject(
+                    id: target.name,
+                    PBXFileReference(
+                        sourceTree: .buildProductsDir,
+                        explicitFileType: explicitFileType,
+                        lastKnownFileType: lastKnownFileType,
+                        path: target.filename,
+                        includeInIndex: false
+                    )
                 )
-            )
 
-            targetFileReferences[target.name] = fileReference.reference
-            targetBuildFiles[target.name] = createObject(
-                id: fileReference.reference,
-                PBXBuildFile(fileRef: fileReference.reference)
-            )
+                targetFileReferences[target.name] = fileReference.reference
+                targetBuildFiles[target.name] = createObject(
+                    id: fileReference.reference,
+                      PBXBuildFile(fileRef: fileReference.reference)
+                )
+            }
         }
 
         try project.targets.forEach(generateTarget)
@@ -507,7 +509,7 @@ public class PBXProjGenerator {
             }
         }
 
-        let fileReference = targetFileReferences[target.name]!
+        let fileReference = targetFileReferences[target.name]
         var buildPhases: [String] = []
 
         func getBuildFilesForPhase(_ buildPhase: BuildPhase) -> [String] {

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		BF_130062884703 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_257516580010 /* Alamofire.framework */; };
 		BF_138356261076 /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_363921640403 /* InterfaceController.swift */; };
-		BF_164567025213 = {isa = PBXBuildFile; fileRef = FR_479264660374 /* Legacy */; };
 		BF_167705969896 /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_145531354566 /* TestProjectUITests.swift */; };
 		BF_186245454304 /* LocalizedStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_118219888726 /* LocalizedStoryboard.storyboard */; };
 		BF_206432481076 /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_340586388409 /* ExtensionDelegate.swift */; };
@@ -159,7 +158,6 @@
 		FR_452853029807 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
 		FR_472296042419 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_473000061463 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_479264660374 /* Legacy */ = {isa = PBXFileReference; includeInIndex = 0; path = Legacy; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_479281060337 /* Folder */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Folder; sourceTree = SOURCE_ROOT; };
 		FR_481575785861 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		FR_500792082643 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LocalizedStoryboard.strings; sourceTree = "<group>"; };
@@ -437,7 +435,6 @@
 				FR_438704538506 /* Framework.framework */,
 				FR_525119120469 /* Framework.framework */,
 				FR_472296042419 /* Framework.framework */,
-				FR_479264660374 /* Legacy */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -503,7 +500,6 @@
 			name = Legacy;
 			passBuildSettingsInEnvironment = 1;
 			productName = Legacy;
-			productReference = FR_479264660374 /* Legacy */;
 		};
 /* End PBXLegacyTarget section */
 


### PR DESCRIPTION
Apparently legacy targets created by Xcode do not have a file or product reference. Xcodeproj is unable to parse legacy targets generated with XcodeGen with the following error message:

`Xcodeproj doesn't know about the following attributes {"productReference"=>"FR_184465694726"} for the 'PBXLegacyTarget' isa.`

This commit removes file and product references for legacy targets.