### PR TITLE
Generate optional info plist and entitlements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Added
 - Added `weak` linking setting for dependencies [#411](https://github.com/yonaskolb/XcodeGen/pull/411) @alvarhansen
+- Added `info` to targets for generating an `Info.plist` [#415](https://github.com/yonaskolb/XcodeGen/pull/415) @yonaskolb
+- Added `entitlements` to targets for generating an `.entitlement` file [#415](https://github.com/yonaskolb/XcodeGen/pull/415) @yonaskolb
 
 #### Changed
 - Performance improvements for large projects [#388](https://github.com/yonaskolb/XcodeGen/pull/388) [#417](https://github.com/yonaskolb/XcodeGen/pull/417) [#416](https://github.com/yonaskolb/XcodeGen/pull/416) @yonaskolb @kastiglione

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -171,6 +171,16 @@ Settings are merged in the following order: groups, base, configs.
 	- `FRAMEWORK_SEARCH_PATHS`: If carthage dependencies are used, the platform build path will be added to this setting
 	- `OTHER_LDFLAGS`:  See `requiresObjCLinking` below
 - [ ] **dependencies**: **[[Dependency](#dependency)]** - Dependencies for the target
+- [ ] **info**: **[Plist](#plist)** - If defined, this will generate and write an `Info.plist` to the specified path and use it by setting the `INFOPLIST_FILE` build setting for every configuration. The following properties are generated automatically, the rest will have to be provided.
+  - `CFBundleIdentifier`
+  - `CFBundleInfoDictionaryVersion`
+  - `CFBundleExecutable`
+  - `CFBundleName`
+  - `CFBundleDevelopmentRegion`
+  - `CFBundleShortVersionString`
+  - `CFBundleVersion`
+  - `CFBundlePackageType`
+- [ ] **entitlements**: **[Plist](#plist)** - If defined this will generate and write a `.entitlements` file, and use it by setting `CODE_SIGN_ENTITLEMENTS` build setting for every configuration. All properties must be provided
 - [ ] **templates**: **[String]** - A list of target templates that will be merged in order
 - [ ] **transitivelyLinkDependencies**: **Bool** - If this is not specified the value from the project set in [Options](#options)`.transitivelyLinkDependencies` will be used.
 - [ ] **directlyEmbedCarthageDependencies**: **Bool** - If this is `true` Carthage dependencies will be embedded using an `Embed Frameworks` build phase instead of the `copy-frameworks` script. Defaults to `true` for all targets except iOS/tvOS/watchOS Applications.
@@ -370,6 +380,25 @@ targets:
     configFiles:
       Debug: App/debug.xcconfig
       Release: App/release.xcconfig
+```
+### Plist
+Plists are created on disk on every generation of the project. They can be used as a way to define `Info.plist` or `.entitlement` files. Some `Info.plist` properties are generated automatically.
+
+- [x] **path**: **String** - This is the path where the plist will be written to
+- [x] **properties**: **[String: Any]** - This is a map of all the plist keys and values
+
+```yml
+targets:
+  App:
+    info:
+      path: App/Info.plist
+      properties:
+        UISupportedInterfaceOrientations: [UIInterfaceOrientationPortrait]
+        UILaunchStoryboardName: LaunchScreen
+    entitlements:
+      path: App/App.entitlements
+      properties:
+        com.apple.security.application-groups: group.com.app
 ```
 
 ### Build Script

--- a/Sources/ProjectSpec/Plist.swift
+++ b/Sources/ProjectSpec/Plist.swift
@@ -1,0 +1,26 @@
+import Foundation
+import JSONUtilities
+
+public struct Plist: Equatable {
+
+    public let path: String
+    public let attributes: [String: Any]
+
+    public init(path: String, attributes: [String: Any] = [:]) {
+        self.path = path
+        self.attributes = attributes
+    }
+
+    public static func == (lhs: Plist, rhs: Plist) -> Bool {
+        return lhs.path == rhs.path &&
+        NSDictionary(dictionary: lhs.attributes).isEqual(to: rhs.attributes)
+    }
+}
+
+extension Plist: JSONObjectConvertible {
+
+    public init(jsonDictionary: JSONDictionary) throws {
+        path = try jsonDictionary.json(atKeyPath: "path")
+        attributes = jsonDictionary.json(atKeyPath: "attributes") ?? [:]
+    }
+}

--- a/Sources/ProjectSpec/Plist.swift
+++ b/Sources/ProjectSpec/Plist.swift
@@ -4,16 +4,16 @@ import JSONUtilities
 public struct Plist: Equatable {
 
     public let path: String
-    public let attributes: [String: Any]
+    public let properties: [String: Any]
 
     public init(path: String, attributes: [String: Any] = [:]) {
         self.path = path
-        self.attributes = attributes
+        self.properties = attributes
     }
 
     public static func == (lhs: Plist, rhs: Plist) -> Bool {
         return lhs.path == rhs.path &&
-        NSDictionary(dictionary: lhs.attributes).isEqual(to: rhs.attributes)
+        NSDictionary(dictionary: lhs.properties).isEqual(to: rhs.properties)
     }
 }
 
@@ -21,6 +21,6 @@ extension Plist: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
         path = try jsonDictionary.json(atKeyPath: "path")
-        attributes = jsonDictionary.json(atKeyPath: "attributes") ?? [:]
+        properties = jsonDictionary.json(atKeyPath: "properties") ?? [:]
     }
 }

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -28,6 +28,8 @@ public struct Target: ProjectTarget {
     public var settings: Settings
     public var sources: [TargetSource]
     public var dependencies: [Dependency]
+    public var info: Plist?
+    public var entitlements: Plist?
     public var transitivelyLinkDependencies: Bool?
     public var directlyEmbedCarthageDependencies: Bool?
     public var requiresObjCLinking: Bool?
@@ -63,6 +65,8 @@ public struct Target: ProjectTarget {
         configFiles: [String: String] = [:],
         sources: [TargetSource] = [],
         dependencies: [Dependency] = [],
+        info: Plist? = nil,
+        entitlements: Plist? = nil,
         transitivelyLinkDependencies: Bool? = nil,
         directlyEmbedCarthageDependencies: Bool? = nil,
         requiresObjCLinking: Bool? = nil,
@@ -82,6 +86,8 @@ public struct Target: ProjectTarget {
         self.configFiles = configFiles
         self.sources = sources
         self.dependencies = dependencies
+        self.info = info
+        self.entitlements = entitlements
         self.transitivelyLinkDependencies = transitivelyLinkDependencies
         self.directlyEmbedCarthageDependencies = directlyEmbedCarthageDependencies
         self.requiresObjCLinking = requiresObjCLinking
@@ -278,6 +284,10 @@ extension Target: NamedJSONDictionaryConvertible {
         } else {
             dependencies = try jsonDictionary.json(atKeyPath: "dependencies", invalidItemBehaviour: .fail)
         }
+
+        info = jsonDictionary.json(atKeyPath: "info")
+        entitlements = jsonDictionary.json(atKeyPath: "entitlements")
+        
         transitivelyLinkDependencies = jsonDictionary.json(atKeyPath: "transitivelyLinkDependencies")
         directlyEmbedCarthageDependencies = jsonDictionary.json(atKeyPath: "directlyEmbedCarthageDependencies")
         requiresObjCLinking = jsonDictionary.json(atKeyPath: "requiresObjCLinking")

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -215,6 +215,8 @@ extension Target: Equatable {
             lhs.settings == rhs.settings &&
             lhs.configFiles == rhs.configFiles &&
             lhs.sources == rhs.sources &&
+            lhs.info == rhs.info &&
+            lhs.entitlements == rhs.entitlements &&
             lhs.dependencies == rhs.dependencies &&
             lhs.prebuildScripts == rhs.prebuildScripts &&
             lhs.postbuildScripts == rhs.postbuildScripts &&
@@ -285,9 +287,13 @@ extension Target: NamedJSONDictionaryConvertible {
             dependencies = try jsonDictionary.json(atKeyPath: "dependencies", invalidItemBehaviour: .fail)
         }
 
-        info = jsonDictionary.json(atKeyPath: "info")
-        entitlements = jsonDictionary.json(atKeyPath: "entitlements")
-        
+        if jsonDictionary["info"] != nil {
+            info = try jsonDictionary.json(atKeyPath: "info") as Plist
+        }
+        if jsonDictionary["entitlements"] != nil {
+            entitlements = try jsonDictionary.json(atKeyPath: "entitlements") as Plist
+        }
+
         transitivelyLinkDependencies = jsonDictionary.json(atKeyPath: "transitivelyLinkDependencies")
         directlyEmbedCarthageDependencies = jsonDictionary.json(atKeyPath: "directlyEmbedCarthageDependencies")
         requiresObjCLinking = jsonDictionary.json(atKeyPath: "requiresObjCLinking")

--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -47,21 +47,11 @@ func generate(spec: String, project: String, isQuiet: Bool, justVersion: Bool) {
         let xcodeProject = try projectGenerator.generateXcodeProject()
 
         logger.info("⚙️  Writing project...")
+        let projectWriter = ProjectWriter(project: project)
+        try projectWriter.writeXcodeProject(xcodeProject)
+        try projectWriter.writePlists()
 
-        try projectGenerator.generateFiles()
-
-        let projectFile = projectPath + "\(project.name).xcodeproj"
-        let tempPath = Path.temporary + "XcodeGen_\(Int(NSTimeIntervalSince1970))"
-        try? tempPath.delete()
-        if projectFile.exists {
-            try projectFile.copy(tempPath)
-        }
-        try xcodeProject.write(path: tempPath, override: true)
-        try? projectFile.delete()
-        try tempPath.copy(projectFile)
-        try? tempPath.delete()
-
-        logger.success("💾  Saved project to \(projectFile.string)")
+        logger.success("💾  Saved project to \(project.projectPath.string)")
     } catch let error as SpecValidationError {
         fatalError(error.description)
     } catch {

--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -48,6 +48,8 @@ func generate(spec: String, project: String, isQuiet: Bool, justVersion: Bool) {
 
         logger.info("⚙️  Writing project...")
 
+        try projectGenerator.generateFiles()
+
         let projectFile = projectPath + "\(project.name).xcodeproj"
         let tempPath = Path.temporary + "XcodeGen_\(Int(NSTimeIntervalSince1970))"
         try? tempPath.delete()

--- a/Sources/XcodeGenKit/InfoPlistGenerator.swift
+++ b/Sources/XcodeGenKit/InfoPlistGenerator.swift
@@ -20,7 +20,7 @@ public class InfoPlistGenerator {
         return dictionary
     }()
 
-    public func generateAttributes(target: Target) -> [String: Any] {
+    public func generateProperties(target: Target) -> [String: Any] {
         var targetInfoPlist = defaultInfoPlist
         switch target.type {
         case .uiTestBundle,

--- a/Sources/XcodeGenKit/InfoPlistGenerator.swift
+++ b/Sources/XcodeGenKit/InfoPlistGenerator.swift
@@ -1,0 +1,42 @@
+import Foundation
+import ProjectSpec
+import PathKit
+
+public class InfoPlistGenerator {
+
+    /**
+     Default info plist attributes taken from:
+     /Applications/Xcode.app/Contents/Developer/Library/Xcode/Templates/Project Templates/Base/Base_DefinitionsInfoPlist.xctemplate/TemplateInfo.plist
+     */
+    var defaultInfoPlist: [String: Any] =  {
+        var dictionary: [String: Any] = [:]
+        dictionary["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
+        dictionary["CFBundleInfoDictionaryVersion"] = "6.0"
+        dictionary["CFBundleExecutable"] = "$(EXECUTABLE_NAME)"
+        dictionary["CFBundleName"] = "$(PRODUCT_NAME)"
+        dictionary["CFBundleDevelopmentRegion"] = "$(DEVELOPMENT_LANGUAGE)"
+        dictionary["CFBundleShortVersionString"] = "1.0"
+        dictionary["CFBundleVersion"] = "1"
+        return dictionary
+    }()
+
+    public func generateAttributes(target: Target) -> [String: Any] {
+        var targetInfoPlist = defaultInfoPlist
+        switch target.type {
+        case .uiTestBundle,
+             .unitTestBundle:
+            targetInfoPlist["CFBundlePackageType"] = "BNDL"
+        case .application,
+             .watch2App:
+            targetInfoPlist["CFBundlePackageType"] = "APPL"
+        case .framework:
+            targetInfoPlist["CFBundlePackageType"] = "FMWK"
+        case .bundle:
+            targetInfoPlist["CFBundlePackageType"] = "BNDL"
+        case .xpcService:
+            targetInfoPlist["CFBundlePackageType"] = "XPC"
+        default: break
+        }
+        return targetInfoPlist
+    }
+}

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -747,8 +747,15 @@ public class PBXProjGenerator {
         let configs: [XCBuildConfiguration] = project.configs.map { config in
             var buildSettings = project.getTargetBuildSettings(target: target, config: config)
 
-            // automatically set INFOPLIST_FILE path
-            if !project.targetHasBuildSetting("INFOPLIST_FILE", target: target, config: config) {
+            // Set CODE_SIGN_ENTITLEMENTS
+            if let entitlements = target.entitlements {
+                buildSettings["CODE_SIGN_ENTITLEMENTS"] = entitlements.path
+            }
+
+            // Set INFOPLIST_FILE
+            if let info = target.info {
+                buildSettings["INFOPLIST_FILE"] = info.path
+            } else if !project.targetHasBuildSetting("INFOPLIST_FILE", target: target, config: config) {
                 if searchForPlist {
                     plistPath = getInfoPlist(target.sources)
                     searchForPlist = false

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -33,6 +33,57 @@ public class ProjectGenerator {
         return XcodeProj(workspace: workspace, pbxproj: pbxProj, sharedData: sharedData)
     }
 
+    public func generateFiles() throws {
+
+        /*
+         Default info plist attributes taken from:
+         /Applications/Xcode.app/Contents/Developer/Library/Xcode/Templates/Project Templates/Base/Base_DefinitionsInfoPlist.xctemplate/TemplateInfo.plist
+        */
+        var defaultInfoPlist: [String: Any] = [:]
+        defaultInfoPlist["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
+        defaultInfoPlist["CFBundleInfoDictionaryVersion"] = "6.0"
+        defaultInfoPlist["CFBundleExecutable"] = "$(EXECUTABLE_NAME)"
+        defaultInfoPlist["CFBundleName"] = "$(PRODUCT_NAME)"
+        defaultInfoPlist["CFBundleDevelopmentRegion"] = "$(DEVELOPMENT_LANGUAGE)"
+        defaultInfoPlist["CFBundleShortVersionString"] = "1.0"
+        defaultInfoPlist["CFBundleVersion"] = "1"
+
+        for target in project.targets {
+            if let plist = target.info {
+                var targetInfoPlist = defaultInfoPlist
+                switch target.type {
+                case .uiTestBundle,
+                     .unitTestBundle:
+                    targetInfoPlist["CFBundlePackageType"] = "BNDL"
+                case .application,
+                     .watch2App:
+                    targetInfoPlist["CFBundlePackageType"] = "APPL"
+                case .framework:
+                    targetInfoPlist["CFBundlePackageType"] = "FMWK"
+                case .bundle:
+                    targetInfoPlist["CFBundlePackageType"] = "BNDL"
+                case .xpcService:
+                    targetInfoPlist["CFBundlePackageType"] = "XPC"
+                default: break
+                }
+                let path = project.basePath + plist.path
+                let attributes = targetInfoPlist.merged(plist.attributes)
+                let data = try PropertyListSerialization.data(fromPropertyList: attributes, format: .xml, options: 0)
+                try? path.delete()
+                try path.parent().mkpath()
+                try path.write(data)
+            }
+
+            if let plist = target.entitlements {
+                let path = project.basePath + plist.path
+                let data = try PropertyListSerialization.data(fromPropertyList: plist.attributes, format: .xml, options: 0)
+                try? path.delete()
+                try path.parent().mkpath()
+                try path.write(data)
+            }
+        }
+    }
+
     func generateWorkspace() throws -> XCWorkspace {
         let dataElement: XCWorkspaceDataElement = .file(XCWorkspaceDataFileRef(location: .self("")))
         let workspaceData = XCWorkspaceData(children: [dataElement])

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -33,57 +33,6 @@ public class ProjectGenerator {
         return XcodeProj(workspace: workspace, pbxproj: pbxProj, sharedData: sharedData)
     }
 
-    public func generateFiles() throws {
-
-        /*
-         Default info plist attributes taken from:
-         /Applications/Xcode.app/Contents/Developer/Library/Xcode/Templates/Project Templates/Base/Base_DefinitionsInfoPlist.xctemplate/TemplateInfo.plist
-        */
-        var defaultInfoPlist: [String: Any] = [:]
-        defaultInfoPlist["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
-        defaultInfoPlist["CFBundleInfoDictionaryVersion"] = "6.0"
-        defaultInfoPlist["CFBundleExecutable"] = "$(EXECUTABLE_NAME)"
-        defaultInfoPlist["CFBundleName"] = "$(PRODUCT_NAME)"
-        defaultInfoPlist["CFBundleDevelopmentRegion"] = "$(DEVELOPMENT_LANGUAGE)"
-        defaultInfoPlist["CFBundleShortVersionString"] = "1.0"
-        defaultInfoPlist["CFBundleVersion"] = "1"
-
-        for target in project.targets {
-            if let plist = target.info {
-                var targetInfoPlist = defaultInfoPlist
-                switch target.type {
-                case .uiTestBundle,
-                     .unitTestBundle:
-                    targetInfoPlist["CFBundlePackageType"] = "BNDL"
-                case .application,
-                     .watch2App:
-                    targetInfoPlist["CFBundlePackageType"] = "APPL"
-                case .framework:
-                    targetInfoPlist["CFBundlePackageType"] = "FMWK"
-                case .bundle:
-                    targetInfoPlist["CFBundlePackageType"] = "BNDL"
-                case .xpcService:
-                    targetInfoPlist["CFBundlePackageType"] = "XPC"
-                default: break
-                }
-                let path = project.basePath + plist.path
-                let attributes = targetInfoPlist.merged(plist.attributes)
-                let data = try PropertyListSerialization.data(fromPropertyList: attributes, format: .xml, options: 0)
-                try? path.delete()
-                try path.parent().mkpath()
-                try path.write(data)
-            }
-
-            if let plist = target.entitlements {
-                let path = project.basePath + plist.path
-                let data = try PropertyListSerialization.data(fromPropertyList: plist.attributes, format: .xml, options: 0)
-                try? path.delete()
-                try path.parent().mkpath()
-                try path.write(data)
-            }
-        }
-    }
-
     func generateWorkspace() throws -> XCWorkspace {
         let dataElement: XCWorkspaceDataElement = .file(XCWorkspaceDataFileRef(location: .self("")))
         let workspaceData = XCWorkspaceData(children: [dataElement])

--- a/Sources/XcodeGenKit/ProjectWriter.swift
+++ b/Sources/XcodeGenKit/ProjectWriter.swift
@@ -1,0 +1,51 @@
+import Foundation
+import ProjectSpec
+import xcodeproj
+import PathKit
+
+public class ProjectWriter {
+
+    let project: Project
+
+    public init(project: Project) {
+        self.project = project
+    }
+
+    public func writeXcodeProject(_ xcodeProject: XcodeProj) throws {
+        let projectPath = project.projectPath
+        let tempPath = Path.temporary + "XcodeGen_\(Int(NSTimeIntervalSince1970))"
+        try? tempPath.delete()
+        if projectPath.exists {
+            try projectPath.copy(tempPath)
+        }
+        try xcodeProject.write(path: tempPath, override: true)
+        try? projectPath.delete()
+        try tempPath.copy(projectPath)
+        try? tempPath.delete()
+    }
+
+    public func writePlists() throws {
+
+        let infoPlistGenerator = InfoPlistGenerator()
+        for target in project.targets {
+            // write Info.plist
+            if let plist = target.info {
+                let path = project.basePath + plist.path
+                let attributes = infoPlistGenerator.generateAttributes(target: target).merged(plist.attributes)
+                let data = try PropertyListSerialization.data(fromPropertyList: attributes, format: .xml, options: 0)
+                try? path.delete()
+                try path.parent().mkpath()
+                try path.write(data)
+            }
+
+            // write entitlements
+            if let plist = target.entitlements {
+                let path = project.basePath + plist.path
+                let data = try PropertyListSerialization.data(fromPropertyList: plist.attributes, format: .xml, options: 0)
+                try? path.delete()
+                try path.parent().mkpath()
+                try path.write(data)
+            }
+        }
+    }
+}

--- a/Sources/XcodeGenKit/ProjectWriter.swift
+++ b/Sources/XcodeGenKit/ProjectWriter.swift
@@ -43,6 +43,11 @@ public class ProjectWriter {
 
     private func writePlist(_ plist: [String: Any], path: String) throws {
         let path = project.basePath + path
+        if path.exists, let data: Data = try? path.read(),
+            let existingPlist = (try? PropertyListSerialization.propertyList(from: data, format: nil)) as? [String: Any], NSDictionary(dictionary: plist).isEqual(to: existingPlist) {
+            // file is the same
+            return
+        }
         let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
         try? path.delete()
         try path.parent().mkpath()

--- a/Sources/XcodeGenKit/ProjectWriter.swift
+++ b/Sources/XcodeGenKit/ProjectWriter.swift
@@ -30,22 +30,22 @@ public class ProjectWriter {
         for target in project.targets {
             // write Info.plist
             if let plist = target.info {
-                let path = project.basePath + plist.path
-                let attributes = infoPlistGenerator.generateAttributes(target: target).merged(plist.attributes)
-                let data = try PropertyListSerialization.data(fromPropertyList: attributes, format: .xml, options: 0)
-                try? path.delete()
-                try path.parent().mkpath()
-                try path.write(data)
+                let properties = infoPlistGenerator.generateProperties(target: target).merged(plist.properties)
+                try writePlist(properties, path: plist.path)
             }
 
             // write entitlements
             if let plist = target.entitlements {
-                let path = project.basePath + plist.path
-                let data = try PropertyListSerialization.data(fromPropertyList: plist.attributes, format: .xml, options: 0)
-                try? path.delete()
-                try path.parent().mkpath()
-                try path.write(data)
+                try writePlist(plist.properties, path: plist.path)
             }
         }
+    }
+
+    private func writePlist(_ plist: [String: Any], path: String) throws {
+        let path = project.basePath + path
+        let data = try PropertyListSerialization.data(fromPropertyList: plist, format: .xml, options: 0)
+        try? path.delete()
+        try path.parent().mkpath()
+        try path.write(data)
     }
 }

--- a/Tests/Fixtures/TestProject/App_iOS/App.entitlements
+++ b/Tests/Fixtures/TestProject/App_iOS/App.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<string>group.com.app</string>
+</dict>
+</plist>

--- a/Tests/Fixtures/TestProject/App_macOS/Info.plist
+++ b/Tests/Fixtures/TestProject/App_macOS/Info.plist
@@ -20,6 +20,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>CustomSetting</key>
+	<string>$CUSTOM_SETTING</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSMainStoryboardFile</key>

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -483,6 +483,7 @@
 		FR_DBD29CA78CDBBEF69B2C39C6D23BBDA1 /* Empty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Empty.h; sourceTree = "<group>"; };
 		FR_DC1C8DE46218F90A3F4FD5F8DE4F0ABB /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
 		FR_E3314150DA4CEFF65D69CF7DB678E845 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FR_E7BC65B06A0819B53634C5CD51946D98 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		FR_EBD99C110BD7AE780C87A31CF2E4E7DB /* App_iOS_Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_iOS_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_ED407ECED0DF010B1E787D238EA91A5D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		FR_EFD283107EDF836BF0D9F4EB3F9A0016 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -722,6 +723,7 @@
 		G_8F5765334752A7E52B1E63ACAC466729 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				FR_E7BC65B06A0819B53634C5CD51946D98 /* App.entitlements */,
 				FR_B993F75B001AB1C272CE83CACC06F0E5 /* AppDelegate.swift */,
 				FR_A0867B127ACF3ED382EB2FD5133D3EA8 /* Assets.xcassets */,
 				FR_05405007CB77B2E003B19B89401C12AB /* Info.plist */,
@@ -2258,6 +2260,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2374,6 +2377,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3920,6 +3924,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4248,6 +4253,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4293,6 +4299,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4384,6 +4391,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -47,6 +47,10 @@ targets:
   App_iOS:
     type: application
     platform: iOS
+    entitlements:
+      path: App_iOS/App.entitlements
+      properties:
+        com.apple.security.application-groups: group.com.app
     attributes:
       ProvisioningStyle: Automatic
     sources:

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -28,7 +28,7 @@ targets:
     platform: macOS
     info:
       path: App_macOS/Info.plist
-      attributes:
+      properties:
         LSMinimumSystemVersion: $(MACOSX_DEPLOYMENT_TARGET)
         NSMainStoryboardFile: Main
         NSPrincipalClass: NSApplication

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -26,6 +26,14 @@ targets:
   App_macOS:
     type: application
     platform: macOS
+    info:
+      path: App_macOS/Info.plist
+      attributes:
+        LSMinimumSystemVersion: $(MACOSX_DEPLOYMENT_TARGET)
+        NSMainStoryboardFile: Main
+        NSPrincipalClass: NSApplication
+        CFBundleIconFile: ""
+        CustomSetting: $CUSTOM_SETTING
     attributes:
       ProvisioningStyle: Automatic
     sources:

--- a/Tests/XcodeGenKitTests/ProjectFixtureTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectFixtureTests.swift
@@ -62,6 +62,7 @@ fileprivate func generateXcodeProject(specPath: Path, file: String = #file, line
     let project = try Project(path: specPath)
     let generator = ProjectGenerator(project: project)
     let xcodeProject = try generator.generateXcodeProject()
+    try generator.generateFiles()
     try xcodeProject.write(path: project.projectPath, override: true)
 
     return xcodeProject

--- a/Tests/XcodeGenKitTests/ProjectFixtureTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectFixtureTests.swift
@@ -62,8 +62,9 @@ fileprivate func generateXcodeProject(specPath: Path, file: String = #file, line
     let project = try Project(path: specPath)
     let generator = ProjectGenerator(project: project)
     let xcodeProject = try generator.generateXcodeProject()
-    try generator.generateFiles()
-    try xcodeProject.write(path: project.projectPath, override: true)
+    let writer = ProjectWriter(project: project)
+    try writer.writePlists()
+    try writer.writeXcodeProject(xcodeProject)
 
     return xcodeProject
 }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -830,6 +830,37 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(buildFileSettings.compactMap({ $0?["ATTRIBUTES"] }).count) == 1
                 try expect(buildFileSettings.compactMap({ $0?["ATTRIBUTES"] as? [String] }).first) == ["Weak"]
             }
+
+            $0.it("generates info.plist") {
+                let plist = Plist(path: "Info.plist", attributes: ["UISupportedInterfaceOrientations": ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationLandscapeLeft"]])
+                let tempPath = Path.temporary + "info"
+                let project = Project(basePath: tempPath, name: "", targets: [Target(name: "", type: .application, platform: .iOS, info: plist)])
+                let pbxProject = try project.generatePbxProj()
+                let generator = ProjectGenerator(project: project)
+                try generator.generateFiles()
+
+                guard let targetConfig = pbxProject.nativeTargets.first?.buildConfigurationList?.buildConfigurations.first else {
+                        throw failure("Couldn't find Target config")
+                }
+
+                try expect(targetConfig.buildSettings["INFOPLIST_FILE"] as? String) == plist.path
+
+                let infoPlistFile = tempPath + plist.path
+                let data: Data = try infoPlistFile.read()
+                let infoPlist = try PropertyListSerialization.propertyList(from: data, options: [], format: nil) as! [String: Any]
+                var expectedInfoPlist: [String: Any] = [:]
+                expectedInfoPlist["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
+                expectedInfoPlist["CFBundleInfoDictionaryVersion"] = "6.0"
+                expectedInfoPlist["CFBundleExecutable"] = "$(EXECUTABLE_NAME)"
+                expectedInfoPlist["CFBundleName"] = "$(PRODUCT_NAME)"
+                expectedInfoPlist["CFBundleDevelopmentRegion"] = "$(DEVELOPMENT_LANGUAGE)"
+                expectedInfoPlist["CFBundleShortVersionString"] = "1.0"
+                expectedInfoPlist["CFBundleVersion"] = "1"
+                expectedInfoPlist["CFBundlePackageType"] = "APPL"
+                expectedInfoPlist["UISupportedInterfaceOrientations"] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationLandscapeLeft"]
+
+                try expect(NSDictionary.init(dictionary: expectedInfoPlist).isEqual(to: infoPlist)).beTrue()
+            }
         }
     }
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -836,8 +836,8 @@ class ProjectGeneratorTests: XCTestCase {
                 let tempPath = Path.temporary + "info"
                 let project = Project(basePath: tempPath, name: "", targets: [Target(name: "", type: .application, platform: .iOS, info: plist)])
                 let pbxProject = try project.generatePbxProj()
-                let generator = ProjectGenerator(project: project)
-                try generator.generateFiles()
+                let writer = ProjectWriter(project: project)
+                try writer.writePlists()
 
                 guard let targetConfig = pbxProject.nativeTargets.first?.buildConfigurationList?.buildConfigurations.first else {
                         throw failure("Couldn't find Target config")

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -155,6 +155,38 @@ class SpecLoadingTests: XCTestCase {
                 try expect(target.dependencies[2]) == Dependency(type: .framework, reference: "path", weakLink: true)
             }
 
+            $0.it("parses info plist") {
+                var targetDictionary = validTarget
+                targetDictionary["info"] = [
+                    "path": "Info.plist",
+                    "attributes": [
+                        "CFBundleName": "MyAppName",
+                        "UIBackgroundModes": ["fetch"]
+                    ]
+                ]
+
+                let target = try Target(name: "", jsonDictionary: targetDictionary)
+                try expect(target.info) == Plist(path: "Info.plist", attributes: [
+                    "CFBundleName": "MyAppName",
+                    "UIBackgroundModes": ["fetch"]
+                    ])
+            }
+
+            $0.it("parses entitlement plist") {
+                var targetDictionary = validTarget
+                targetDictionary["entitlements"] = [
+                    "path": "app.entitlements",
+                    "attributes": [
+                        "com.apple.security.application-groups": "com.group",
+                    ]
+                ]
+
+                let target = try Target(name: "", jsonDictionary: targetDictionary)
+                try expect(target.entitlements) == Plist(path: "app.entitlements", attributes: [
+                    "com.apple.security.application-groups": "com.group",
+                    ])
+            }
+
             $0.it("parses cross platform targets") {
                 let targetDictionary: [String: Any] = [
                     "platform": ["iOS", "tvOS"],

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -159,7 +159,7 @@ class SpecLoadingTests: XCTestCase {
                 var targetDictionary = validTarget
                 targetDictionary["info"] = [
                     "path": "Info.plist",
-                    "attributes": [
+                    "properties": [
                         "CFBundleName": "MyAppName",
                         "UIBackgroundModes": ["fetch"]
                     ]
@@ -176,7 +176,7 @@ class SpecLoadingTests: XCTestCase {
                 var targetDictionary = validTarget
                 targetDictionary["entitlements"] = [
                     "path": "app.entitlements",
-                    "attributes": [
+                    "properties": [
                         "com.apple.security.application-groups": "com.group",
                     ]
                 ]


### PR DESCRIPTION
Resolves #406

This allows an `Info.plist` or `.entitlements` file to be generated per target via the project spec.
Some basic attributes are generated by default, but app specific ones are not for now.

This features is powerful when used in combination with `include` and `targetTemplates`.

- [x] read and generate
- [x] basic defaults
- [x] tests
- [ ] fine grained per platform/product defaults
- [x] documentation