### PR TITLE
Generate TEST_HOST

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -828,6 +828,19 @@ public class PBXProjGenerator {
                 }
             }
 
+            // automatically set TEST_HOST
+            if target.type == .unitTestBundle,
+                !project.targetHasBuildSetting("TEST_HOST", target: target, config: config) {
+                for dependency in target.dependencies {
+                    if dependency.type == .target,
+                        let dependencyTarget = project.getTarget(dependency.reference),
+                        dependencyTarget.type.isApp {
+                        buildSettings["TEST_HOST"] = "$(BUILT_PRODUCTS_DIR)/\(dependencyTarget.productName).app/\(dependencyTarget.productName)"
+                        break
+                    }
+                }
+            }
+
             // objc linkage
             if anyDependencyRequiresObjCLinking {
                 let otherLinkingFlags = "OTHER_LDFLAGS"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -1362,6 +1362,9 @@
 					AT_D40C01B2BAD29EDEA392714DFB69FE8F = {
 						CUSTOM = value;
 					};
+					NT_193BAF154270D1C21E269EDF2A1BD3F6 = {
+						TestTargetID = NT_BEB0891E36797FE2214A0A9D516D408D;
+					};
 					NT_B91A6EACD6F5192FECA2E95FD531D0CA = {
 						ProvisioningStyle = Automatic;
 					};
@@ -2829,6 +2832,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Production Debug";
 		};
@@ -3119,6 +3123,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Staging Release";
 		};
@@ -3359,6 +3364,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Test Release";
 		};
@@ -3843,6 +3849,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Test Debug";
 		};
@@ -4472,6 +4479,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Production Release";
 		};
@@ -4488,6 +4496,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Staging Debug";
 		};

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -2832,6 +2832,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
 				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Production Debug";
@@ -3123,6 +3124,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
 				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Staging Release";
@@ -3364,6 +3366,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
 				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Test Release";
@@ -3849,6 +3852,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
 				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Test Debug";
@@ -4479,6 +4483,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
 				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Production Release";
@@ -4496,6 +4501,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
 				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Staging Debug";


### PR DESCRIPTION
Fixes #377 and #408

This generates a `TEST_HOST` build setting and a `TestTargetID` project attribute for unit tests