### PR TITLE
Use the provided TargetSource.headerVisibility

### DIFF
--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -119,6 +119,7 @@ public struct TargetSource: Equatable {
         self.type = type
         self.optional = optional
         self.buildPhase = buildPhase
+        self.headerVisibility = headerVisibility
     }
 }
 


### PR DESCRIPTION
This was missing in the init - simply use the value provided by the
user.