### PR TITLE
Don't overwrite INFOPLIST_FILE setting with info path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Fixed
 - Fixed XPC Service package type [#435](https://github.com/yonaskolb/XcodeGen/pull/435) @alvarhansen
 - Fixed phase ordering for modulemap and static libary header Copy File phases. [402](https://github.com/yonaskolb/XcodeGen/pull/402) @brentleyjones
+- Fixed overwriting INFOPLIST_FILE setting with info path [#443](https://github.com/yonaskolb/XcodeGen/pull/443) @feischl97
 
 #### Changed
 - Changed spelling of build phases to **preBuildPhase** and **postBuildPhase**. [402](https://github.com/yonaskolb/XcodeGen/pull/402) @brentleyjones

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -171,7 +171,7 @@ Settings are merged in the following order: groups, base, configs.
 	- `FRAMEWORK_SEARCH_PATHS`: If carthage dependencies are used, the platform build path will be added to this setting
 	- `OTHER_LDFLAGS`:  See `requiresObjCLinking` below
 - [ ] **dependencies**: **[[Dependency](#dependency)]** - Dependencies for the target
-- [ ] **info**: **[Plist](#plist)** - If defined, this will generate and write an `Info.plist` to the specified path and use it by setting the `INFOPLIST_FILE` build setting for every configuration. The following properties are generated automatically, the rest will have to be provided.
+- [ ] **info**: **[Plist](#plist)** - If defined, this will generate and write an `Info.plist` to the specified path and use it by setting the `INFOPLIST_FILE` build setting for every configuration, unless `INFOPLIST_FILE` is already defined in  **settings** for this configuration. The following properties are generated automatically, the rest will have to be provided.
   - `CFBundleIdentifier`
   - `CFBundleInfoDictionaryVersion`
   - `CFBundleExecutable`

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -792,13 +792,11 @@ public class PBXProjGenerator {
                 buildSettings["CODE_SIGN_ENTITLEMENTS"] = entitlements.path
             }
 
-            // Set INFOPLIST_FILE
-            if project.targetHasBuildSetting("INFOPLIST_FILE", target: target, config: config) {
-                // do not overwrite Info.plist path when already defined
-            } else if let info = target.info {
-                buildSettings["INFOPLIST_FILE"] = info.path
-            } else if !project.targetHasBuildSetting("INFOPLIST_FILE", target: target, config: config) {
-                if searchForPlist {
+            // Set INFOPLIST_FILE if not defined in settings
+            if !project.targetHasBuildSetting("INFOPLIST_FILE", target: target, config: config) {
+                if let info = target.info {
+                    buildSettings["INFOPLIST_FILE"] = info.path
+                } else if searchForPlist {
                     plistPath = getInfoPlist(target.sources)
                     searchForPlist = false
                 }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -793,7 +793,9 @@ public class PBXProjGenerator {
             }
 
             // Set INFOPLIST_FILE
-            if let info = target.info {
+            if project.targetHasBuildSetting("INFOPLIST_FILE", target: target, config: config) {
+                // do not overwrite Info.plist path when already defined
+            } else if let info = target.info {
                 buildSettings["INFOPLIST_FILE"] = info.path
             } else if !project.targetHasBuildSetting("INFOPLIST_FILE", target: target, config: config) {
                 if searchForPlist {


### PR DESCRIPTION
Resolves #440.
Just added a check if for a config INFOPLIST_FILE is already set in settings. If it is it will not be overwritten with the generated Info.plist.
I also updated projectspec.md to reflect this change.
I did not add any tests, are they necessary?