### PR TITLE
Always generate Sources build phase

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -549,10 +549,8 @@ public class PBXProjGenerator {
         try target.prebuildScripts.forEach(generateBuildScript)
 
         let sourcesBuildPhaseFiles = getBuildFilesForPhase(.sources)
-        if !sourcesBuildPhaseFiles.isEmpty {
-            let sourcesBuildPhase = createObject(id: target.name, PBXSourcesBuildPhase(files: sourcesBuildPhaseFiles))
-            buildPhases.append(sourcesBuildPhase.reference)
-        }
+        let sourcesBuildPhase = createObject(id: target.name, PBXSourcesBuildPhase(files: sourcesBuildPhaseFiles))
+        buildPhases.append(sourcesBuildPhase.reference)
 
         let resourcesBuildPhaseFiles = getBuildFilesForPhase(.resources) + copyResourcesReferences
         if !resourcesBuildPhaseFiles.isEmpty {

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -496,6 +496,7 @@
 			isa = PBXLegacyTarget;
 			buildConfigurationList = CL_479264660374 /* Build configuration list for PBXLegacyTarget "Legacy" */;
 			buildPhases = (
+				SBP_47926466037 /* Sources */,
 			);
 			buildToolPath = /usr/bin/true;
 			dependencies = (
@@ -529,6 +530,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CL_324671077936 /* Build configuration list for PBXNativeTarget "App_watchOS" */;
 			buildPhases = (
+				SBP_32467107793 /* Sources */,
 				RBP_32467107793 /* Resources */,
 				CFBP_4684049960 /* CopyFiles */,
 				SSBP_5954948530 /* Carthage */,
@@ -911,6 +913,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		SBP_32467107793 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		SBP_43870453850 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -924,6 +933,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF_456457948943 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_47926466037 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -281,7 +281,7 @@ func projectGeneratorTests() {
                 let pbxProject = try getPbxProj(scriptSpec)
 
                 guard let nativeTarget = pbxProject.objects.nativeTargets.referenceValues
-                    .first(where: { !$0.buildPhases.isEmpty }) else {
+                    .first(where: { $0.buildPhases.count >= 2 }) else {
                     throw failure("Target with build phases not found")
                 }
                 let buildPhases = nativeTarget.buildPhases


### PR DESCRIPTION
This generates a Compile Sources build phase even if there are not source files in the target.
This fixes rare cases where a target doesn't have a Compile Sources build phases and linking fails in Xcode