### PR TITLE
Fix compilerFlags incorrectly being set on non-sources build phases

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -72,7 +72,7 @@ class SourceGenerator {
                 settings["ATTRIBUTES"] = [headerVisibility.settingName]
             }
         }
-        if targetSource.compilerFlags.count > 0 {
+        if chosenBuildPhase == .sources && targetSource.compilerFlags.count > 0 {
             settings["COMPILER_FLAGS"] = targetSource.compilerFlags.joined(separator: " ")
         }
 

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		BF_243071719122 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_172952167809 /* FrameworkFile.swift */; };
 		BF_259448131292 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = FR_815403394914 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_268392110450 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_587738154368 /* Assets.xcassets */; };
-		BF_279581961655 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_868653349092 /* Assets.xcassets */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		BF_279581961655 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_868653349092 /* Assets.xcassets */; };
 		BF_280535243540 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_609193904586 /* Main.storyboard */; };
 		BF_284620660317 /* MyBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_238161558082 /* MyBundle.bundle */; };
 		BF_292474606791 = {isa = PBXBuildFile; fileRef = FR_525119120469 /* Framework.framework */; };
@@ -338,8 +338,8 @@
 		G_2883690153011 /* Carthage */ = {
 			isa = PBXGroup;
 			children = (
-				G_2262017442691 /* Mac */,
 				G_2262017438925 /* iOS */,
+				G_2262017442691 /* Mac */,
 				G_8628897169668 /* tvOS */,
 				G_8244488572839 /* watchOS */,
 			);
@@ -478,11 +478,11 @@
 				G_3234630030493 /* FileGroup */,
 				G_4661500274312 /* Framework */,
 				G_1952740716080 /* Frameworks */,
+				G_8268950006174 /* iMessage */,
+				G_1646573205915 /* iMessage MessagesExtension */,
 				G_8620238527590 /* Products */,
 				G_7189434949822 /* Resources */,
 				G_6651250437419 /* StandaloneFiles */,
-				G_8268950006174 /* iMessage */,
-				G_1646573205915 /* iMessage MessagesExtension */,
 				FR_479281060337 /* Folder */,
 				FR_815403394914 /* Headers */,
 				FR_232605427418 /* Mintfile */,
@@ -497,9 +497,9 @@
 		G_8620238527590 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				FR_825232110500 /* App_iOS.app */,
 				FR_783122899910 /* App_iOS_Tests.xctest */,
 				FR_123503999387 /* App_iOS_UITests.xctest */,
+				FR_825232110500 /* App_iOS.app */,
 				FR_507023492251 /* App_watchOS Extension.appex */,
 				FR_324671077936 /* App_watchOS.app */,
 				FR_662315837182 /* Framework.framework */,


### PR DESCRIPTION
Noticed this while working on #346.