### PR TITLE
Improve performance of getCombinedBuildSettings

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -355,7 +355,7 @@ public class PBXProjGenerator {
 
             func getSingleBuildSetting(_ setting: String) -> String? {
                 let settings = project.configs.compactMap {
-                    project.getCombinedBuildSettings(basePath: project.basePath, target: target, config: $0)[setting] as? String
+                    project.getCombinedBuildSetting(setting, target: target, config: $0) as? String
                 }
                 guard settings.count == project.configs.count,
                     let firstSetting = settings.first,
@@ -670,8 +670,7 @@ public class PBXProjGenerator {
             buildPhases.append(resourcesBuildPhase.reference)
         }
 
-        let buildSettings = project.getCombinedBuildSettings(basePath: project.basePath, target: target, config: project.configs[0])
-        let swiftObjCInterfaceHeader = buildSettings["SWIFT_OBJC_INTERFACE_HEADER_NAME"] as? String
+        let swiftObjCInterfaceHeader = project.getCombinedBuildSetting("SWIFT_OBJC_INTERFACE_HEADER_NAME", target: target, config: project.configs[0]) as? String
 
         if target.type == .staticLibrary
             && swiftObjCInterfaceHeader != ""
@@ -807,7 +806,7 @@ public class PBXProjGenerator {
             var buildSettings = project.getTargetBuildSettings(target: target, config: config)
 
             // automatically set INFOPLIST_FILE path
-            if !project.targetHasBuildSetting("INFOPLIST_FILE", basePath: project.basePath, target: target, config: config) {
+            if !project.targetHasBuildSetting("INFOPLIST_FILE", target: target, config: config) {
                 if searchForPlist {
                     plistPath = getInfoPlist(target.sources)
                     searchForPlist = false
@@ -819,7 +818,7 @@ public class PBXProjGenerator {
 
             // automatically calculate bundle id
             if let bundleIdPrefix = project.options.bundleIdPrefix,
-                !project.targetHasBuildSetting("PRODUCT_BUNDLE_IDENTIFIER", basePath: project.basePath, target: target, config: config) {
+                !project.targetHasBuildSetting("PRODUCT_BUNDLE_IDENTIFIER", target: target, config: config) {
                 let characterSet = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-.")).inverted
                 let escapedTargetName = target.name
                     .replacingOccurrences(of: "_", with: "-")
@@ -830,7 +829,7 @@ public class PBXProjGenerator {
 
             // automatically set test target name
             if target.type == .uiTestBundle,
-                !project.targetHasBuildSetting("TEST_TARGET_NAME", basePath: project.basePath, target: target, config: config) {
+                !project.targetHasBuildSetting("TEST_TARGET_NAME", target: target, config: config) {
                 for dependency in target.dependencies {
                     if dependency.type == .target,
                         let dependencyTarget = project.getTarget(dependency.reference),

--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -81,31 +81,27 @@ extension Project {
     }
 
     // combines all levels of a target's settings: target, target config, project, project config
-    public func getCombinedBuildSettings(basePath: Path, target: ProjectTarget, config: Config, includeProject: Bool = true) -> BuildSettings {
-        var buildSettings: BuildSettings = [:]
-        if includeProject {
-            if let configFilePath = configFiles[config.name] {
-                buildSettings += loadConfigFileBuildSettings(path: configFilePath)
-            }
-            buildSettings += getProjectBuildSettings(config: config)
+    public func getCombinedBuildSetting(_ setting: String, target: ProjectTarget, config: Config) -> Any? {
+        if let target = target as? Target,
+            let value = getTargetBuildSettings(target: target, config: config)[setting] {
+            return value
         }
-        if let configFilePath = target.configFiles[config.name] {
-            buildSettings += loadConfigFileBuildSettings(path: configFilePath)
+        if let configFilePath = target.configFiles[config.name],
+            let value = loadConfigFileBuildSettings(path: configFilePath)?[setting] {
+            return value
         }
-        if let target = target as? Target {
-            buildSettings += getTargetBuildSettings(target: target, config: config)
+        if let value = getProjectBuildSettings(config: config)[setting] {
+            return value
         }
-        return buildSettings
+        if let configFilePath = configFiles[config.name],
+            let value = loadConfigFileBuildSettings(path: configFilePath)?[setting] {
+            return value
+        }
+        return nil
     }
 
-    public func targetHasBuildSetting(_ setting: String, basePath: Path, target: Target, config: Config, includeProject: Bool = true) -> Bool {
-        let buildSettings = getCombinedBuildSettings(
-            basePath: basePath,
-            target: target,
-            config: config,
-            includeProject: includeProject
-        )
-        return buildSettings[setting] != nil
+    public func targetHasBuildSetting(_ setting: String, target: Target, config: Config) -> Bool {
+        return getCombinedBuildSetting(setting, target: target, config: config) != nil
     }
 
     /// Removes values from build settings if they are defined in an xcconfig file


### PR DESCRIPTION
This change refactors `getCombinedBuildSettings` for performance.

Using Instruments with our project and XCHammer (which uses XcodeGen), there was a large amount of memory management costs for calls to this method. In particular because this method was called for every target, which doesn't scale well for projects with lots of targets.

All use of `getCombinedBuildSettings()` was looking up the value for single key. For this use case, its inefficient to combine the  target, target-config, project, and project-config dictionaries into a single dictionary, since a dictionary is not the result wanted by callers. With this change, the function has been renamed to be singular (`getCombinedBuildSetting()`) and it takes a key to look for in the underlying dictionaries.

Note: Some unused parameters were also removed.