### PR TITLE
Fix link typo in FAQ.md

### DIFF
--- a/Docs/FAQ.md
+++ b/Docs/FAQ.md
@@ -17,4 +17,4 @@ Yes, simply generate your project and then run `pod install` which will integrat
 
 ## How do I setup code signing
 
-At the moment there are no special options for code signing in XcodeGen, and this must be configured via regular build settings. For code signing to work, you need to tell Xcode which development team to use. This requires setting the `DEVELOPMENT_TEAM` and possibly `CODE_SIGN_STYLE` build settings. See [Configuring build settings](Usage#configuring-build-settings) for how to do that
+At the moment there are no special options for code signing in XcodeGen, and this must be configured via regular build settings. For code signing to work, you need to tell Xcode which development team to use. This requires setting the `DEVELOPMENT_TEAM` and possibly `CODE_SIGN_STYLE` build settings. See [Configuring build settings](Usage.md#configuring-build-settings) for how to do that


### PR DESCRIPTION
Tiny change to fix a typo in a link: from `Usage#configuring-build-settings` (which goes to a 404) to `Usage.md#configuring-build-settings`.