### PR TITLE
Support frameworks in source paths

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -587,6 +587,7 @@ public class PBXProjGenerator {
             buildPhases.append(copyFilesPhase.reference)
         }
 
+        copyFrameworksReferences += getBuildFilesForPhase(.frameworks)
         if !copyFrameworksReferences.isEmpty {
 
             let copyFilesPhase = createObject(

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -164,6 +164,7 @@ class SourceGenerator {
             switch fileExtension {
             case "swift", "m", "mm", "cpp", "c", "S", "xcdatamodeld": return .sources
             case "h", "hh", "hpp", "ipp", "tpp", "hxx", "def": return .headers
+            case "framework": return .frameworks
             case "xcconfig", "entitlements", "gpx", "lproj", "apns": return nil
             default: return .resources
             }


### PR DESCRIPTION
This adds support for users passing pre-compiled frameworks in as a
source file of a target, and correctly adding it to the copy frameworks
build phase. Previously it would be added to the copy resources build
phase.