### PR TITLE
Automatically set project SDK root if there is only a single platform

### DIFF
--- a/Sources/ProjectSpec/DeploymentTarget.swift
+++ b/Sources/ProjectSpec/DeploymentTarget.swift
@@ -40,6 +40,15 @@ extension Platform {
         case .macOS: return "MACOSX_DEPLOYMENT_TARGET"
         }
     }
+
+    public var sdkRoot: String {
+        switch self {
+        case .iOS: return "iphoneos"
+        case .tvOS: return "appletvos"
+        case .watchOS: return "watchos"
+        case .macOS: return "macosx"
+        }
+    }
 }
 
 extension Version {

--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -10,6 +10,15 @@ extension Project {
     public func getProjectBuildSettings(config: Config) -> BuildSettings {
         var buildSettings: BuildSettings = [:]
 
+        // set project SDKROOT is a single platform
+        if targets.count > 0 {
+            let platforms = Dictionary(grouping: targets) { $0.platform }
+            if platforms.count == 1 {
+                let platform = platforms.first!.key
+                buildSettings["SDKROOT"] = platform.sdkRoot
+            }
+        }
+
         if let type = config.type, options.settingPresets.applyProject {
             buildSettings += SettingsPresetFile.base.getBuildSettings()
             buildSettings += SettingsPresetFile.config(type).getBuildSettings()


### PR DESCRIPTION
Fixes #320