### PR TITLE
Default `SKIP_INSTALL` to `YES` for static libraries

### DIFF
--- a/SettingPresets/Products/library.static.yml
+++ b/SettingPresets/Products/library.static.yml
@@ -1,0 +1,1 @@
+SKIP_INSTALL: 'YES'


### PR DESCRIPTION
Child of #350. Addresses 4.

`SKIP_INSTALL` being `NO` by default for static libraries results in invalid archives.