### PR TITLE
Add "sdkRoot" option for Dependency

### DIFF
--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -10,6 +10,7 @@ public struct Dependency: Equatable {
     public var removeHeaders: Bool = true
     public var link: Bool?
     public var implicit: Bool = false
+    public var sdkRoot: Bool = false
     public var weakLink: Bool = false
 
     public init(
@@ -19,6 +20,7 @@ public struct Dependency: Equatable {
         codeSign: Bool? = nil,
         link: Bool? = nil,
         implicit: Bool = false,
+        sdkRoot: Bool = false,
         weakLink: Bool = false
     ) {
         self.type = type
@@ -26,6 +28,7 @@ public struct Dependency: Equatable {
         self.embed = embed
         self.codeSign = codeSign
         self.link = link
+        self.sdkRoot = sdkRoot
         self.implicit = implicit
         self.weakLink = weakLink
     }
@@ -62,6 +65,9 @@ extension Dependency: JSONObjectConvertible {
         }
         if let bool: Bool = jsonDictionary.json(atKeyPath: "implicit") {
             implicit = bool
+        }
+        if let bool: Bool = jsonDictionary.json(atKeyPath: "sdkRoot") {
+            sdkRoot = bool
         }
         if let bool: Bool = jsonDictionary.json(atKeyPath: "weak") {
             weakLink = bool

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -495,7 +495,14 @@ public class PBXProjGenerator {
                 guard target.type != .staticLibrary else { break }
 
                 let fileReference: PBXFileElement
-                if dependency.implicit {
+                
+                if dependency.sdkRoot {
+                    fileReference = sourceGenerator.getFileReference(
+                        path: Path(dependency.reference),
+                        inPath: project.basePath,
+                        sourceTree: .sdkRoot
+                    )
+                } else if dependency.implicit {
                     fileReference = sourceGenerator.getFileReference(
                         path: Path(dependency.reference),
                         inPath: project.basePath,


### PR DESCRIPTION
Whether the framework is an library under the SDKROOT directory. Defaults to false.

ex.

if you want link `$(SDKROOT)/System/Library/Frameworks/StoreKit.framework`

```
- framework: System/Library/Frameworks/StoreKit.framework
  embed: false
  sdkRoot: true
```