### PR TITLE
Improve linking for static library targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Fixed compiler flags being set on non source files in mixed build phase target sources [347](https://github.com/yonaskolb/XcodeGen/pull/347) @brentleyjones
 - Fixed `options.xcodeVersion` not being parsed [348](https://github.com/yonaskolb/XcodeGen/pull/38) @brentleyjones
 
+#### Changed
+- Improved linking for `static.library` targets [352](https://github.com/yonaskolb/XcodeGen/pull/352) @brentleyjones
+
 #### Internal
 - Moved brew formula to homebrew core
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -296,7 +296,7 @@ A dependency can be one of a 3 types:
 These only applied to `target` and `framework` dependencies.
 
 - [ ] **embed**: **Bool** - Whether to embed the dependency. Defaults to true for application target and false for non application targets.
-- [ ] **link**: **Bool** - Whether to link the dependency. Defaults to true but only static library and dynamic frameworks are linked. This only applies for target dependencies.
+- [ ] **link**: **Bool** - Whether to link the dependency. Defaults to `true` depending on the type of the dependency and the type of the target (e.g. static libraries will only link to executables by default).
 - [ ] **codeSign**: **Bool** - Whether the `codeSignOnCopy` setting is applied when embedding framework. Defaults to true
 - [ ] **removeHeaders**: **Bool** - Whether the `removeHeadersOnCopy` setting is applied when embedding the framework. Defaults to true
 

--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -9,7 +9,7 @@ public struct Dependency: Equatable {
     public var embed: Bool?
     public var codeSign: Bool?
     public var removeHeaders: Bool = true
-    public var link: Bool = true
+    public var link: Bool?
     public var implicit: Bool = false
 
     public init(
@@ -17,7 +17,7 @@ public struct Dependency: Equatable {
         reference: String,
         embed: Bool? = nil,
         codeSign: Bool? = nil,
-        link: Bool = true,
+        link: Bool? = nil,
         implicit: Bool = false
     ) {
         self.type = type
@@ -53,10 +53,8 @@ extension Dependency: JSONObjectConvertible {
 
         embed = jsonDictionary.json(atKeyPath: "embed")
         codeSign = jsonDictionary.json(atKeyPath: "codeSign")
-
-        if let bool: Bool = jsonDictionary.json(atKeyPath: "link") {
-            link = bool
-        }
+        link = jsonDictionary.json(atKeyPath: "link")
+        
         if let bool: Bool = jsonDictionary.json(atKeyPath: "removeHeaders") {
             removeHeaders = bool
         }

--- a/Sources/ProjectSpec/Linkage.swift
+++ b/Sources/ProjectSpec/Linkage.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public enum Linkage {
+    case dynamic
+    case `static`
+    case none
+}
+
+extension Target {
+    
+    public var defaultLinkage: Linkage {
+        switch type {
+        case .none,
+             .appExtension,
+             .application,
+             .bundle,
+             .commandLineTool,
+             .messagesApplication,
+             .messagesExtension,
+             .ocUnitTestBundle,
+             .stickerPack,
+             .tvExtension,
+             .uiTestBundle,
+             .unitTestBundle,
+             .watchApp,
+             .watchExtension,
+             .watch2App,
+             .watch2Extension,
+             .xcodeExtension,
+             .xpcService:
+            return .none
+        case .framework:
+            // TODO: This should check `MACH_O_TYPE` in case this is a "Static Framework"
+            return .dynamic
+        case .dynamicLibrary:
+            return .dynamic
+        case .staticLibrary:
+            return .static
+        }
+    }
+}

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -779,7 +779,7 @@ public class PBXProjGenerator {
                     }
                 case .target:
                     if let dependencyTarget = project.getTarget(dependency.reference) {
-                        if isTopLevel || (dependency.embed == nil && dependencyTarget.type != .staticLibrary) {
+                        if isTopLevel || dependency.embed == nil {
                             dependencies[dependency.reference] = dependency
                             if !dependencyTarget.shouldEmbedDependencies {
                                 // traverse target's dependencies if it doesn't embed them itself

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -436,7 +436,7 @@ public class PBXProjGenerator {
                 dependencies.append(targetDependency.reference)
 
                 let dependecyLinkage = dependencyTarget.defaultLinkage
-                let shouldLink = dependecyLinkage == .dynamic
+                let shouldLink = (dependecyLinkage == .dynamic && target.type != .staticLibrary)
                     || (dependecyLinkage == .static && target.type.isExecutable)
                 if dependency.link ?? shouldLink {
                     let dependencyBuildFile = targetBuildFiles[dependencyTargetName]!
@@ -471,6 +471,8 @@ public class PBXProjGenerator {
                 }
 
             case .framework:
+                guard target.type != .staticLibrary else { break }
+                
                 let fileReference: String
                 if dependency.implicit {
                     fileReference = sourceGenerator.getFileReference(
@@ -504,6 +506,8 @@ public class PBXProjGenerator {
                 }
 
             case .carthage:
+                guard target.type != .staticLibrary else { break }
+                
                 var platformPath = Path(getCarthageBuildPath(platform: target.platform))
                 var frameworkPath = platformPath + dependency.reference
                 if frameworkPath.extension == nil {

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -436,9 +436,9 @@ public class PBXProjGenerator {
                 dependencies.append(targetDependency.reference)
 
                 let dependecyLinkage = dependencyTarget.defaultLinkage
-                let shouldLink = (dependecyLinkage == .dynamic && target.type != .staticLibrary)
-                    || (dependecyLinkage == .static && target.type.isExecutable)
-                if dependency.link ?? shouldLink {
+                let link = dependency.link ?? ((dependecyLinkage == .dynamic && target.type != .staticLibrary)
+                    || (dependecyLinkage == .static && target.type.isExecutable))
+                if link {
                     let dependencyBuildFile = targetBuildFiles[dependencyTargetName]!
                     let buildFile = createObject(
                         id: dependencyBuildFile.reference + target.name,
@@ -447,9 +447,9 @@ public class PBXProjGenerator {
                     targetFrameworkBuildFiles.append(buildFile.reference)
                 }
 
-                let shouldEmbed = target.type.isApp
-                    || (target.type.isTest && (dependencyTarget.type.isFramework || dependencyTarget.type == .bundle))
-                if (dependency.embed ?? shouldEmbed) && !dependencyTarget.type.isLibrary {
+                let embed = dependency.embed ?? (!dependencyTarget.type.isLibrary && (target.type.isApp
+                    || (target.type.isTest && (dependencyTarget.type.isFramework || dependencyTarget.type == .bundle))))
+                if embed {
                     let embedFile = createObject(
                         id: dependencyFileReference + target.name,
                         PBXBuildFile(

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -435,7 +435,10 @@ public class PBXProjGenerator {
 
                 dependencies.append(targetDependency.reference)
 
-                if (dependencyTarget.type.isLibrary || dependencyTarget.type.isFramework) && dependency.link {
+                let dependecyLinkage = dependencyTarget.defaultLinkage
+                let shouldLink = dependecyLinkage == .dynamic
+                    || (dependecyLinkage == .static && target.type.isExecutable)
+                if dependency.link ?? shouldLink {
                     let dependencyBuildFile = targetBuildFiles[dependencyTargetName]!
                     let buildFile = createObject(
                         id: dependencyBuildFile.reference + target.name,

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		BF_331192862207 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_481575785861 /* ViewController.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		BF_334321520545 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_377082606829 /* Assets.xcassets */; };
 		BF_334778067417 = {isa = PBXBuildFile; fileRef = FR_783122899910 /* App_iOS_Tests.xctest */; };
+		BF_337656089700 = {isa = PBXBuildFile; fileRef = FR_399755008402 /* StaticLibrary_ObjC.a */; };
 		BF_360196406184 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_722239415598 /* TestProjectTests.swift */; };
 		BF_425679397292 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_183521624014 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_441538117869 /* App_watchOS Extension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_507023492251 /* App_watchOS Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -46,8 +47,10 @@
 		BF_538515166673 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_256263906698 /* LaunchScreen.storyboard */; };
 		BF_561304997165 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_675266829517 /* Standalone.swift */; };
 		BF_563614389392 = {isa = PBXBuildFile; fileRef = FR_618687462494 /* iMessageExtension.appex */; };
+		BF_607543323797 = {isa = PBXBuildFile; fileRef = FR_698230898030 /* StaticLibrary_ObjC.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_612351978356 /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_264279911176 /* Interface.storyboard */; };
 		BF_624802436672 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_172952167809 /* FrameworkFile.swift */; };
+		BF_632297340262 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_698230898030-1" /* StaticLibrary_ObjC.m */; };
 		BF_647038614509 /* iMessageApp.app in Resources */ = {isa = PBXBuildFile; fileRef = FR_935153865209 /* iMessageApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		BF_670499288392 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = VG_229021855709 /* Model.xcdatamodeld */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		BF_681504666330 = {isa = PBXBuildFile; fileRef = FR_825232110500 /* App_iOS.app */; };
@@ -69,6 +72,7 @@
 		BF_905038616071 /* Framework.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_472296042419 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BF_905617636654 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = FR_815403394914 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_940936137577 = {isa = PBXBuildFile; fileRef = FR_123503999387 /* App_iOS_UITests.xctest */; };
+		BF_943177036061 /* StaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_399755008402 /* StaticLibrary_ObjC.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -100,12 +104,40 @@
 			remoteGlobalIDString = NT_618687462494;
 			remoteInfo = iMessageExtension;
 		};
+		CIP_33710394010 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_8448771205358 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_399755008402;
+			remoteInfo = StaticLibrary_ObjC;
+		};
+		CIP_66745555235 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_8448771205358 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_399755008402;
+			remoteInfo = StaticLibrary_ObjC;
+		};
 		CIP_67619158112 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = P_8448771205358 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = NT_825232110500;
 			remoteInfo = App_iOS;
+		};
+		CIP_72152212817 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_8448771205358 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_399755008402;
+			remoteInfo = StaticLibrary_ObjC;
+		};
+		CIP_78441234790 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_8448771205358 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_399755008402;
+			remoteInfo = StaticLibrary_ObjC;
 		};
 		CIP_82410178775 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -120,6 +152,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = NT_825232110500;
 			remoteInfo = App_iOS;
+		};
+		CIP_95747640947 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_8448771205358 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_399755008402;
+			remoteInfo = StaticLibrary_ObjC;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -188,6 +227,7 @@
 		FR_340586388409 /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
 		FR_363921640403 /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
 		FR_377082606829 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		FR_399755008402 /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_408537768279 /* StandaloneAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = StandaloneAssets.xcassets; sourceTree = "<group>"; };
 		FR_410645050443 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Alamofire.framework; sourceTree = "<group>"; };
 		FR_438704538506 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -212,6 +252,8 @@
 		FR_660690926982 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = config.xcconfig; sourceTree = "<group>"; };
 		FR_662315837182 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_675266829517 /* Standalone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Standalone.swift; sourceTree = "<group>"; };
+		FR_698230898030 /* StaticLibrary_ObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticLibrary_ObjC.h; sourceTree = "<group>"; };
+		"FR_698230898030-1" /* StaticLibrary_ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticLibrary_ObjC.m; sourceTree = "<group>"; };
 		FR_722239415598 /* TestProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectTests.swift; sourceTree = "<group>"; };
 		FR_725187762757 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		FR_746876637628 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
@@ -285,6 +327,7 @@
 			files = (
 				BF_729846993631 /* Alamofire.framework in Frameworks */,
 				BF_324363145049 /* Framework.framework in Frameworks */,
+				BF_943177036061 /* StaticLibrary_ObjC.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -363,6 +406,15 @@
 				VG_264279911176 /* Interface.storyboard */,
 			);
 			path = App_watchOS;
+			sourceTree = "<group>";
+		};
+		G_3997550084026 /* StaticLibrary_ObjC */ = {
+			isa = PBXGroup;
+			children = (
+				FR_698230898030 /* StaticLibrary_ObjC.h */,
+				"FR_698230898030-1" /* StaticLibrary_ObjC.m */,
+			);
+			path = StaticLibrary_ObjC;
 			sourceTree = "<group>";
 		};
 		G_4661500274312 /* Framework */ = {
@@ -483,6 +535,7 @@
 				G_8620238527590 /* Products */,
 				G_7189434949822 /* Resources */,
 				G_6651250437419 /* StandaloneFiles */,
+				G_3997550084026 /* StaticLibrary_ObjC */,
 				FR_479281060337 /* Folder */,
 				FR_815403394914 /* Headers */,
 				FR_232605427418 /* Mintfile */,
@@ -508,6 +561,7 @@
 				FR_472296042419 /* Framework.framework */,
 				FR_935153865209 /* iMessageApp.app */,
 				FR_618687462494 /* iMessageExtension.appex */,
+				FR_399755008402 /* StaticLibrary_ObjC.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -615,6 +669,21 @@
 			productReference = FR_324671077936 /* App_watchOS.app */;
 			productType = "com.apple.product-type.application.watchapp2";
 		};
+		NT_399755008402 /* StaticLibrary_ObjC */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_399755008402 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC" */;
+			buildPhases = (
+				SBP_39975500840 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StaticLibrary_ObjC;
+			productName = StaticLibrary_ObjC;
+			productReference = FR_399755008402 /* StaticLibrary_ObjC.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		NT_438704538506 /* Framework_watchOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CL_438704538506 /* Build configuration list for PBXNativeTarget "Framework_watchOS" */;
@@ -627,6 +696,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				TD_562366646359 /* PBXTargetDependency */,
 			);
 			name = Framework_watchOS;
 			productName = Framework_watchOS;
@@ -645,6 +715,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				TD_202479103763 /* PBXTargetDependency */,
 			);
 			name = Framework_iOS;
 			productName = Framework_iOS;
@@ -680,6 +751,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				TD_698828390883 /* PBXTargetDependency */,
 			);
 			name = Framework_macOS;
 			productName = Framework_macOS;
@@ -714,6 +786,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				TD_883611297273 /* PBXTargetDependency */,
 			);
 			name = Framework_tvOS;
 			productName = Framework_tvOS;
@@ -755,6 +828,7 @@
 			dependencies = (
 				TD_257389546865 /* PBXTargetDependency */,
 				TD_354342487294 /* PBXTargetDependency */,
+				TD_490183489588 /* PBXTargetDependency */,
 				TD_669996692733 /* PBXTargetDependency */,
 			);
 			name = App_iOS;
@@ -818,6 +892,7 @@
 				NT_662315837182 /* Framework_tvOS */,
 				NT_438704538506 /* Framework_watchOS */,
 				LT_479264660374 /* Legacy */,
+				NT_399755008402 /* StaticLibrary_ObjC */,
 				NT_935153865209 /* iMessageApp */,
 				NT_618687462494 /* iMessageExtension */,
 			);
@@ -1045,6 +1120,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		SBP_39975500840 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_632297340262 /* StaticLibrary_ObjC.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		SBP_43870453850 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1132,6 +1215,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		TD_202479103763 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = NT_399755008402 /* StaticLibrary_ObjC */;
+			targetProxy = CIP_66745555235 /* PBXContainerItemProxy */;
+		};
 		TD_249869083204 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = NT_507023492251 /* App_watchOS Extension */;
@@ -1157,15 +1245,35 @@
 			target = NT_825232110500 /* App_iOS */;
 			targetProxy = CIP_88714386547 /* PBXContainerItemProxy */;
 		};
+		TD_490183489588 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = NT_399755008402 /* StaticLibrary_ObjC */;
+			targetProxy = CIP_72152212817 /* PBXContainerItemProxy */;
+		};
+		TD_562366646359 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = NT_399755008402 /* StaticLibrary_ObjC */;
+			targetProxy = CIP_78441234790 /* PBXContainerItemProxy */;
+		};
 		TD_669996692733 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = NT_935153865209 /* iMessageApp */;
 			targetProxy = CIP_28856087625 /* PBXContainerItemProxy */;
 		};
+		TD_698828390883 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = NT_399755008402 /* StaticLibrary_ObjC */;
+			targetProxy = CIP_33710394010 /* PBXContainerItemProxy */;
+		};
 		TD_762620471828 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = NT_618687462494 /* iMessageExtension */;
 			targetProxy = CIP_31792113134 /* PBXContainerItemProxy */;
+		};
+		TD_883611297273 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = NT_399755008402 /* StaticLibrary_ObjC */;
+			targetProxy = CIP_95747640947 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1822,6 +1930,16 @@
 			};
 			name = "Test Debug";
 		};
+		BC_464603633927 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
 		BC_467730755629 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2167,6 +2285,16 @@
 			};
 			name = "Test Release";
 		};
+		BC_592419322448 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
 		BC_594849660073 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2237,6 +2365,16 @@
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		BC_629891546665 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Production Debug";
 		};
@@ -2461,6 +2599,16 @@
 			};
 			name = "Production Debug";
 		};
+		BC_724654958001 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
 		BC_730521266150 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2634,6 +2782,16 @@
 				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Staging Debug";
+		};
+		BC_776042221288 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
 		};
 		BC_790711614758 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
@@ -2844,6 +3002,16 @@
 			};
 			name = "Staging Debug";
 		};
+		BC_866329197584 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
 		BC_879000441352 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2894,6 +3062,19 @@
 				BC_128566007109 /* Staging Release */,
 				BC_568928282286 /* Test Debug */,
 				BC_264159662496 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_399755008402 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_629891546665 /* Production Debug */,
+				BC_592419322448 /* Production Release */,
+				BC_724654958001 /* Staging Debug */,
+				BC_776042221288 /* Staging Release */,
+				BC_866329197584 /* Test Debug */,
+				BC_464603633927 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";

--- a/Tests/Fixtures/TestProject/StaticLibrary_ObjC/StaticLibrary_ObjC.h
+++ b/Tests/Fixtures/TestProject/StaticLibrary_ObjC/StaticLibrary_ObjC.h
@@ -1,0 +1,4 @@
+#include <Foundation/Foundation.h>
+
+@interface SLObjC: NSObject
+@end

--- a/Tests/Fixtures/TestProject/StaticLibrary_ObjC/StaticLibrary_ObjC.m
+++ b/Tests/Fixtures/TestProject/StaticLibrary_ObjC/StaticLibrary_ObjC.m
@@ -1,0 +1,9 @@
+#include "StaticLibrary_ObjC.h"
+
+@implementation SLObjC
+
+- (NSString *)description {
+  return "Hello, World!";
+}
+
+@end

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -51,6 +51,7 @@ targets:
       PRODUCT_BUNDLE_IDENTIFIER: com.project.app
     dependencies:
       - target: Framework_iOS
+      - target: StaticLibrary_ObjC
       - carthage: Alamofire
       - target: App_watchOS
       - target: iMessageApp
@@ -106,6 +107,11 @@ targets:
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.project.iMessageApp.extension
 
+  StaticLibrary_ObjC:
+    type: library.static
+    platform: iOS
+    sources: StaticLibrary_ObjC
+
   Framework:
     type: framework
     platform: [iOS, tvOS, watchOS, macOS]
@@ -122,6 +128,7 @@ targets:
         path: scripts/script.sh
     dependencies:
       - carthage: Alamofire
+      - target: StaticLibrary_ObjC
   App_iOS_Tests:
     type: bundle.unit-test
     platform: iOS

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -51,7 +51,6 @@ targets:
       PRODUCT_BUNDLE_IDENTIFIER: com.project.app
     dependencies:
       - target: Framework_iOS
-      - target: StaticLibrary_ObjC
       - carthage: Alamofire
       - target: App_watchOS
       - target: iMessageApp

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -305,8 +305,10 @@ class ProjectGeneratorTests: XCTestCase {
                 //     - target: iOSFrameworkB
                 //     - carthage: CarthageD
                 //     # should be implicitly added
-                //     # - framework: iOSFrameworkA.framework
+                //     # - target: iOSFrameworkA
                 //     #   embed: true
+                //     # - target: StaticLibrary
+                //     #   embed: false
                 //     # - carthage: CarthageA
                 //     #   embed: true
                 //     # - framework: FrameworkC.framework
@@ -430,6 +432,7 @@ class ProjectGeneratorTests: XCTestCase {
                 ])
                 expectedLinkedFiles[appTest.name] = Set([
                     iosFrameworkA.filename,
+                    staticLibrary.filename,
                     "FrameworkC.framework",
                     iosFrameworkB.filename,
                     "FrameworkD.framework",

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -382,7 +382,6 @@ class ProjectGeneratorTests: XCTestCase {
                 expectedResourceFiles[iosFrameworkA.name] = Set()
                 expectedLinkedFiles[iosFrameworkA.name] = Set([
                     "FrameworkC.framework",
-                    staticLibrary.filename,
                     "CarthageA.framework",
                     "CarthageB.framework",
                 ])


### PR DESCRIPTION
Child of #350. Addresses 2.i, 2.iii, 3.

With these changes there are fewer warnings in the new build system (no longer links dynamic frameworks to static libraries), and more things have the correct default (only links static libraries to  executables and `transitivelyLinkDependencies` now works with them).



