### PR TITLE
Bug carthage dependencies with different platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed `--project` argument not taking effect [#487](https://github.com/yonaskolb/XcodeGen/pull/487) @monowerker
 - Fixed Sticker Packs from generating an empty Source file phase which caused in error in the new build system [#492](https://github.com/yonaskolb/XcodeGen/pull/492) @rpassis
 - Fixed generated schemes for tool targets not setting the executable [#496](https://github.com/yonaskolb/XcodeGen/pull/496) @yonaskolb
+- Fixed resolving Carthage dependencies for iOS app with watchOS target. [465](https://github.com/yonaskolb/XcodeGen/pull/465) @raptorxcz
 
 ## 2.1.0
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -967,7 +967,13 @@ public class PBXProjGenerator {
                         frameworks[dependency.reference] = dependency
                     case .target:
                         if let projectTarget = project.getProjectTarget(dependency.reference) {
-                            queue.append(projectTarget)
+                            if let dependencyTarget = projectTarget as? Target {
+                                if topLevelTarget.platform == dependencyTarget.platform {
+                                    queue.append(projectTarget)
+                                }
+                            } else {
+                                queue.append(projectTarget)
+                            }
                         }
                     default:
                         break


### PR DESCRIPTION
When project is generated, then in iOS app are added all carthage dependencies.
This behaviour is wrong, because iOS target can have watchOS target as a dependency.