### PR TITLE
Fix excluding directories that have sub-directories

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -241,7 +241,7 @@ class SourceGenerator {
                             return [$0]
                         }
 
-                        return (try? $0.recursiveChildren().filter { $0.isFile }) ?? []
+                        return (try? $0.recursiveChildren()) ?? []
                     }
                     .reduce([], +)
             }

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -206,6 +206,10 @@ class SourceGeneratorTests: XCTestCase {
                   - a.ignored
                   - project.xcodeproj:
                     - project.pbxproj
+                  - a.playground:
+                    - Sources:
+                      - a.swift
+                    - Resources
                 """
                 try createDirectories(directories)
 
@@ -220,6 +224,7 @@ class SourceGeneratorTests: XCTestCase {
                     "ignore.file",
                     "*.ignored",
                     "*.xcodeproj",
+                    "*.playground",
                     // not supported
                     // "**/*.ignored",
                 ]
@@ -248,6 +253,10 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFileMissing(paths: ["Sources", "a.ignored"])
                 try pbxProj.expectFileMissing(paths: ["Sources", "ignore.file"])
                 try pbxProj.expectFileMissing(paths: ["Sources", "project.xcodeproj"])
+                try pbxProj.expectFileMissing(paths: ["Sources", "a.playground"])
+                // not supported: "**/*.ignored"
+                // try pbxProj.expectFileMissing(paths: ["Sources", "A", "a.ignored"])
+                // try pbxProj.expectFileMissing(paths: ["Sources", "A", "B", "b.ignored"])
             }
 
             $0.it("generates file sources") {


### PR DESCRIPTION
Without this change

https://github.com/brentleyjones/XcodeGen/blob/fix-excludes/Sources/XcodeGenKit/SourceGenerator.swift#L259-L264

would return `true` because `children` would always have all of the directories under any directory.

This would mean that even if we intended to exclude the directory it wouldn't be excluded. All of the files under it would, which normally is fine, but when the directories under it are seen as files (Playgrounds, Asset Catalogs, Bundles) those would end up not being excluded.