### PR TITLE
Make validation of Xcode projects optional

### DIFF
--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -21,8 +21,10 @@ public class ProjectGenerator {
         return project.configs.first { $0.type == .release }!
     }
 
-    public func generateXcodeProject() throws -> XcodeProj {
-        try project.validate()
+    public func generateXcodeProject(validate: Bool = true) throws -> XcodeProj {
+        if validate {
+            try project.validate()
+        }
         let pbxProjGenerator = PBXProjGenerator(project: project)
         let pbxProject = try pbxProjGenerator.generate()
         let workspace = try generateWorkspace()


### PR DESCRIPTION
Validation requires several things of the Xcode project, one being that files are already on disk. In some cases, it's useful to generate projects containing files that don't exist on disk yet. Additionally, this is useful for testing purposes, and generating projects on a machine where the files don't exist.

Additionally, this flag is needed to run source code generators and download files at build time, but want to have an Xcode project containing entries for those files.