### PR TITLE
Improve Carthage dependency lookup performance

### DIFF
--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -8,7 +8,11 @@ public struct Project {
 
     public var basePath: Path
     public var name: String
-    public var targets: [Target]
+    public var targets: [Target] {
+        didSet {
+            self.targetsMap = Dictionary(uniqueKeysWithValues: self.targets.map { ($0.name, $0) })
+        }
+    }
     public var settings: Settings
     public var settingGroups: [String: Settings]
     public var configs: [Config]

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -18,6 +18,7 @@ public struct Project {
     public var fileGroups: [String]
     public var configFiles: [String: String]
     public var include: [String] = []
+    private var targetsMap: [String: Target]
 
     public init(
         basePath: Path,
@@ -35,6 +36,7 @@ public struct Project {
         self.basePath = basePath
         self.name = name
         self.targets = targets
+        self.targetsMap = Dictionary(uniqueKeysWithValues: self.targets.map { ($0.name, $0) })
         self.configs = configs
         self.settings = settings
         self.settingGroups = settingGroups
@@ -46,7 +48,7 @@ public struct Project {
     }
 
     public func getTarget(_ targetName: String) -> Target? {
-        return targets.first { $0.name == targetName }
+        return targetsMap[targetName]
     }
 
     public func getConfig(_ configName: String) -> Config? {
@@ -117,6 +119,7 @@ extension Project {
         } else {
             options = SpecOptions()
         }
+        self.targetsMap = Dictionary(uniqueKeysWithValues: self.targets.map { ($0.name, $0) })
     }
 
     static func filterJSON(jsonDictionary: JSONDictionary) throws -> JSONDictionary {


### PR DESCRIPTION
Previously for large projects, project generation time could be up to 40 seconds in our testing because of lookup up Carthage dependencies (regardless of if you have any). This change improves the performance of this with 2 changes.

1. Store a dictionary of target name -> target. This allows much faster lookups than the previous O(n) array lookup (this should also improve performance of other callers of `getTarget`
2. Remove the recursively lookups of carthage dependencies. Previously this traversed your entire dependency tree for each target. Now we iteratively discover the dependencies, while still only visiting them once.