### PR TITLE
Fix launch action to not run frameworks

### DIFF
--- a/Sources/ProjectSpec/XCProjExtensions.swift
+++ b/Sources/ProjectSpec/XCProjExtensions.swift
@@ -33,6 +33,10 @@ extension PBXProductType {
     public var isTest: Bool {
         return fileExtension == "xctest"
     }
+    
+    public var isExecutable: Bool {
+        return isApp || isExtension || isTest
+    }
 
     public var name: String {
         return rawValue.replacingOccurrences(of: "com.apple.product-type.", with: "")

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -70,6 +70,9 @@ public class ProjectGenerator {
             }
             return XCScheme.ExecutionAction(scriptText: action.script, title: action.name, environmentBuildable: environmentBuildable)
         }
+        
+        let target = project.getTarget(scheme.build.targets.first!.target)
+        let shouldExecuteOnLaunch = target?.type.isExecutable == true
 
         let buildableReference = buildActionEntries.first!.buildableReference
         let productRunable = XCScheme.BuildableProductRunnable(buildableReference: buildableReference)
@@ -107,10 +110,11 @@ public class ProjectGenerator {
         )
 
         let launchAction = XCScheme.LaunchAction(
-            buildableProductRunnable: productRunable,
+            buildableProductRunnable: shouldExecuteOnLaunch ? productRunable : nil,
             buildConfiguration: scheme.run?.config ?? defaultDebugConfig.name,
             preActions: scheme.run?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.run?.postActions.map(getExecutionAction) ?? [],
+            macroExpansion: shouldExecuteOnLaunch ? nil : buildableReference,
             commandlineArguments: launchCommandLineArgs,
             environmentVariables: launchVariables
         )

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
@@ -69,8 +69,7 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "NT_472296042419"
@@ -78,7 +77,7 @@
             BlueprintName = "Framework_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
             argument = "argument"


### PR DESCRIPTION
Currently generated schemes incorrectly are launchable for frameworks. This change implements them in the same way that Xcode naturally does.

App Extensions are still broke. Once https://github.com/xcode-project-manager/xcodeproj/issues/276 is implemented I can make another PR to fix them.