### PR TITLE
Validate incorrect config settings definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ targets:
     deploymentTarget: "10.0"
     sources: [MyApp]
     settings:
-      debug:
-        CUSTOM_BUILD_SETTING: my_debug_value
-      release:
-        CUSTOM_BUILD_SETTING: my_release_value
+      configs:
+        debug:
+          CUSTOM_BUILD_SETTING: my_debug_value
+        release:
+          CUSTOM_BUILD_SETTING: my_release_value
     dependencies:
       - target: MyFramework
       - carthage: Alamofire

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -22,6 +22,24 @@ extension Project {
                     }
                 }
             }
+
+            if settings.buildSettings.count == configs.count {
+                var allConfigs = true
+                for buildSetting in settings.buildSettings.keys {
+                    var isConfig = false
+                    for config in configs {
+                        if config.name.lowercased().contains(buildSetting.lowercased()) {
+                            isConfig = true
+                        }
+                    }
+                    if !isConfig {
+                        allConfigs = false
+                    }
+                }
+                if allConfigs {
+                    errors.append(.invalidPerConfigSettings)
+                }
+            }
             return errors
         }
 

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -21,6 +21,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidConfigFileConfig(String)
         case missingConfigForTargetScheme(target: String, configType: ConfigType)
         case missingDefaultConfig(configName: String)
+        case invalidPerConfigSettings
 
         public var description: String {
             switch self {
@@ -56,6 +57,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Target \(target.quoted) is missing a config of type \(configType.rawValue) to generate its scheme"
             case let .missingDefaultConfig(name):
                 return "Default configuration \(name) doesn't exist"
+            case .invalidPerConfigSettings:
+                return "Settings that are for a specific config must go in \"configs\". \"base\" can be used for common settings"
             }
         }
     }

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -205,6 +205,14 @@ class ProjectSpecTests: XCTestCase {
                 try expectValidationError(project, .missingDefaultConfig(configName: "foo"))
             }
 
+            $0.it("validates config settings format") {
+                var project = baseProject
+                project.configs = Config.defaultConfigs
+                project.settings.buildSettings = ["Debug": ["SETTING": "VALUE"], "Release": ["SETTING": "VALUE"]]
+
+                try expectValidationError(project, .invalidPerConfigSettings)
+            }
+
             $0.it("allows custom scheme for aggregated target") {
                 var project = baseProject
                 let buildScript = BuildScript(script: .path(#file), name: "buildScript1")


### PR DESCRIPTION
This fixes the example in the readme with regards to setting per config build settings. This was crashing Xcode. This also adds a validation error for when this happens.
Fixes #428