### PR TITLE
Set higher version .xcdatamodeld file as current

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -288,7 +288,7 @@ public class PBXProjGenerator {
             }
             .sorted { child1, child2 in
                 if child1.object.sortOrder == child2.object.sortOrder {
-                    return child1.object.nameOrPath < child2.object.nameOrPath
+                    return child1.object.nameOrPath.localizedStandardCompare(child2.object.nameOrPath) == .orderedAscending
                 } else {
                     return child1.object.sortOrder < child2.object.sortOrder
                 }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -119,7 +119,7 @@ class SourceGenerator {
                 let models = (try? path.children()) ?? []
                 let modelFileReference = models
                     .filter { $0.extension == "xcdatamodel" }
-                    .sorted()
+                    .sorted { $0.string.localizedStandardCompare($1.string) == .orderedDescending }
                     .map { path in
                         createObject(
                             id: path.byRemovingBase(path: project.basePath).string,

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -119,7 +119,7 @@ class SourceGenerator {
                 let models = (try? path.children()) ?? []
                 let modelFileReference = models
                     .filter { $0.extension == "xcdatamodel" }
-                    .sorted { $0.string.localizedStandardCompare($1.string) == .orderedDescending }
+                    .sorted { $0.string.localizedStandardCompare($1.string) == .orderedAscending }
                     .map { path in
                         createObject(
                             id: path.byRemovingBase(path: project.basePath).string,
@@ -131,7 +131,7 @@ class SourceGenerator {
                         )
                     }
                 let versionGroup = addObject(id: fileReferencePath.string, XCVersionGroup(
-                    currentVersion: modelFileReference.first?.reference,
+                    currentVersion: modelFileReference.last?.reference,
                     path: fileReferencePath.string,
                     sourceTree: sourceTree,
                     versionGroupType: "wrapper.xcdatamodel",


### PR DESCRIPTION
Sort .xcdatamodeld files in decreasing order to set higher version core data  model as current.

Current sorting of file takes place as:

```
ABC 10.xcdatamodel
ABC 11.xcdatamodel
ABC 12.xcdatamodel
ABC 13.xcdatamodel
ABC 14.xcdatamodel
ABC 15.xcdatamodel
ABC 16.xcdatamodel
ABC 17.xcdatamodel
ABC 18.xcdatamodel
ABC 19.xcdatamodel
ABC 2.xcdatamodel
ABC 20.xcdatamodel
ABC 3.xcdatamodel
ABC 4.xcdatamodel
ABC 5.xcdatamodel
ABC 6.xcdatamodel
ABC 7.xcdatamodel
ABC 8.xcdatamodel
ABC 9.xcdatamodel
```

after this change sorting will be like

```
ABC 20.xcdatamodel
ABC 19.xcdatamodel
ABC 18.xcdatamodel
ABC 17.xcdatamodel
ABC 16.xcdatamodel
ABC 15.xcdatamodel
ABC 14.xcdatamodel
ABC 13.xcdatamodel
ABC 12.xcdatamodel
ABC 11.xcdatamodel
ABC 10.xcdatamodel
ABC 9.xcdatamodel
ABC 8.xcdatamodel
ABC 7.xcdatamodel
ABC 6.xcdatamodel
ABC 5.xcdatamodel
ABC 4.xcdatamodel
ABC 3.xcdatamodel
ABC 2.xcdatamodel
```

and First element will be set as current core data model