### PR TITLE
Add additional params to archive action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `aggregateTargets` [354](https://github.com/yonaskolb/XcodeGen/pull/354) @yonaskolb
 - Added `options.groupSortPosition` [356](https://github.com/yonaskolb/XcodeGen/pull/356) @yonaskolb
 - Added ability to specify `copyFiles` build phase for sources [345](https://github.com/yonaskolb/XcodeGen/pull/345) @brentleyjones
+- Added `customArchiveName` and `revealArchiveInOrganizer` to `archive`  [367](https://github.com/yonaskolb/XcodeGen/pull/367) @sxua
 
 #### Fixed
 - Sort files using localizedStandardCompare [341](https://github.com/yonaskolb/XcodeGen/pull/341) @rohitpal440

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -549,6 +549,11 @@ A multiline script can be written using the various YAML multiline methods, for 
 - [ ] **gatherCoverageData**: **Bool** - a boolean that indicates if this scheme should gather coverage data. This defaults to false
 - [ ] **targets**: **[String]** - a list of targets to test
 
+### Archive Action
+
+- [ ] **customArchiveName**: **String** - the custom name to give to the archive
+- [ ] **revealArchiveInOrganizer**: **Bool** - flag to determine whether the archive will be revealed in Xcode's Organizer after it's done building
+
 ### Environment Variable
 
 - [x] **variable**: **String** - variable's name.
@@ -582,4 +587,6 @@ schemes:
       config: prod-debug
     archive:
       config: prod-release
+      customArchiveName: MyTarget
+      revealArchiveInOrganizer: false
 ```

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -150,14 +150,20 @@ public struct Scheme: Equatable {
 
     public struct Archive: BuildAction {
         public var config: String?
+        public var customArchiveName: String?
+        public var revealArchiveInOrganizer: Bool
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
         public init(
             config: String,
+            customArchiveName: String? = nil,
+            revealArchiveInOrganizer: Bool = true,
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = []
         ) {
             self.config = config
+            self.customArchiveName = customArchiveName
+            self.revealArchiveInOrganizer = revealArchiveInOrganizer
             self.preActions = preActions
             self.postActions = postActions
         }
@@ -233,6 +239,8 @@ extension Scheme.Archive: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
         config = jsonDictionary.json(atKeyPath: "config")
+        customArchiveName = jsonDictionary.json(atKeyPath: "customArchiveName")
+        revealArchiveInOrganizer = jsonDictionary.json(atKeyPath: "revealArchiveInOrganizer") ?? true
         preActions = jsonDictionary.json(atKeyPath: "preActions") ?? []
         postActions = jsonDictionary.json(atKeyPath: "postActions") ?? []
     }

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -133,7 +133,8 @@ public class ProjectGenerator {
 
         let archiveAction = XCScheme.ArchiveAction(
             buildConfiguration: scheme.archive?.config ?? defaultReleaseConfig.name,
-            revealArchiveInOrganizer: true,
+            revealArchiveInOrganizer: scheme.archive?.revealArchiveInOrganizer ?? true,
+            customArchiveName: scheme.archive?.customArchiveName,
             preActions: scheme.archive?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.archive?.postActions.map(getExecutionAction) ?? []
         )


### PR DESCRIPTION
This change adds an ability to customize archive name and whether it should be revealed in organizer or not. Basically, one can set options displayed on an image below via `project.yml`

<img width="378" alt="screen shot 2018-08-02 at 3 24 53 pm" src="https://user-images.githubusercontent.com/375762/43583617-aada763e-9668-11e8-8947-f8dcb909db1e.png">
