### PR TITLE
Fix issue with legacy target fileref

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -445,8 +445,6 @@ public class PBXProjGenerator {
 
                 guard let dependencyTarget = project.getTarget(dependencyTargetName) else { continue }
 
-                let dependencyFileReference = targetFileReferences[dependencyTarget.name]!
-
                 let dependecyLinkage = dependencyTarget.defaultLinkage
                 let link = dependency.link ?? (
                     (dependecyLinkage == .dynamic && target.type != .staticLibrary)
@@ -472,7 +470,7 @@ public class PBXProjGenerator {
                 if embed {
                     let embedFile = addObject(
                         PBXBuildFile(
-                            file: dependencyFileReference,
+                            file: targetFileReferences[dependencyTarget.name]!,
                             settings: getEmbedSettings(dependency: dependency, codeSign: dependency.codeSign ?? !dependencyTarget.type.isExecutable)
                         )
                     )


### PR DESCRIPTION
`xcodegen` was crashing when generating a `legacy` target as a dependency of another target (in this case an application). In the case of legacy targets, `targetFileReferences[dependencyTarget.name]` seems to be `nil`, and the generator was crashing on the force-unwrap. The value was only for used targets that are embedded into the parent target's bundle, so I moved the unwrap to that location.