### PR TITLE
Transitively embed dependencies

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -85,6 +85,7 @@ Note that target names can also be changed by adding a `name` property to a targ
 - [ ] **disabledValidations**: **[String]** - A list of validations that can be disabled if they're too strict for your use case. By default this is set to an empty array. Currently these are the available options:
   - `missingConfigs`: Disable errors for configurations in yaml files that don't exist in the project itself. This can be useful if you include the same yaml file in different projects
 - [ ] **defaultConfig**: **String** - The default configuration for command line builds from Xcode. If the configuration provided here doesn't match one in your [configs](#configs) key, XcodeGen will fail. If you don't set this, the first configuration alphabetically will be chosen.
+- [ ] **transientlyLinkDependencies**: **Bool** - If this is `true` then targets will link to the dependencies of their target dependencies. If a target should embed its dependencies, such as application and test bundles, it will embed these transient dependencies as well. Some complex setups might want to set this to `false` and explicitly specify dependencies at every level. Targets can override this with [Target](#target).transientlyLinkDependencies. Defaults to `true`.
 
 ```yaml
 options:
@@ -162,6 +163,7 @@ Settings are merged in the following order: groups, base, configs.
 	- `INFOPLIST_FILE`: If it doesn't exist your sources will be searched for `Info.plist` files and the first one found will be used for this setting
 	- `FRAMEWORK_SEARCH_PATHS`: If carthage dependencies are used, the platform build path will be added to this setting
 - [ ] **dependencies**: **[[Dependency](#dependency)]** - Dependencies for the target
+- [ ] **transientlyLinkDependencies**: **Bool** - If this is not specified the value from the project set in [Options](#options)`.transientlyLinkDependencies` will be used.
 - [ ] **prebuildScripts**: **[[Build Script](#build-script)]** - Build scripts that run *before* any other build phases
 - [ ] **postbuildScripts**: **[[Build Script](#build-script)]** - Build scripts that run *after* any other build phases
 - [ ] **buildRules**: **[[Build Rule](#build-rule)]** - Custom build rules

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -17,6 +17,7 @@ public struct SpecOptions: Equatable {
     public var xcodeVersion: String?
     public var deploymentTarget: DeploymentTarget
     public var defaultConfig: String?
+    public var transientlyLinkDependencies: Bool
 
     public enum ValidationType: String {
         case missingConfigs
@@ -56,7 +57,8 @@ public struct SpecOptions: Equatable {
         xcodeVersion: String? = nil,
         deploymentTarget: DeploymentTarget = .init(),
         disabledValidations: [ValidationType] = [],
-        defaultConfig: String? = nil
+        defaultConfig: String? = nil,
+        transientlyLinkDependencies: Bool = true
     ) {
         self.carthageBuildPath = carthageBuildPath
         self.carthageExecutablePath = carthageExecutablePath
@@ -71,6 +73,7 @@ public struct SpecOptions: Equatable {
         self.deploymentTarget = deploymentTarget
         self.disabledValidations = disabledValidations
         self.defaultConfig = defaultConfig
+        self.transientlyLinkDependencies = transientlyLinkDependencies
     }
 }
 
@@ -89,5 +92,6 @@ extension SpecOptions: JSONObjectConvertible {
         deploymentTarget = jsonDictionary.json(atKeyPath: "deploymentTarget") ?? DeploymentTarget()
         disabledValidations = jsonDictionary.json(atKeyPath: "disabledValidations") ?? []
         defaultConfig = jsonDictionary.json(atKeyPath: "defaultConfig")
+        transientlyLinkDependencies = jsonDictionary.json(atKeyPath: "transientlyLinkDependencies") ?? true
     }
 }

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -28,6 +28,7 @@ public struct Target {
     public var settings: Settings
     public var sources: [TargetSource]
     public var dependencies: [Dependency]
+    public var transientlyLinkDependencies: Bool?
     public var prebuildScripts: [BuildScript]
     public var postbuildScripts: [BuildScript]
     public var buildRules: [BuildRule]
@@ -59,6 +60,7 @@ public struct Target {
         configFiles: [String: String] = [:],
         sources: [TargetSource] = [],
         dependencies: [Dependency] = [],
+        transientlyLinkDependencies: Bool? = nil,
         prebuildScripts: [BuildScript] = [],
         postbuildScripts: [BuildScript] = [],
         buildRules: [BuildRule] = [],
@@ -74,6 +76,7 @@ public struct Target {
         self.configFiles = configFiles
         self.sources = sources
         self.dependencies = dependencies
+        self.transientlyLinkDependencies = transientlyLinkDependencies
         self.prebuildScripts = prebuildScripts
         self.postbuildScripts = postbuildScripts
         self.buildRules = buildRules
@@ -165,6 +168,7 @@ extension Target: Equatable {
             lhs.type == rhs.type &&
             lhs.platform == rhs.platform &&
             lhs.deploymentTarget == rhs.deploymentTarget &&
+            lhs.transientlyLinkDependencies == rhs.transientlyLinkDependencies &&
             lhs.settings == rhs.settings &&
             lhs.configFiles == rhs.configFiles &&
             lhs.sources == rhs.sources &&
@@ -277,6 +281,8 @@ extension Target: NamedJSONDictionaryConvertible {
         } else {
             dependencies = try jsonDictionary.json(atKeyPath: "dependencies", invalidItemBehaviour: .fail)
         }
+        transientlyLinkDependencies = jsonDictionary.json(atKeyPath: "transientlyLinkDependencies")
+        
         prebuildScripts = jsonDictionary.json(atKeyPath: "prebuildScripts") ?? []
         postbuildScripts = jsonDictionary.json(atKeyPath: "postbuildScripts") ?? []
         buildRules = jsonDictionary.json(atKeyPath: "buildRules") ?? []

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -391,9 +391,10 @@ public class PBXProjGenerator {
         var copyWatchReferences: [String] = []
         var extensions: [String] = []
         
-        let dependenciesAndTransient = getAllDependenciesPlusTransientNeedingEmbedding(target: target)
+        let targetDependencies = (target.transientlyLinkDependencies ?? project.options.transientlyLinkDependencies) ?
+            getAllDependenciesPlusTransientNeedingEmbedding(target: target) : target.dependencies
 
-        for dependency in dependenciesAndTransient {
+        for dependency in targetDependencies {
 
             var embedAttributes: [String] = []
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -390,8 +390,10 @@ public class PBXProjGenerator {
         var copyResourcesReferences: [String] = []
         var copyWatchReferences: [String] = []
         var extensions: [String] = []
+        
+        let dependenciesAndTransient = getAllDependenciesPlusTransientNeedingEmbedding(target: target)
 
-        for dependency in target.dependencies {
+        for dependency in dependenciesAndTransient {
 
             var embedAttributes: [String] = []
 
@@ -441,10 +443,10 @@ public class PBXProjGenerator {
                     )
                     targetFrameworkBuildFiles.append(buildFile.reference)
                 }
-
-                if (dependency.embed ?? target.type.isApp) && !dependencyTarget.type.isLibrary {
-
-
+                
+                let shouldEmbed = target.type.isApp
+                    || (target.type.isTest && (dependencyTarget.type.isFramework || dependencyTarget.type == .bundle))
+                if (dependency.embed ?? shouldEmbed) && !dependencyTarget.type.isLibrary {
                     let embedFile = createObject(
                         id: dependencyFileReference + target.name,
                         PBXBuildFile(
@@ -497,6 +499,7 @@ public class PBXProjGenerator {
                     )
                     copyFrameworksReferences.append(embedFile.reference)
                 }
+                
             case .carthage:
                 var platformPath = Path(getCarthageBuildPath(platform: target.platform))
                 var frameworkPath = platformPath + dependency.reference
@@ -742,6 +745,51 @@ public class PBXProjGenerator {
         }
 
         return frameworks
+    }
+    
+    func getAllDependenciesPlusTransientNeedingEmbedding(target topLevelTarget: Target) -> [Dependency] {
+        // this is used to resolve cyclical target dependencies
+        var visitedTargets: Set<String> = []
+        var dependencies: [String: Dependency] = [:]
+        var queue: [Target] = [topLevelTarget]
+        while !queue.isEmpty {
+            let target = queue.removeFirst()
+            if visitedTargets.contains(target.name) {
+                continue
+            }
+            
+            let isTopLevel = target == topLevelTarget
+            
+            for dependency in target.dependencies {
+                // don't overwrite dependencies, to allow top level ones to rule
+                if dependencies.contains(reference: dependency.reference) {
+                    continue
+                }
+                
+                // don't want a dependency if it's going to be embedded or statically linked in a non-top level target
+                // in .target check we filter out targets that will embed all of their dependencies
+                switch dependency.type {
+                case .framework, .carthage:
+                    if isTopLevel || dependency.embed == nil {
+                        dependencies[dependency.reference] = dependency
+                    }
+                case .target:
+                    if let dependencyTarget = project.getTarget(dependency.reference) {
+                        if isTopLevel || (dependency.embed == nil && dependencyTarget.type != .staticLibrary) {
+                            dependencies[dependency.reference] = dependency
+                            if !dependencyTarget.shouldEmbedDependencies {
+                                // traverse target's dependencies if it doesn't embed them itself
+                                queue.append(dependencyTarget)
+                            }
+                        }
+                    }
+                }
+            }
+            
+            visitedTargets.update(with: target.name)
+        }
+        
+        return dependencies.sorted(by: { $0.key < $1.key }).map { $0.value }
     }
 }
 

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		BF_441538117869 /* App_watchOS Extension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_507023492251 /* App_watchOS Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		BF_447782698339 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_752394658615 /* Alamofire.framework */; };
 		BF_456457948943 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_172952167809 /* FrameworkFile.swift */; };
+		BF_461525575903 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_752394658615 /* Alamofire.framework */; };
 		BF_470396236719 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_410645050443 /* Alamofire.framework */; };
 		BF_496472559782 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_183521624014 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_503484983186 /* MoreUnder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_196911129660 /* MoreUnder.swift */; };
@@ -230,6 +231,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		FBP_32467107793 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_461525575903 /* Alamofire.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FBP_43870453850 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -274,8 +283,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_324363145049 /* Framework.framework in Frameworks */,
 				BF_729846993631 /* Alamofire.framework in Frameworks */,
+				BF_324363145049 /* Framework.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -592,6 +601,7 @@
 			buildPhases = (
 				SBP_32467107793 /* Sources */,
 				RBP_32467107793 /* Resources */,
+				FBP_32467107793 /* Frameworks */,
 				CFBP_4684049960 /* CopyFiles */,
 				SSBP_5954948530 /* Carthage */,
 			);
@@ -743,8 +753,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				TD_354342487294 /* PBXTargetDependency */,
 				TD_257389546865 /* PBXTargetDependency */,
+				TD_354342487294 /* PBXTargetDependency */,
 				TD_669996692733 /* PBXTargetDependency */,
 			);
 			name = App_iOS;

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -267,6 +267,221 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(dependencies[0].object.target) == nativeTargets.first { $0.object.name == framework.name }!.reference
                 try expect(dependencies[1].object.target) == nativeTargets.first { $0.object.name == app.name }!.reference
             }
+            
+            $0.it("generates targets with correct transient embeds") {
+                // App # Embeds it's frameworks, so shouldn't embed in tests
+                //   dependencies:
+                //     - framework: FrameworkA.framework
+                //     - framework: FrameworkB.framework
+                //       embed: false
+                // StaticLibrary:
+                //  dependencies: []
+                // ResourceBundle
+                //  dependencies: []
+                // iOSFrameworkA
+                //   dependencies:
+                //     - target: StaticLibrary
+                //     - target: ResourceBundle
+                //     # Won't embed FrameworkC.framework, so should embed in tests
+                //     - framework: FrameworkC.framework
+                //     - carthage: CarthageA
+                //     - carthage: CarthageB
+                //       embed: false
+                // iOSFrameworkB
+                //   dependencies:
+                //     - target: iOSFrameworkA
+                //     # Won't embed FrameworkD.framework, so should embed in tests
+                //     - framework: FrameworkD.framework
+                //     - framework: FrameworkE.framework
+                //       embed: true
+                //     - framework: FrameworkF.framework
+                //       embed: false
+                //     - carthage: CarthageC
+                //       embed: true
+                // AppTest
+                //   dependencies:
+                //     # Being an app, shouldn't be embedded
+                //     - target: App
+                //     - target: iOSFrameworkB
+                //     - carthage: CarthageD
+                //     # should be implicitly added
+                //     # - framework: iOSFrameworkA.framework
+                //     #   embed: true
+                //     # - carthage: CarthageA
+                //     #   embed: true
+                //     # - framework: FrameworkC.framework
+                //     #   embed: true
+                //     # - framework: FrameworkD.framework
+                //     #   embed: true
+                //
+                
+                var expectedResourceFiles: [String: Set<String>] = [:]
+                var expectedLinkedFiles: [String: Set<String>] = [:]
+                var expectedEmbeddedFrameworks: [String: Set<String>] = [:]
+                
+                let app = Target(
+                    name: "App",
+                    type: .application,
+                    platform: .iOS,
+                    // Embeds it's frameworks, so they shouldn't embed in AppTest
+                    dependencies: [
+                        Dependency(type: .framework, reference: "FrameworkA.framework"),
+                        Dependency(type: .framework, reference: "FrameworkB.framework", embed: false),
+                    ]
+                )
+                expectedResourceFiles[app.name] = Set()
+                expectedLinkedFiles[app.name] = Set([
+                    "FrameworkA.framework",
+                    "FrameworkB.framework",
+                ])
+                expectedEmbeddedFrameworks[app.name] = Set([
+                    "FrameworkA.framework",
+                ])
+                
+                let staticLibrary = Target(
+                    name: "StaticLibrary",
+                    type: .staticLibrary,
+                    platform: .iOS,
+                    dependencies: []
+                )
+                expectedResourceFiles[staticLibrary.name] = Set()
+                expectedLinkedFiles[staticLibrary.name] = Set()
+                expectedEmbeddedFrameworks[staticLibrary.name] = Set()
+                
+                let resourceBundle = Target(
+                    name: "ResourceBundle",
+                    type: .bundle,
+                    platform: .iOS,
+                    dependencies: []
+                )
+                expectedResourceFiles[resourceBundle.name] = Set()
+                expectedLinkedFiles[resourceBundle.name] = Set()
+                expectedEmbeddedFrameworks[resourceBundle.name] = Set()
+                
+                let iosFrameworkA = Target(
+                    name: "iOSFrameworkA",
+                    type: .framework,
+                    platform: .iOS,
+                    dependencies: [
+                        Dependency(type: .target, reference: resourceBundle.name),
+                        Dependency(type: .framework, reference: "FrameworkC.framework"),
+                        Dependency(type: .carthage, reference: "CarthageA"),
+                        // Statically linked, so don't embed into test
+                        Dependency(type: .target, reference: staticLibrary.name),
+                        Dependency(type: .carthage, reference: "CarthageB", embed: false),
+                    ]
+                )
+                expectedResourceFiles[iosFrameworkA.name] = Set()
+                expectedLinkedFiles[iosFrameworkA.name] = Set([
+                    "FrameworkC.framework",
+                    staticLibrary.filename,
+                    "CarthageA.framework",
+                    "CarthageB.framework",
+                ])
+                expectedEmbeddedFrameworks[iosFrameworkA.name] = Set()
+                
+                let iosFrameworkB = Target(
+                    name: "iOSFrameworkB",
+                    type: .framework,
+                    platform: .iOS,
+                    dependencies: [
+                        Dependency(type: .target, reference: iosFrameworkA.name),
+                        Dependency(type: .framework, reference: "FrameworkD.framework"),
+                        // Embedded into framework, so don't embed into test
+                        Dependency(type: .framework, reference: "FrameworkE.framework", embed: true),
+                        Dependency(type: .carthage, reference: "CarthageC", embed: true),
+                        // Statically linked, so don't embed into test
+                        Dependency(type: .framework, reference: "FrameworkF.framework", embed: false),
+                    ]
+                )
+                expectedResourceFiles[iosFrameworkB.name] = Set()
+                expectedLinkedFiles[iosFrameworkB.name] = Set([
+                    iosFrameworkA.filename,
+                    "FrameworkC.framework",
+                    "FrameworkD.framework",
+                    "FrameworkE.framework",
+                    "FrameworkF.framework",
+                    "CarthageA.framework",
+                    "CarthageC.framework",
+                ])
+                expectedEmbeddedFrameworks[iosFrameworkB.name] = Set([
+                    "FrameworkE.framework",
+                ])
+                
+                let appTest = Target(
+                    name: "AppTest",
+                    type: .unitTestBundle,
+                    platform: .iOS,
+                    dependencies: [
+                        Dependency(type: .target, reference: app.name),
+                        Dependency(type: .target, reference: iosFrameworkB.name),
+                        Dependency(type: .carthage, reference: "CarthageD"),
+                    ]
+                )
+                expectedResourceFiles[appTest.name] = Set([
+                    resourceBundle.filename,
+                ])
+                expectedLinkedFiles[appTest.name] = Set([
+                    iosFrameworkA.filename,
+                    "FrameworkC.framework",
+                    iosFrameworkB.filename,
+                    "FrameworkD.framework",
+                    "CarthageA.framework",
+                    "CarthageD.framework",
+                ])
+                expectedEmbeddedFrameworks[appTest.name] = Set([
+                    iosFrameworkA.filename,
+                    "FrameworkC.framework",
+                    iosFrameworkB.filename,
+                    "FrameworkD.framework",
+                ])
+                
+                let targets = [app, staticLibrary, resourceBundle, iosFrameworkA, iosFrameworkB, appTest]
+                
+                let project = Project(
+                    basePath: "",
+                    name: "test",
+                    targets: targets
+                )
+                let pbxProject = try project.generatePbxProj()
+                
+                for target in targets {
+                    guard let nativeTarget = pbxProject.objects.nativeTargets.referenceValues.first(where: { $0.name == target.name }) else {
+                        throw failure("PBXNativeTarget for \(target) not found")
+                    }
+                    let buildPhases = nativeTarget.buildPhases
+                    let resourcesPhases = pbxProject.objects.resourcesBuildPhases.objectReferences.filter { buildPhases.contains($0.reference) }
+                    let frameworkPhases = pbxProject.objects.frameworksBuildPhases.objectReferences.filter { buildPhases.contains($0.reference) }
+                    let copyFilesPhases = pbxProject.objects.copyFilesBuildPhases.objectReferences.filter { buildPhases.contains($0.reference) }
+                    
+                    // ensure only the right resources are copies, no more, no less
+                    let expectedResourceFiles = expectedResourceFiles[target.name]!
+                    try expect(resourcesPhases.count) == (expectedResourceFiles.isEmpty ? 0 : 1)
+                    if !expectedResourceFiles.isEmpty {
+                        let resourceFiles = resourcesPhases[0].object.files
+                            .compactMap { pbxProject.objects.buildFiles[$0]?.fileRef.flatMap { pbxProject.objects.fileReferences[$0]?.nameOrPath } }
+                        try expect(Set(resourceFiles)) == expectedResourceFiles
+                    }
+                    
+                    // ensure only the right things are linked, no more, no less
+                    let expectedLinkedFiles = expectedLinkedFiles[target.name]!
+                    try expect(frameworkPhases.count) == (expectedLinkedFiles.isEmpty ? 0 : 1)
+                    if !expectedLinkedFiles.isEmpty {
+                        let linkFrameworks = frameworkPhases[0].object.files
+                            .compactMap { pbxProject.objects.buildFiles[$0]?.fileRef.flatMap { pbxProject.objects.fileReferences[$0]?.nameOrPath } }
+                        try expect(Set(linkFrameworks)) == expectedLinkedFiles
+                    }
+                    
+                    // ensure only the right things are embedded, no more, no less
+                    let expectedEmbeddedFrameworks = expectedEmbeddedFrameworks[target.name]!
+                    try expect(copyFilesPhases.count) == (expectedEmbeddedFrameworks.isEmpty ? 0 : 1)
+                    if !expectedEmbeddedFrameworks.isEmpty {
+                        let copyFiles = copyFilesPhases[0].object.files
+                            .compactMap { pbxProject.objects.buildFiles[$0]?.fileRef.flatMap { pbxProject.objects.fileReferences[$0]?.nameOrPath } }
+                        try expect(Set(copyFiles)) == expectedEmbeddedFrameworks
+                    }
+                }
+            }
 
             $0.it("generates run scripts") {
                 var scriptSpec = project


### PR DESCRIPTION
If a target embeds dependencies (i.e. App and Test bundles) and a dependency has dependencies that can be embedded, then we should embed those dependencies as long as they weren't embedded along the way.

This already happens for Carthage dependencies, the change makes it happen for non-Carthage frameworks as well.

Also, closes #219, since it correctly picks up on the transitive dependency and embeds it properly.