### PR TITLE
Add mlmodel to compiled file extensions

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -192,7 +192,8 @@ class SourceGenerator {
                  "S",
                  "xcdatamodeld",
                  "intentdefinition",
-                 "metal":
+                 "metal",
+		 "mlmodel":
                 return .sources
             case "h",
                  "hh",

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -193,7 +193,7 @@ class SourceGenerator {
                  "xcdatamodeld",
                  "intentdefinition",
                  "metal",
-		 "mlmodel":
+                 "mlmodel":
                 return .sources
             case "h",
                  "hh",

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -435,6 +435,7 @@ class SourceGeneratorTests: XCTestCase {
                     - file.123
                     - file.xcassets
                     - file.metal
+                    - file.mlmodel
                     - Info.plist
                     - Intent.intentdefinition
                 """
@@ -484,6 +485,7 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFile(paths: ["C", "file.123"], buildPhase: .resources)
                 try pbxProj.expectFile(paths: ["C", "Info.plist"], buildPhase: .none)
                 try pbxProj.expectFile(paths: ["C", "file.metal"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: ["C", "file.mlmodel"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["C", "Intent.intentdefinition"], buildPhase: .sources)
             }
 


### PR DESCRIPTION
Xcode requires that '.mlmodel' files be handled as Sources and not as Resources.  They need to be processed and compiled and not copied as part of resource bundle.