### PR TITLE
Use process unique temporary so we don't get duplicate temporary path…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed XPC Service package type [#435](https://github.com/yonaskolb/XcodeGen/pull/435) @alvarhansen
 - Fixed phase ordering for modulemap and static libary header Copy File phases. [402](https://github.com/yonaskolb/XcodeGen/pull/402) @brentleyjones
 - Add `.intentdefinition` files to sources build phase instead of resources [#442](https://github.com/yonaskolb/XcodeGen/pull/442) @yonaskolb
+- Fixed intermittent errors when running multiple `xcodegen`s concurrently [#450](https://github.com/yonaskolb/XcodeGen/pull/450) @bryansum
 
 #### Changed
 - Changed spelling of build phases to **preBuildPhase** and **postBuildPhase**. [402](https://github.com/yonaskolb/XcodeGen/pull/402) @brentleyjones

--- a/Sources/XcodeGenKit/FileWriter.swift
+++ b/Sources/XcodeGenKit/FileWriter.swift
@@ -13,7 +13,7 @@ public class FileWriter {
 
     public func writeXcodeProject(_ xcodeProject: XcodeProj, to projectPath: Path? = nil) throws {
         let projectPath = project.defaultProjectPath
-        let tempPath = Path.temporary + "XcodeGen_\(Int(NSTimeIntervalSince1970))"
+        let tempPath = try Path.processUniqueTemporary() + "XcodeGen"
         try? tempPath.delete()
         if projectPath.exists {
             try projectPath.copy(tempPath)


### PR DESCRIPTION
This commit resolves #378. The issue was that the temporary directory path was only distinguished by a second-level timestamp, which meant interleaved `xcodegen` calls would use the same temporary directory. This fix uses a globally unique string given by `NSProcessInfo`.

Test plan:
* Run multiple instances of XcodeGen at the same time in a tight loop (I used `while true; do xcodegen;  done`
* Observe that we don't see any errors reported as before.