### PR TITLE
Changes XPC Service package type to XPC!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+#### Fixed
+- Fixed XPC Service package type [#435](https://github.com/yonaskolb/XcodeGen/pull/435) @alvarhansen
+
 ## 2.0.0
 
 #### Added

--- a/Sources/XcodeGenKit/InfoPlistGenerator.swift
+++ b/Sources/XcodeGenKit/InfoPlistGenerator.swift
@@ -33,8 +33,9 @@ public class InfoPlistGenerator {
             targetInfoPlist["CFBundlePackageType"] = "FMWK"
         case .bundle:
             targetInfoPlist["CFBundlePackageType"] = "BNDL"
-        case .xpcService:
-            targetInfoPlist["CFBundlePackageType"] = "XPC"
+        case .xpcService,
+             .appExtension:
+            targetInfoPlist["CFBundlePackageType"] = "XPC!"
         default: break
         }
         return targetInfoPlist


### PR DESCRIPTION
According to Xcode templates, the package type for XPC Service is `XPC!`.
And App Extension template inherits from XCP Service Base.

When trying to run App Extension in simulator with package type `XPC` I get following error:
`
Appex bundle at /Users/alvarhansen/Library/Developer/CoreSimulator/Devices/4ABE6541-2875-40E3-A7DC-BAD7F8AC274B/data/Library/Caches/com.apple.mobile.installd.staging/temp.w9qEII/extracted/myappwithxpc.app/PlugIns/Today.appex with id com.monese.myappwithxpc.Today has an illegal value for the CFBundlePackageType key in its Info.plist: XPC
`