### PR TITLE
Add showEnvVars to build scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+#### Added
+- Added `showEnvVars` to build scripts to disable printing the environment [351](https://github.com/yonaskolb/XcodeGen/pull/351) @keith
+
 ## 1.10.3
 
 #### Fixed

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -352,6 +352,7 @@ Run script build phases added via **prebuildScripts** or **postBuildScripts**. T
 - [ ] **inputFiles**: **[String]** - list of input files
 - [ ] **outputFiles**: **[String]** - list of output files
 - [ ] **shell**: **String** - shell used for the script. Defaults to `/bin/sh`
+- [ ] **showEnvVars**: **Bool** - whether the environment variables accessible to the script show be printed to the build log. Defaults to yes
 - [ ] **runOnlyWhenInstalling**: **Bool** - whether the script is only run when installing (`runOnlyForDeploymentPostprocessing`). Defaults to no
 
 Either a **path** or **script** must be defined, the rest are optional.

--- a/Sources/ProjectSpec/BuildScript.swift
+++ b/Sources/ProjectSpec/BuildScript.swift
@@ -9,6 +9,7 @@ public struct BuildScript: Equatable {
     public var inputFiles: [String]
     public var outputFiles: [String]
     public var runOnlyWhenInstalling: Bool
+    public let showEnvVars: Bool
 
     public enum ScriptType: Equatable {
         case path(String)
@@ -21,7 +22,8 @@ public struct BuildScript: Equatable {
         inputFiles: [String] = [],
         outputFiles: [String] = [],
         shell: String? = nil,
-        runOnlyWhenInstalling: Bool = false
+        runOnlyWhenInstalling: Bool = false,
+        showEnvVars: Bool = true
     ) {
         self.script = script
         self.name = name
@@ -29,6 +31,7 @@ public struct BuildScript: Equatable {
         self.outputFiles = outputFiles
         self.shell = shell
         self.runOnlyWhenInstalling = runOnlyWhenInstalling
+        self.showEnvVars = showEnvVars
     }
 }
 
@@ -47,5 +50,6 @@ extension BuildScript: JSONObjectConvertible {
         }
         shell = jsonDictionary.json(atKeyPath: "shell")
         runOnlyWhenInstalling = jsonDictionary.json(atKeyPath: "runOnlyWhenInstalling") ?? false
+        showEnvVars = jsonDictionary.json(atKeyPath: "showEnvVars") ?? true
     }
 }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -561,6 +561,7 @@ public class PBXProjGenerator {
                 shellScript: shellScript
             )
             shellScriptPhase.runOnlyForDeploymentPostprocessing = buildScript.runOnlyWhenInstalling
+            shellScriptPhase.showEnvVarsInLog = buildScript.showEnvVars
             let shellScriptPhaseReference = createObject(id: String(describing: buildScript.name) + shellScript + target.name, shellScriptPhase)
             buildPhases.append(shellScriptPhaseReference.reference)
         }

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -338,8 +338,8 @@
 		G_2883690153011 /* Carthage */ = {
 			isa = PBXGroup;
 			children = (
-				G_2262017442691 /* Mac */,
 				G_2262017438925 /* iOS */,
+				G_2262017442691 /* Mac */,
 				G_8628897169668 /* tvOS */,
 				G_8244488572839 /* watchOS */,
 			);
@@ -478,11 +478,11 @@
 				G_3234630030493 /* FileGroup */,
 				G_4661500274312 /* Framework */,
 				G_1952740716080 /* Frameworks */,
+				G_8268950006174 /* iMessage */,
+				G_1646573205915 /* iMessage MessagesExtension */,
 				G_8620238527590 /* Products */,
 				G_7189434949822 /* Resources */,
 				G_6651250437419 /* StandaloneFiles */,
-				G_8268950006174 /* iMessage */,
-				G_1646573205915 /* iMessage MessagesExtension */,
 				FR_479281060337 /* Folder */,
 				FR_815403394914 /* Headers */,
 				FR_232605427418 /* Mintfile */,
@@ -497,9 +497,9 @@
 		G_8620238527590 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				FR_825232110500 /* App_iOS.app */,
 				FR_783122899910 /* App_iOS_Tests.xctest */,
 				FR_123503999387 /* App_iOS_UITests.xctest */,
+				FR_825232110500 /* App_iOS.app */,
 				FR_507023492251 /* App_watchOS Extension.appex */,
 				FR_324671077936 /* App_watchOS.app */,
 				FR_662315837182 /* Framework.framework */,

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -335,13 +335,15 @@ class SpecLoadingTests: XCTestCase {
                 let scripts: [[String: Any]] = [
                     ["path": "script.sh"],
                     ["script": "shell script\ndo thing", "name": "myscript", "inputFiles": ["file", "file2"], "outputFiles": ["file", "file2"], "shell": "bin/customshell", "runOnlyWhenInstalling": true],
+                    ["script": "shell script\ndo thing", "name": "myscript", "inputFiles": ["file", "file2"], "outputFiles": ["file", "file2"], "shell": "bin/customshell", "showEnvVars": false],
                 ]
                 target["prebuildScripts"] = scripts
                 target["postbuildScripts"] = scripts
 
                 let expectedScripts = [
                     BuildScript(script: .path("script.sh")),
-                    BuildScript(script: .script("shell script\ndo thing"), name: "myscript", inputFiles: ["file", "file2"], outputFiles: ["file", "file2"], shell: "bin/customshell", runOnlyWhenInstalling: true),
+                    BuildScript(script: .script("shell script\ndo thing"), name: "myscript", inputFiles: ["file", "file2"], outputFiles: ["file", "file2"], shell: "bin/customshell", runOnlyWhenInstalling: true, showEnvVars: true),
+                    BuildScript(script: .script("shell script\ndo thing"), name: "myscript", inputFiles: ["file", "file2"], outputFiles: ["file", "file2"], shell: "bin/customshell", runOnlyWhenInstalling: false, showEnvVars: false),
                 ]
 
                 let parsedTarget = try Target(name: "test", jsonDictionary: target)


### PR DESCRIPTION
This allows us to disable printing the environment in build logs.