### PR TITLE
Update Linkage to handle additional PBXProductType case from xcodeproj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+#### Added
+- Added support for the `instrumentsPackage` product type
+
 ## 2.1.0
 
 #### Added

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -215,6 +215,7 @@ This will provide default build settings for a certain product type. It can be a
 - `bundle.ui-testing`
 - `bundle.ocunit-test`
 - `framework`
+- `instruments-package`
 - `library.dynamic`
 - `library.static`
 - `tool`

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI.git",
         "state": {
           "branch": null,
-          "revision": "37f4a7f863f6fe76ce44fc0023f331eea0089beb",
-          "version": "5.2.0"
+          "revision": "5318c37d3cacc8780f50b87a8840a6774320ebdf",
+          "version": "5.2.2"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/tuist/xcodeproj.git",
         "state": {
           "branch": null,
-          "revision": "23da51abd3de3bedaad59a0afbb150b48504b5b0",
-          "version": "6.3.0"
+          "revision": "8e15cc74149ee946b7ae125685177915b4ff7317",
+          "version": "6.4.0"
         }
       },
       {

--- a/Sources/ProjectSpec/Linkage.swift
+++ b/Sources/ProjectSpec/Linkage.swift
@@ -15,6 +15,7 @@ extension Target {
              .application,
              .bundle,
              .commandLineTool,
+             .instrumentsPackage,
              .messagesApplication,
              .messagesExtension,
              .ocUnitTestBundle,

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -7,15 +7,15 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		AT_D40C01B2BAD29EDEA392714DFB69FE8F /* SuperTarget */ = {
+		BF3693DCA6182D7AEC410AFC08078F33 /* SuperTarget */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = CL_B523BC91AF70F483BF998E2BA8DD6669 /* Build configuration list for PBXAggregateTarget "SuperTarget" */;
+			buildConfigurationList = 7CBF487CACC0BBFB530D79633BC124AA /* Build configuration list for PBXAggregateTarget "SuperTarget" */;
 			buildPhases = (
-				SSBP_831D7D5A30B0F736E1E92F7B5CF9428F /* MyScript */,
+				CF3AABFD4A48983B322677DAACDF6B95 /* MyScript */,
 			);
 			dependencies = (
-				TD_B8AB4064784522A5F3760CB1372D1BCD /* PBXTargetDependency */,
-				TD_D056799E80FFF41247BAE692D01142F0 /* PBXTargetDependency */,
+				16C98D48AA905F0ACDB2677E8E10558D /* PBXTargetDependency */,
+				9C162664CD744CFC1AA23F81C4BE5566 /* PBXTargetDependency */,
 			);
 			name = SuperTarget;
 			productName = SuperTarget;
@@ -23,935 +23,935 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		BF_021628792D80050372F6E56A6C3D0561 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_B993F75B001AB1C272CE83CACC06F0E5 /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
-		BF_0378AD9857D61219363F74B2FA308B5A /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_EFD283107EDF836BF0D9F4EB3F9A0016 /* Framework.framework */; };
-		BF_0A6C302954FF03411D6F2704ECF5C738 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_0B3CE605B6243480C374176E01B1BB12 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_96127F4D9D804B89024AB846F0961621 /* module.modulemap */; };
-		BF_0BBC6762FFFC3394DCB0570CCEFB1970 /* iMessageExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_0570C52FB0BC489485EAF0CE7B7119A1 /* iMessageExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_149B8FD8F114C531F675E01FBE814609 /* ResourceFolder in Resources */ = {isa = PBXBuildFile; fileRef = FR_1B0304C0E4DC73614BAA550E4A80D41C /* ResourceFolder */; };
-		BF_19C973A29D9994B1E0655B1AFC5528AD /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_6542B94EE7DA40CD30BC54DED26C61C7 /* Interface.storyboard */; };
-		BF_1C8AAB7468188315681C0879591969B4 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_96127F4D9D804B89024AB846F0961621 /* module.modulemap */; };
-		BF_1EC32E6544284999188A140FB5FC6E67 /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_5CFDEA59B939FA9F3CA4F775B9E6AD2B /* TestProjectUITests.swift */; };
-		BF_230439786C4C6849F488A5FADC6A42A5 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_11478908A963CED036DABEF21D85DF01 /* Result.framework */; };
-		BF_2356EAE09301354149D45720369BE7F2 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_D0BE69522DB875ADB041E9135E0767CA /* StaticLibrary_ObjC.h */; };
-		BF_30024D558743C8ABC415D87431CDC13C /* SomeFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_2F56FD7A1F7782467AC9F315B6133468 /* SomeFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_3080067722B357BFC053D89CCDBF5397 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */; };
-		BF_33EA0F8B2ADA2D24A683FCD8D6235B10 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_36BCFE51A59D5EAE19684491C9F5427F /* StaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_1C00E09FA3D2CDB962FE8D5584853E0D /* StaticLibrary_ObjC.a */; };
-		BF_3811C1771AF5342AD8F9FEB63A3465B5 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */; };
-		BF_390908C547D6F8520DF9AA0CC5A98EB1 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = FR_3DD4DE355C21662A9169EE41C44F73E3 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_3B680DD27CFCD491675F1BF257A95A24 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_42C8B667C3B7417C14B063AF0F16C1A6 /* StaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_36044227861B95AC5060E7D063BED65A /* StaticLibrary_ObjC.a */; };
-		BF_47A75C8A7EF15658238E254C846C5C6B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_30676EBEE9BE54AA26CAE69BE744CAE8 /* Main.storyboard */; };
-		BF_47FBEFEA08B9642C1F711EDA77FC8C89 /* LocalizedStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_FE6D89DA2D7E7F58340D566590FF221C /* LocalizedStoryboard.storyboard */; };
-		BF_47FF83A37355E90F93C0F5B2CFBCE317 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_82E3C6C060C4487B5177509917C3FAE3 /* Standalone.swift */; };
-		BF_486398284252AEE9001DD72E5E710D93 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_6A3D8067EBC18CB321826EB21FEBD094 /* libc++.tbd */; };
-		BF_4D56F3F4D081A77C11325B96DD34D8E1 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */; };
-		BF_4EBBAD70FA73DDC89BD933866B90DD08 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_51D370314B5DA8E002A908021E459F50 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_A55A35F549FD72775C37ED05342812AA /* Assets.xcassets */; };
-		BF_527E94EECC2501E12D28790BF9318FD3 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_96127F4D9D804B89024AB846F0961621 /* module.modulemap */; };
-		BF_52C8E2C5962601534CE6F00B88FDB048 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_14B7B5469AA17939993A2B25E775D391 /* Main.storyboard */; };
-		BF_5336CD16DBDB1654D75AA91B922DEAD6 /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_CC3A24A5C8E1815346752C5AB0745176 /* InterfaceController.swift */; };
-		BF_569CC068CD4B7BCE35E974D7B61566DB /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_59E5DB880E7823E6BC1D62FAF99E5758 /* App_watchOS.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = FR_30E7940EF436086816B40DAC068BD238 /* App_watchOS.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_5C6407EDAC3D88B020BCB46724DC1D14 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */; };
-		BF_65835F9276FF0DB8E27D098367F9D03C /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = VG_C247AA37E9057916EDDC65C7B55E2F38 /* Localizable.stringsdict */; };
-		BF_67219751DE020023F9D6068EDCCDC445 /* SomeXPCService.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_4EB4AAACD714C13E5BC894C71B954299 /* SomeXPCService.xpc */; };
-		BF_6AA4D902E371C0F078917EB44F966B16 /* App_watchOS Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_545DDE4AB557C8FAAD87775CD4271BDF /* App_watchOS Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_6E2D4086A22C12D516A06AE66DC48D16 /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_099E2C49D4A0B799E78B39C47FBEADF7 /* Framework.framework */; };
-		BF_703163C1C547AD6EF09BEA5F5F5ED49C /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_96127F4D9D804B89024AB846F0961621 /* module.modulemap */; };
-		BF_729EB1C88A5E43B2342099D81B301F4D /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */; };
-		BF_76825DD9B3B10103CDAB9D235BDF6A91 /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_5FEC20FF753341FD0483E2E4C622DB05 /* MessagesViewController.swift */; };
-		BF_77C9BB7BED4F5970D02E69312259FE09 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_C2A280C4FA602E6610BCFB820602B69E /* StaticLibrary_ObjC.m */; };
-		BF_7C9646667C0D479544A2207DEE3E930B /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = FR_3DD4DE355C21662A9169EE41C44F73E3 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_81711FB79375EB743254B809B4E246E0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_4DB225C7FF39C16EEFD9A1A5595FCDBC /* AppDelegate.swift */; };
-		BF_8610CB66872BC72C1690EBD8D102FBC0 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */; };
-		BF_86F2552DA1E230901EC4CB1A40399019 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_CEAE8D9C3F3920D6EADE5455C188EAAE /* Result.framework */; };
-		BF_8765851BF5D99B10C220DDD57B968B10 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_11478908A963CED036DABEF21D85DF01 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_90F0E9253F2768C312B65530931CD55A /* Empty.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_DBD29CA78CDBBEF69B2C39C6D23BBDA1 /* Empty.h */; };
-		BF_910C2D6055BD22643F042545CD21AA78 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_D0BE69522DB875ADB041E9135E0767CA /* StaticLibrary_ObjC.h */; };
-		BF_93A4E1A93C7DB4289E526466D547E55E /* SomeFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_2F56FD7A1F7782467AC9F315B6133468 /* SomeFramework.framework */; };
-		BF_9743BCF98E3EF021AB384652DA126416 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_9A09F93850576AF57455BE58FD53C42F /* Contacts.framework */; };
-		BF_9830FFD35765AACD86D1B619E22830D6 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = FR_3DD4DE355C21662A9169EE41C44F73E3 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_98DEE7FD578AA439550E0023A2ECE8D0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_25BDF725104C5E280D45CBF33F54C72C /* ViewController.swift */; };
-		BF_9A74AED05E2F61530BFA0F7D23AF0112 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = VG_EB676136B9F946373D4796800CC00AD4 /* Model.xcdatamodeld */; settings = {COMPILER_FLAGS = "-Werror"; }; };
-		BF_9D9B97D239384F4CE6E73852E027B787 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_B537FEE8515090D3BA0F5CFF3BC76BB1 /* Assets.xcassets */; };
-		BF_A29F8B04C9DD9ADE1EF5AFDAAA0130D2 /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_DBB69305458B16774C88720CDD3978E5 /* ExtensionDelegate.swift */; };
-		BF_A8A5905BCA8872B2D7B0EF6326B33077 /* MyBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_291D6D09ACADC420638E83BEE89DFFEB /* MyBundle.bundle */; };
-		BF_ABA4EA32A6DB022806126D9C1418BBA3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_ED407ECED0DF010B1E787D238EA91A5D /* Assets.xcassets */; };
-		BF_AC2CE59D56846478FDFBB376FF9F9DC0 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_BE436BDD64E90EFB600D47AC69B49DD3 /* Localizable.strings */; };
-		BF_B2B4B15D6F7B242DBDA39939111282F9 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_D7B45FAEE40EE622B4FA9192609F9717 /* TestProjectTests.swift */; };
-		BF_B5446C54E942A18E025D2061A88004A4 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_11478908A963CED036DABEF21D85DF01 /* Result.framework */; };
-		BF_B57F9691AD12CA8AE5528A2BAB9E4A43 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_F256536BB07CF3E64C4DD934F75BED9C /* LaunchScreen.storyboard */; };
-		BF_B69A0C5F1A19F65CA603F58247A8CD41 /* Framework2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_1EA1EAB0CB9BD96BC550879E58911B12 /* Framework2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_B6E31790D07B981E52CD5BC9049FE303 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_B8E824A58BFE0B81E16BB26087FDC8B4 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_CEAE8D9C3F3920D6EADE5455C188EAAE /* Result.framework */; };
-		BF_BD2537A230BFC8A86681F0AF34C929DA /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_8B770F475242D91FC20289A3B35CD165 /* Result.framework */; };
-		BF_BEFDF47CD7D88221A9C166BD65BF2013 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_C5EA496FE2EDF51C92DC55FD552472E5 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_D0BE69522DB875ADB041E9135E0767CA /* StaticLibrary_ObjC.h */; };
-		BF_C9D24A56926211130F4E25B5D9972B58 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_C2A280C4FA602E6610BCFB820602B69E /* StaticLibrary_ObjC.m */; };
-		BF_CD062A97959629BD672893FDAE89A1E9 /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_BB49B398F9291781A60DA963A0BF168C /* NotificationController.swift */; };
-		BF_D0676C98017B6FDD96A733CB851645DE /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_C2A280C4FA602E6610BCFB820602B69E /* StaticLibrary_ObjC.m */; };
-		BF_D0D1D142403C75D11757CB7092E8D035 /* XPC Service.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_1FA381C639CE4923ED6845790A5DF9D2 /* XPC Service.xpc */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_D2532BE2FA7D664875AD6E29A22269C0 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_9A09F93850576AF57455BE58FD53C42F /* Contacts.framework */; };
-		BF_D3D64E2595369BBDEF03E07543AE2779 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */; };
-		BF_D6588CD7B83034816FFD3A7DB10DAD78 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_16B791CFA2095097A17CC216977DF6EF /* Assets.xcassets */; };
-		BF_D7E271A6820E0A908736F44F99341DE1 /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_EFD283107EDF836BF0D9F4EB3F9A0016 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_DA12D48C9BCEC64D55B87CE8703432BE /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_D0BE69522DB875ADB041E9135E0767CA /* StaticLibrary_ObjC.h */; };
-		BF_DBF3047DCE71CB2E7B9AC7367F44F8DB /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_CCC97AF230188CAF9B4A66324891CCAD /* StaticLibrary.swift */; };
-		BF_E228A4D3997297780216722D71AC9FE5 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_C2A280C4FA602E6610BCFB820602B69E /* StaticLibrary_ObjC.m */; };
-		BF_E2D02DDEDD7DC21831F50A6EAA71E528 /* StandaloneAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_C6A9DE885CAF350F6C9D0AC6F7324CD3 /* StandaloneAssets.xcassets */; };
-		BF_E35C9C198B45406E64439FF96C17F056 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_E6B3BA0A3A687598FB5CCDF0524E1B10 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */; };
-		BF_EA0063B4FC2A0980A746D35A8DF71CED /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = VG_06DC429EEFBBA25BC3EE1AA1B4062C10 /* MainInterface.storyboard */; };
-		BF_EBC45940911A4942BA04AE1285BF3802 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_A0867B127ACF3ED382EB2FD5133D3EA8 /* Assets.xcassets */; };
-		BF_EC0616A0D18A2F723D2AF50287C43669 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = FR_3DD4DE355C21662A9169EE41C44F73E3 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_ED8BB47A2229EC3BEE544608267FB82D /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_DC1C8DE46218F90A3F4FD5F8DE4F0ABB /* Result.framework */; };
-		BF_F12E44D8E7F617E8A5FD8E1A342E5FAD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_752FB5DFFBC490CFB9742549A0C48527 /* ViewController.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
-		BF_F3D57DA3E1F8A539BDD72E02A8C23FC6 /* iMessageApp.app in Resources */ = {isa = PBXBuildFile; fileRef = FR_3305E7E3B08D04C667D02BD29D3A45A9 /* iMessageApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_F6A0FC1F0C9A4EC13BCCBB764D716C3F /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_CEAE8D9C3F3920D6EADE5455C188EAAE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_F6FBB97A7DE0F6D06661A00E3B22E8CF /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_099E2C49D4A0B799E78B39C47FBEADF7 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_F7AC9F45ED37FCD5A749FD6F5F4518AF /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_82E3C6C060C4487B5177509917C3FAE3 /* Standalone.swift */; };
-		BF_F8D73622DA7CFF30DB9AD17C08C63655 /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_1EA1EAB0CB9BD96BC550879E58911B12 /* Framework2.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		BF_F9E44FE6ECBD936A8C762D425DDBA37C /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FR_CEAE8D9C3F3920D6EADE5455C188EAAE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		BF_FA28229372AB6236883309181258AF26 /* XPC_Service.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_7F4496C534F2DF8C4FB9A8D52414990B /* XPC_Service.m */; };
-		BF_FA5F3C87A2571E0F39637D118B6C6F8F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FR_B243640A6F73B3F3D33ABD05ABDBC26B /* Assets.xcassets */; };
-		BF_FD13F69A90FB1D5676B97A8C77D710B4 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_F5436E663145426483F206F8A61400BC /* main.m */; };
-		BF_FF7EBDFA4462D2983743C84CE99D9714 /* MoreUnder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_AC5B2FCE520D5306B254D5857E15B6CB /* MoreUnder.swift */; };
+		03F389DFD30F3CE5A441925C10CAED46 /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5ABEA2284F13483EFDF7C0E050F0450 /* MessagesViewController.swift */; };
+		03FC73E479EBD3CFF4E55BBC6CC82311 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		097B0B6C198B9A52D4312F11000496FD /* App_watchOS.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = A680BE9F68A255B0FB291AE6F0A2B045 /* App_watchOS.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		0C8ADA24D201C830751FBE37DFB5FAA2 /* iMessageExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = D629E142AB87C681D4EC90F7106F7299 /* iMessageExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		0D281787B630CE62E91F9F7219EFF40D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D8A016580A3B8F72B820BFBF93749CD7 /* Assets.xcassets */; };
+		0F7F220834A3E2B344322B64DB5140DF /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BB1B49A91B892152D68ED76D9D4E759 /* libc++.tbd */; };
+		13C624ABA05AC67129468002144005A9 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0704B6CAFBB53E0EBB08F6B385901D43 /* ViewController.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		1985E98D7107DFCBB2F2AC7DC6A155B5 /* SomeFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 73E7D4B860A5B6B80540E64703192744 /* SomeFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1E105E72C258FF9843B21D8A3F520CFB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1F06D99242F4223D081F0DF78367F3 /* LaunchScreen.storyboard */; };
+		205719BEDEFFC911468631925C617988 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D185A35C1FB /* module.modulemap */; };
+		21B9D91DC3573A47C3298339795D0D2A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B419F22EB75EDD4AB9B92F32F7D39755 /* Assets.xcassets */; };
+		262B4F15CB0780B21C37D89F5EA9FE80 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		29A79F030DD325754FD2C82C4A6E0AE6 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B53F03FF0 /* Result.framework */; };
+		2DE309130A6F5A7E2E7E13169357C316 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		319B977623307E83E948E9E4CEBB432E /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359FD0114B0C /* StaticLibrary_ObjC.h */; };
+		3474A5D469F41494C4CB871D75C77106 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D185A35C1FB /* module.modulemap */; };
+		36152E299B36BCA0F25AD1FC9B002835 /* MoreUnder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8718C7CD3BE86D9B1F51203A548A51 /* MoreUnder.swift */; };
+		36F2B8CC97BD885A59E4FBA6EBC8EB22 /* StandaloneAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3571E41E19A5AB8AAAB04109D524DB4F /* StandaloneAssets.xcassets */; };
+		3799FF03E75F5D3C925CBB18B8BB7BF6 /* Framework2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3EF21DF245F66BEF5446AAEF769A4194 /* Framework2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3A9B6CE17CFDF8537B52B1AFC4668973 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D0C79A8C750EC0DE748C463D6992773 /* StaticLibrary_ObjC.m */; };
+		3C96F8384CC8C6401A0EE14727C5D323 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D0C79A8C750EC0DE748C463D6992773 /* StaticLibrary_ObjC.m */; };
+		3E7ABFF8EC0A3EC912899F469BF5A126 /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F6BCB5FEFB16F1BA368059F4B1505A /* InterfaceController.swift */; };
+		41B0909025B983E66FCC4AA8A1FE3634 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D185A35C1FB /* module.modulemap */; };
+		446723391DA2F5E9AD4CE064EF80F99A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C3FE6B986506724DAB5D0FC4361D53 /* ViewController.swift */; };
+		44D5928E07962D68D84D775AF3F59D81 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 74FBDFA5CB063F6001AD8ACD1776F055 /* Main.storyboard */; };
+		46DA8D104900945921DF4E7DDF584C25 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4A06CFF585E242ADFB8CDDBA43E73115 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */; };
+		4C29EFBFCC52C847A4B6A268433D0B45 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B53F03FF0 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4E1D7AEB1B385E219995CB9C703F4DAC /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */; };
+		53B2D7C4FD56D5D1D8AF16B23110235D /* StaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D0BF47DF71A6DBA33ED23FD22D023EF /* StaticLibrary_ObjC.a */; };
+		53E84BFC6E79B3CFDF2EDB28E2E6F7D2 /* LocalizedStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0C6BA0D12467A13EC012C728D9169681 /* LocalizedStoryboard.storyboard */; };
+		54D6B532658C2616DA4AD8CDDB1BBB89 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B384745ED88A7A92353B7D120F975B4 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359FD0114B0C /* StaticLibrary_ObjC.h */; };
+		5BEF6520D576C03A372B55F47E0C9DBB /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */; };
+		5CA4B07D0D79B2D8C48DBF7118FDBEF6 /* Empty.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 068EDF47F0B087F6A4052AC08A2FA1E4 /* Empty.h */; };
+		5CAADD8469B81616A79CECD7DC2F58B5 /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAF6C55B555E3E1352645B630CCB23E /* ExtensionDelegate.swift */; };
+		5CB4C10148DD10D82B5ADBBDAD52BCD1 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B53F03FF0 /* Result.framework */; };
+		5F49DEBEDCC54D28AD3571B88753A356 /* App_watchOS Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 0D09D243DBCF9D32E239F1E8A64D75AB /* App_watchOS Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		6544AAAD64A06DA3D891642A337C1730 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D0C79A8C750EC0DE748C463D6992773 /* StaticLibrary_ObjC.m */; };
+		6CD98D352BB52EB22E352454E74CA42C /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 65C8D6D1DDC1512D396C07B712F31188 /* Localizable.stringsdict */; };
+		6CE2C63470E541C3A04F3E9ED6B3F10B /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EF21DF245F66BEF5446AAEF769A4194 /* Framework2.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		6D175FFCC1377D131785965D99F7E90E /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D185A35C1FB /* module.modulemap */; };
+		704298EAAB9D0F8C8471EE1F149F82AC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09B82F603D981398F38D762E418E8BB9 /* AppDelegate.swift */; };
+		74BC0F70B2D3EC06E623CB0FD6630D0F /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B53F03FF0 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		74D29BA5C4116670E4585FA413AF8460 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BD97AF0F94A15A5B7DDB75C0C7CDF /* Standalone.swift */; };
+		74E74F67565A0084FFA3E17C735B09EF /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D0C79A8C750EC0DE748C463D6992773 /* StaticLibrary_ObjC.m */; };
+		7856158603A68D4FF152F8E96305B3E7 /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A9274BE42A03DC5DA1FAD04992ED6E3 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7A3C2B80CE0F5D42B7684BF5928B1694 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 2E1E747C7BC434ADB80CC269B7B595DC /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+		7C9152ACD50B4F96C205B0DDEFD7D6D3 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B47B80AF9EAE0ADB4FA469CFDB7ABB8F /* MainInterface.storyboard */; };
+		7E84045B3F49256D14A8E8C1FF19490A /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C934C1F7A68CCD0AB6B384782470EE7B /* NotificationController.swift */; };
+		7EC05429C10D0A00A8AE38CADF3F5DCA /* XPC_Service.m in Sources */ = {isa = PBXBuildFile; fileRef = 148B7C933698BCC4F1DBA979CF051F81 /* XPC_Service.m */; };
+		824FECDE01A22CDE6C288C1969A645E9 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */; };
+		82D432D23D2ACC56338BE911465E6F89 /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41FC82ED1C4C3B7B3D7B2FB721574442 /* Framework.framework */; };
+		8493DEA48BF40EFFAC6FBD459C0E9EE4 /* ResourceFolder in Resources */ = {isa = PBXBuildFile; fileRef = 6B1603BA83AA0C7B94E45168D7E684C4 /* ResourceFolder */; };
+		862C296BFE176C091397763A66610C41 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3797E591F302ECC0AA2FC607B190E2C8 /* Assets.xcassets */; };
+		8670A20B54D6E96461DD53EBCB0644EC /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */; };
+		87C8C972BF12378AD6D85C79760FB151 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 814D72C2B921F60B759C2D4BB2604550 /* Main.storyboard */; };
+		8BCF9B1A396126583737A6687CF20696 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 2E1E747C7BC434ADB80CC269B7B595DC /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+		8BD6E6E86A37882FB7C802E33DD03105 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB178D03E75929F3F5B10C56838882EC /* Result.framework */; };
+		9CB4F00B54E46A4F9E477ABBD94C4C25 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1A2F579A6F79C62DDA05712E2AB1F7 /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		A1144E47C6EFE30830087F384717526E /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDB2B6A77D39CD5602F2125F01DEF025 /* Contacts.framework */; };
+		A3A3D2042DF93D8FBF171C1B0C8DA244 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D132EA69984F32DA9DC727B6360D9F12 /* TestProjectTests.swift */; };
+		A4A2DCF0818C891E44C2BA675B91B5CF /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C872631362DDBAFCE71E5C66EDD61432 /* Interface.storyboard */; };
+		AF083D3FCE667FF0E55C291CB9B99328 /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587B9E9A3533E965CA602B763210583F /* TestProjectUITests.swift */; };
+		BA3997DDBE08311586C3B9DA73F8DC49 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BAC0E24AC446937ADEE256F08C17D0EC /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */; };
+		BBB8CB2B1E70458EF477A9084959FEF5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 42B95EB66A17FBA091F50601196CAA83 /* Assets.xcassets */; };
+		BC45B351474BD07D6C4BCD66327FFBFE /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C3B73C7A69119513C543ED75DAB1C492 /* StaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 056A43A09CE7E88D578696D83330E45F /* StaticLibrary_ObjC.a */; };
+		C511BD950B937DB0F2FC5DDD0ED96D20 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */; };
+		C95B9FB572B661497D2EC9BD728667A8 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E55F45EACB0F382722D61C8D518BF80D /* Assets.xcassets */; };
+		CBAC0459E3DCD72B512329E604C46B2E /* MyBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B5068D64404C61A67A184584E13804D /* MyBundle.bundle */; };
+		CC83632C49106DE960F699314C45FA87 /* XPC Service.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = 22237B8EBD9E6BE8EBC8735F5AA17192 /* XPC Service.xpc */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CF187FEB832DA1662FCB636FCC9C7926 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 187E665975BB5611AF0F27E15659D85C /* main.m */; };
+		D5221D8AE288C1875C03AD3AE9DB6411 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BD97AF0F94A15A5B7DDB75C0C7CDF /* Standalone.swift */; };
+		D7BFCCEFB53658505D03C6A9A5F0A0FA /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 306796628DD52FA55E833B65DD4F2A22 /* Model.xcdatamodeld */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		D8859E56A17FCD26C7ED6548C81B1324 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 2E1E747C7BC434ADB80CC269B7B595DC /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+		D8C50B10DC463A32C288C1A88FDCECC2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9E17D598D98065767A04740F5E729CCA /* Localizable.strings */; };
+		DAFD488BAFDFD93F6B540648BC4CAF3A /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE5B41F583 /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DE50B077EE4BFABAF128321B2A13886F /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A9274BE42A03DC5DA1FAD04992ED6E3 /* Framework.framework */; };
+		E011E6F68007B6479AF63E8E7433C0C4 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */; };
+		E32A04EF64C8989C8349A476E3DC1F19 /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 41FC82ED1C4C3B7B3D7B2FB721574442 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E48B36322124BDE8EE3AF22EB3B2B47C /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E7555C1BCBCF88204907587DBD341663 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 2E1E747C7BC434ADB80CC269B7B595DC /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+		EA0D7CDB58D81E7D92E731535E41FB5E /* SomeFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 73E7D4B860A5B6B80540E64703192744 /* SomeFramework.framework */; };
+		EEDCCB9427FA46F272DFC190FCCBE77A /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC91042453E18DF74BA1C0F957D87DC /* StaticLibrary.swift */; };
+		EF285B90A968453FA1CB0CDE8C0AD440 /* iMessageApp.app in Resources */ = {isa = PBXBuildFile; fileRef = 9A87A926D563773658FB87FEEE4DD132 /* iMessageApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		EFBDE105D3397BE7AAC207B8AD3CC8BB /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE5B41F583 /* Result.framework */; };
+		F04CBE9A3D61F78E4FEE6A09AED606C0 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359FD0114B0C /* StaticLibrary_ObjC.h */; };
+		F08C4D2A18A75CC292F45F1FB8E06CDE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 108BB29172D27BE3BD1E7F3536D14EAD /* Assets.xcassets */; };
+		F7ECF245988DABA0164DFF08607F6C31 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE5B41F583 /* Result.framework */; };
+		FBDBC020EE959F32F0FF0E6252028356 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDB2B6A77D39CD5602F2125F01DEF025 /* Contacts.framework */; };
+		FE01CB2392794EC5CD44533920AA051B /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359FD0114B0C /* StaticLibrary_ObjC.h */; };
+		FE4C8407830C0189E1F61AFBEF16398B /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B76E17CE3574081D5BF45B449F3F46DB /* Result.framework */; };
+		FE5B714E4FCA0E8BF74B9FA58C516DBA /* SomeXPCService.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = 70A8E15C81E454DC950C59F092CC1049 /* SomeXPCService.xpc */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		CIP_1AEF07B9F6A9BC9605E82F26AE7BFE15 /* PBXContainerItemProxy */ = {
+		14A6C07F14B40638A00E0CF40992D84F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_6AEE12F93D449E249F5348BBF35D3053;
-			remoteInfo = StaticLibrary_ObjC_iOS;
-		};
-		CIP_1C3D8F2BF099A773651CF8A195466469 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_D4C3E345E90AF9F6CBE8CF226FCFBCD6;
-			remoteInfo = StaticLibrary_ObjC_tvOS;
-		};
-		CIP_1F8C8F9FAC75236BB2F60C3BCAE41C55 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_6AEE12F93D449E249F5348BBF35D3053;
-			remoteInfo = StaticLibrary_ObjC_iOS;
-		};
-		CIP_291A38592460740F400A80DE5DBA9679 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_BEB0891E36797FE2214A0A9D516D408D;
-			remoteInfo = App_iOS;
-		};
-		CIP_47399FDE0885501C87782313489C95A3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_34A020E43FBBD797051205235CD82B70;
-			remoteInfo = StaticLibrary_ObjC_watchOS;
-		};
-		CIP_4FA1F11884BC4F5DBDFAC1FBEC60AFC1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_BEB0891E36797FE2214A0A9D516D408D;
-			remoteInfo = App_iOS;
-		};
-		CIP_5E9F76628F77E820EB9AA60A282D8691 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_6BD068FAAC6AA35C090C48147B94EC6E;
-			remoteInfo = iMessageApp;
-		};
-		CIP_5F2FD3F0AED59431B4F98D7238CAA733 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_5245AB6D3B3CFBC95AEBADF6E0C593B8;
-			remoteInfo = "App_watchOS Extension";
-		};
-		CIP_64ED071F49DC88F8192387D7A18827F1 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_15609BCEEB00CBCC4C42110EB0366A6F;
-			remoteInfo = StaticLibrary_ObjC_macOS;
-		};
-		CIP_6D60DD975DE7829AEA72BD4098DE13E6 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_38A9FE87056942A2746E0FF025B52A91;
-			remoteInfo = App_watchOS;
-		};
-		CIP_73A78E804E93B79E9ED934358CDD7D9D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_BEB0891E36797FE2214A0A9D516D408D;
-			remoteInfo = App_iOS;
-		};
-		CIP_862C50E687ABB75CCDF71F1157709A4D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_9F72C903B42E1AA3B88F97B917231B15;
-			remoteInfo = Framework2_iOS;
-		};
-		CIP_A760C88E6F24D3F06081AEBDEB8AE54B /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_7D108AE86BED8C9CCF52C2646FA4C5DE;
-			remoteInfo = Framework_iOS;
-		};
-		CIP_B5B71FB9D5064D7E05E9E44827A87775 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_6A4FC6EE80FB2821AB96D51C3BC8966E;
+			remoteGlobalIDString = 1C26A6A0BC446191F311D470FDFF54F8;
 			remoteInfo = iMessageExtension;
 		};
-		CIP_BAAD03920C86C2839C3C93FDA5568ECE /* PBXContainerItemProxy */ = {
+		22F895524FF6719804A47F116C4BA59B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_23509FD082D1F788E6D6431F509B11AF;
-			remoteInfo = "XPC Service";
+			remoteGlobalIDString = 13E8C5AB873CEE21E18E552F5E94B768;
+			remoteInfo = StaticLibrary_ObjC_iOS;
 		};
-		CIP_C82ED1EBAD4D7218ED9694EB7BF4DE74 /* PBXContainerItemProxy */ = {
+		25DA50745F9940A4FAB501F710F7886E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_15609BCEEB00CBCC4C42110EB0366A6F;
-			remoteInfo = StaticLibrary_ObjC_macOS;
-		};
-		CIP_CA46A507405C3CBD7579D2C9A3F8719E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_9D53AF351F8DAE25354F2391248DFCCA;
+			remoteGlobalIDString = 53A3B531E3947D8A8722745EA59EBB5B;
 			remoteInfo = Framework_macOS;
 		};
-		CIP_DC690C90FF2F615A1EB93D9803F8D905 /* PBXContainerItemProxy */ = {
+		46CEA5545DFE17B465A6C2715FC7D92C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_7D108AE86BED8C9CCF52C2646FA4C5DE;
+			remoteGlobalIDString = 578C80E461E675508CED5DC3F45C99C7;
+			remoteInfo = StaticLibrary_ObjC_macOS;
+		};
+		6325BA6A4CFF5F72679F35D8942CA681 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0867B0DACEF28C11442DE8F70C48D1AC;
+			remoteInfo = App_iOS;
+		};
+		67F63874B91EB0AD7BFE9C2260EED1D0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E7815F2F0D9CDECF9185AAF3A6B474C1;
+			remoteInfo = "XPC Service";
+		};
+		73C27A037CFB6A421B7824FEDFA0C989 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 13E8C5AB873CEE21E18E552F5E94B768;
+			remoteInfo = StaticLibrary_ObjC_iOS;
+		};
+		763FB8D4F0CDA2971921394807FE4623 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0867B0DACEF28C11442DE8F70C48D1AC;
+			remoteInfo = App_iOS;
+		};
+		886557AFA819F7C3EC08283AF902D647 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0867B0DACEF28C11442DE8F70C48D1AC;
+			remoteInfo = App_iOS;
+		};
+		A4C9F7E41E936ED3DB506ED144393C22 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CE7D183D3752B5B35D2D8E6DC832BED5;
+			remoteInfo = Framework2_iOS;
+		};
+		CD04B2F75AFB4C4E0E81FD50AA666C20 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AE3F93DB94E7208F2F1D9A78B91C1BC8;
 			remoteInfo = Framework_iOS;
+		};
+		CEA3F70DEEC34DCA66DB1E0EFA84942B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 834F55973F05AC8A18144DB04FF6F2C7;
+			remoteInfo = iMessageApp;
+		};
+		D2ADEBFCC2EBFB67A6A763400BA65C92 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AE3F93DB94E7208F2F1D9A78B91C1BC8;
+			remoteInfo = Framework_iOS;
+		};
+		D8E7CFCA90E697A5E3D856E17A865EDC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 93542A75A613F00FDB5C9C63B5101409;
+			remoteInfo = StaticLibrary_ObjC_tvOS;
+		};
+		DB55C4664A117055BA46376BD622A680 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 578C80E461E675508CED5DC3F45C99C7;
+			remoteInfo = StaticLibrary_ObjC_macOS;
+		};
+		F2E7F07F956B38B4B4FE8C62A4F22580 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 307AE3FA155FFD09B74AE351B15321B6;
+			remoteInfo = "App_watchOS Extension";
+		};
+		FB1C6EFD8B6003738E55DF998093397E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7D3D92034F4F203C140574F08DF5F38F;
+			remoteInfo = StaticLibrary_ObjC_watchOS;
+		};
+		FED461798C856A866AC3B22F8F40B6E4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 208179651927D1138D19B5AD54E29D2B;
+			remoteInfo = App_watchOS;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		CFBP_0B6C520DAC94DDCE678BE15C53528F25 /* CopyFiles */ = {
+		06FAE8D6834F982AA934B3E847C58D16 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
-				BF_910C2D6055BD22643F042545CD21AA78 /* StaticLibrary_ObjC.h in CopyFiles */,
-				BF_527E94EECC2501E12D28790BF9318FD3 /* module.modulemap in CopyFiles */,
+				FE01CB2392794EC5CD44533920AA051B /* StaticLibrary_ObjC.h in CopyFiles */,
+				6D175FFCC1377D131785965D99F7E90E /* module.modulemap in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_1C40B0777F31334440F91C2DB34EF404 /* Embed Frameworks */ = {
+		08DA9F1F0ED13AC054003B27D5F7A95E /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_B69A0C5F1A19F65CA603F58247A8CD41 /* Framework2.framework in Embed Frameworks */,
-				BF_D7E271A6820E0A908736F44F99341DE1 /* Framework.framework in Embed Frameworks */,
-				BF_30024D558743C8ABC415D87431CDC13C /* SomeFramework.framework in Embed Frameworks */,
+				4C29EFBFCC52C847A4B6A268433D0B45 /* Result.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_2FE0B34CC045616C815F2675387DA9D5 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				BF_F9E44FE6ECBD936A8C762D425DDBA37C /* Result.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CFBP_3BE6FE084D6BE913354F37B1DD9A8D92 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				BF_F6A0FC1F0C9A4EC13BCCBB764D716C3F /* Result.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CFBP_469B033759EACBB99ECBF1008677C590 /* Embed App Extensions */ = {
+		2F0735A423E554B267BBA0A5FA4E9D99 /* Embed App Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				BF_6AA4D902E371C0F078917EB44F966B16 /* App_watchOS Extension.appex in Embed App Extensions */,
+				0C8ADA24D201C830751FBE37DFB5FAA2 /* iMessageExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_4DFB7882C9F8BAB250BB0A6B9457B4CC /* CopyFiles */ = {
+		3217EBDE07BBCBDE3C16CEDC81DB57CD /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
-				BF_C5EA496FE2EDF51C92DC55FD552472E5 /* StaticLibrary_ObjC.h in CopyFiles */,
-				BF_0B3CE605B6243480C374176E01B1BB12 /* module.modulemap in CopyFiles */,
+				5B384745ED88A7A92353B7D120F975B4 /* StaticLibrary_ObjC.h in CopyFiles */,
+				41B0909025B983E66FCC4AA8A1FE3634 /* module.modulemap in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_712E86A86BBF89DB5B5F3874B24B8996 /* CopyFiles */ = {
+		7FAF0BBB3DE701EBE5DBE810BBE743E3 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
-				BF_DA12D48C9BCEC64D55B87CE8703432BE /* StaticLibrary_ObjC.h in CopyFiles */,
-				BF_703163C1C547AD6EF09BEA5F5F5ED49C /* module.modulemap in CopyFiles */,
+				319B977623307E83E948E9E4CEBB432E /* StaticLibrary_ObjC.h in CopyFiles */,
+				3474A5D469F41494C4CB871D75C77106 /* module.modulemap in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_961F46C30E720E886AEFD11D45DDA199 /* Embed Watch Content */ = {
+		807155B9081529D99AAB474392826D85 /* Embed Watch Content */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
 			dstSubfolderSpec = 16;
 			files = (
-				BF_59E5DB880E7823E6BC1D62FAF99E5758 /* App_watchOS.app in Embed Watch Content */,
+				097B0B6C198B9A52D4312F11000496FD /* App_watchOS.app in Embed Watch Content */,
 			);
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_AD91D17C63B2CD9AE7EFB9EFD62A8223 /* Embed App Extensions */ = {
+		865AAD9909027AC34D1374EA5877AE78 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 13;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
 			files = (
-				BF_0BBC6762FFFC3394DCB0570CCEFB1970 /* iMessageExtension.appex in Embed App Extensions */,
+				5CA4B07D0D79B2D8C48DBF7118FDBEF6 /* Empty.h in CopyFiles */,
 			);
-			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_CB2355266C8BAA9C97863011F3DE05A2 /* Embed Frameworks */ = {
+		924D7F0A22013EE6F06E74009AB5D420 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				F04CBE9A3D61F78E4FEE6A09AED606C0 /* StaticLibrary_ObjC.h in CopyFiles */,
+				205719BEDEFFC911468631925C617988 /* module.modulemap in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A8688B5E0D1C2F35AD20BB852C7EEF98 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				BF_F6FBB97A7DE0F6D06661A00E3B22E8CF /* Framework.framework in Embed Frameworks */,
-				BF_8765851BF5D99B10C220DDD57B968B10 /* Result.framework in Embed Frameworks */,
+				74BC0F70B2D3EC06E623CB0FD6630D0F /* Result.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_CC1EF1963551F7E08925519982C248B9 /* CopyFiles */ = {
+		C765431E5FF4B02F59DE79B068D2CB68 /* Embed App Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
+			dstPath = "";
+			dstSubfolderSpec = 13;
 			files = (
-				BF_2356EAE09301354149D45720369BE7F2 /* StaticLibrary_ObjC.h in CopyFiles */,
-				BF_1C8AAB7468188315681C0879591969B4 /* module.modulemap in CopyFiles */,
+				5F49DEBEDCC54D28AD3571B88753A356 /* App_watchOS Extension.appex in Embed App Extensions */,
 			);
+			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_CC737A6BF6243B189B109606B0C4B5A2 /* CopyFiles */ = {
+		F8CDEFED6ED131A09041F995E056117D /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				E32A04EF64C8989C8349A476E3DC1F19 /* Framework.framework in Embed Frameworks */,
+				DAFD488BAFDFD93F6B540648BC4CAF3A /* Result.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB79B30FEA6073A29B4D9FCC48B7B747 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
 			dstSubfolderSpec = 16;
 			files = (
-				BF_D0D1D142403C75D11757CB7092E8D035 /* XPC Service.xpc in CopyFiles */,
-				BF_67219751DE020023F9D6068EDCCDC445 /* SomeXPCService.xpc in CopyFiles */,
+				CC83632C49106DE960F699314C45FA87 /* XPC Service.xpc in CopyFiles */,
+				FE5B714E4FCA0E8BF74B9FA58C516DBA /* SomeXPCService.xpc in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CFBP_D7E07645BC437C4DFBB212DFC4F3B09E /* CopyFiles */ = {
+		FE78CC3322C9C2DB1D64EAAA793C45CA /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
+			dstPath = "";
+			dstSubfolderSpec = 10;
 			files = (
-				BF_90F0E9253F2768C312B65530931CD55A /* Empty.h in CopyFiles */,
+				3799FF03E75F5D3C925CBB18B8BB7BF6 /* Framework2.framework in Embed Frameworks */,
+				7856158603A68D4FF152F8E96305B3E7 /* Framework.framework in Embed Frameworks */,
+				1985E98D7107DFCBB2F2AC7DC6A155B5 /* SomeFramework.framework in Embed Frameworks */,
 			);
+			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FR_05405007CB77B2E003B19B89401C12AB /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_0570C52FB0BC489485EAF0CE7B7119A1 /* iMessageExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = iMessageExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_07C0A7866967FA47B3F2777BF4AB694A /* XPC_Service.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPC_Service.h; sourceTree = "<group>"; };
-		FR_0823766D9A1DAB5D3F9CC04A9B35FA3E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_099E2C49D4A0B799E78B39C47FBEADF7 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_0A30B76CD8B0A84B8C488FABC16C4682 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_11478908A963CED036DABEF21D85DF01 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
-		FR_11E95FCD1DEB0C8A01A053518C1DAA8E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_16B791CFA2095097A17CC216977DF6EF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		FR_1B0304C0E4DC73614BAA550E4A80D41C /* ResourceFolder */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ResourceFolder; path = Resources/ResourceFolder; sourceTree = SOURCE_ROOT; };
-		FR_1C00E09FA3D2CDB962FE8D5584853E0D /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_1EA1EAB0CB9BD96BC550879E58911B12 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_1FA381C639CE4923ED6845790A5DF9D2 /* XPC Service.xpc */ = {isa = PBXFileReference; includeInIndex = 0; path = "XPC Service.xpc"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_22A431E337CB22CE70E39135206EDE27 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = config.xcconfig; sourceTree = "<group>"; };
-		FR_257D977B4221AB25C1EC0ACD6128A89B /* App_iOS_UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_iOS_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_25BDF725104C5E280D45CBF33F54C72C /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkFile.swift; sourceTree = "<group>"; };
-		FR_2649A01C17A7301DD72EA826604ED8AA /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
-		FR_291D6D09ACADC420638E83BEE89DFFEB /* MyBundle.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = MyBundle.bundle; sourceTree = "<group>"; };
-		FR_2F56FD7A1F7782467AC9F315B6133468 /* SomeFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SomeFramework.framework; path = Vendor/SomeFramework.framework; sourceTree = "<group>"; };
-		FR_30E7940EF436086816B40DAC068BD238 /* App_watchOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_watchOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_3305E7E3B08D04C667D02BD29D3A45A9 /* iMessageApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = iMessageApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_347062562C9C212A082B1326BBCDC71B /* Model 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 2.xcdatamodel"; sourceTree = "<group>"; };
-		FR_35B9B5E8A2ED60FBB9CED8AE515B16B5 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LocalizedStoryboard.strings; sourceTree = "<group>"; };
-		FR_36044227861B95AC5060E7D063BED65A /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_3744DA35690747A918CC896E2354C59D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_3B4065B548BFD8CFB3D1153F7106DDA3 /* Folder */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Folder; sourceTree = SOURCE_ROOT; };
-		FR_3B708FF662F6F7D8E4FABBB1B3F33604 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_3DD4DE355C21662A9169EE41C44F73E3 /* Headers */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Headers; sourceTree = SOURCE_ROOT; };
-		FR_3ED99EEAF978C071491E281B8EAFD249 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_41E1155D8A7FDD97B783A1D5B3AD2C5B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_426E58636FD3B81A8F45788D3E65BC50 /* StaticLibrary_Swift.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = StaticLibrary_Swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_4B58A01ABBE8E0A56B7B5A539C9BF5C7 /* Base */ = {isa = PBXFileReference; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
-		FR_4DB225C7FF39C16EEFD9A1A5595FCDBC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		FR_4EB4AAACD714C13E5BC894C71B954299 /* SomeXPCService.xpc */ = {isa = PBXFileReference; path = SomeXPCService.xpc; sourceTree = "<group>"; };
-		FR_545DDE4AB557C8FAAD87775CD4271BDF /* App_watchOS Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "App_watchOS Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_58A974F0E117C1384FD1B5147E524659 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
-		FR_5A840A83C22F13EBFE051C061E549F95 /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_5CFDEA59B939FA9F3CA4F775B9E6AD2B /* TestProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectUITests.swift; sourceTree = "<group>"; };
-		FR_5E4B4E53251DE2294715A48CC249EBFD /* Mintfile */ = {isa = PBXFileReference; path = Mintfile; sourceTree = "<group>"; };
-		FR_5FEC20FF753341FD0483E2E4C622DB05 /* MessagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
-		FR_62ECE5A3D0F25415CB50A28226B91EBE /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_640ADF15D2B92FDC35556B2E0934C21C /* App_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_654475F320EF1630562C841CA8B6938A /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_6643E0FE8DD9AAC71691A739070C6833 /* Model 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 3.xcdatamodel"; sourceTree = "<group>"; };
-		FR_6A3D8067EBC18CB321826EB21FEBD094 /* libc++.tbd */ = {isa = PBXFileReference; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
-		FR_752FB5DFFBC490CFB9742549A0C48527 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		FR_7532DD7B78451A5040048474AC4FBCCC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		FR_7C782E8FBF41DE8BB1E3789DF2C8C1F7 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
-		FR_7C8280C3C5E1D43BBB12A5F0156A8305 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
-		FR_7F4496C534F2DF8C4FB9A8D52414990B /* XPC_Service.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XPC_Service.m; sourceTree = "<group>"; };
-		FR_81A08F81FED7C42DC346B9611ECD21AA /* XPC_ServiceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPC_ServiceProtocol.h; sourceTree = "<group>"; };
-		FR_82E3C6C060C4487B5177509917C3FAE3 /* Standalone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Standalone.swift; sourceTree = "<group>"; };
-		FR_89162821C7F86126DC7F165E93E0DD23 /* App_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_8B770F475242D91FC20289A3B35CD165 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
-		FR_96127F4D9D804B89024AB846F0961621 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.module; path = module.modulemap; sourceTree = "<group>"; };
-		FR_98BB4C8D33EB0E666C136ACD08B21EB3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_9A09F93850576AF57455BE58FD53C42F /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
-		FR_9B4B00A3CDADD50167B2393562AEBAB2 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.module; path = module.modulemap; sourceTree = "<group>"; };
-		FR_A0867B127ACF3ED382EB2FD5133D3EA8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		FR_A0DA89632C14F8DF99F15196E6EBB7D5 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_A51DE87AC269BC36016F9CAC32B4ECB2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LocalizedStoryboard.storyboard; sourceTree = "<group>"; };
-		FR_A55A35F549FD72775C37ED05342812AA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyFramework.h; sourceTree = "<group>"; };
-		FR_ABEBA07AEF9FB6D7F5B6D94FD76FF330 /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_AC5B2FCE520D5306B254D5857E15B6CB /* MoreUnder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreUnder.swift; sourceTree = "<group>"; };
-		FR_B243640A6F73B3F3D33ABD05ABDBC26B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		FR_B537FEE8515090D3BA0F5CFF3BC76BB1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		FR_B993F75B001AB1C272CE83CACC06F0E5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		FR_BB49B398F9291781A60DA963A0BF168C /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
-		FR_BCEF8D29C9B93D3160D8D76DD368C8AD /* en */ = {isa = PBXFileReference; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
-		FR_C2A280C4FA602E6610BCFB820602B69E /* StaticLibrary_ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticLibrary_ObjC.m; sourceTree = "<group>"; };
-		FR_C5682A1371F91CBD1254C115F0439F12 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		FR_C6A9DE885CAF350F6C9D0AC6F7324CD3 /* StandaloneAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = StandaloneAssets.xcassets; sourceTree = "<group>"; };
-		FR_C73B96CEEE97DE429C638EBD9C2F3D2B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		FR_C86A7EAE4DFF4327D1E7D32A597CA4AC /* SomeFile */ = {isa = PBXFileReference; path = SomeFile; sourceTree = "<group>"; };
-		FR_CB1D0F4BB53B8DEE921C6E232193A62B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_CC3A24A5C8E1815346752C5AB0745176 /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
-		FR_CCC97AF230188CAF9B4A66324891CCAD /* StaticLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticLibrary.swift; sourceTree = "<group>"; };
-		FR_CEAE8D9C3F3920D6EADE5455C188EAAE /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
-		FR_D0BE69522DB875ADB041E9135E0767CA /* StaticLibrary_ObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticLibrary_ObjC.h; sourceTree = "<group>"; };
-		FR_D5FDE9E6362055E854CE1D3980716A4C /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_D7B45FAEE40EE622B4FA9192609F9717 /* TestProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectTests.swift; sourceTree = "<group>"; };
-		FR_DACDD51068A6E1B7D2470F3E27E5EB2C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_DBB69305458B16774C88720CDD3978E5 /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
-		FR_DBD29CA78CDBBEF69B2C39C6D23BBDA1 /* Empty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Empty.h; sourceTree = "<group>"; };
-		FR_DC1C8DE46218F90A3F4FD5F8DE4F0ABB /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
-		FR_E3314150DA4CEFF65D69CF7DB678E845 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_E7BC65B06A0819B53634C5CD51946D98 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
-		FR_EBD99C110BD7AE780C87A31CF2E4E7DB /* App_iOS_Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_iOS_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_ED407ECED0DF010B1E787D238EA91A5D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		FR_EFD283107EDF836BF0D9F4EB3F9A0016 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_F5353B71B99044C8C37D7601A8107195 /* base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = base.xcconfig; sourceTree = "<group>"; };
-		FR_F5436E663145426483F206F8A61400BC /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		FR_F861CF6DF133AAD164CBE6DF2C7CEBFF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		020E4DA91C9132845CAFDC5D91A750AF /* en */ = {isa = PBXFileReference; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		056A43A09CE7E88D578696D83330E45F /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		068EDF47F0B087F6A4052AC08A2FA1E4 /* Empty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Empty.h; sourceTree = "<group>"; };
+		0704B6CAFBB53E0EBB08F6B385901D43 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		089EC08C7E2D830C5916FDD909257364 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		09B82F603D981398F38D762E418E8BB9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		0B193CC6D2B3003418A550B6B0D1F6AA /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LocalizedStoryboard.strings; sourceTree = "<group>"; };
+		0BB1B49A91B892152D68ED76D9D4E759 /* libc++.tbd */ = {isa = PBXFileReference; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
+		0C5AC2545AE4D4F7F44E2E9B53F03FF0 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
+		0D09D243DBCF9D32E239F1E8A64D75AB /* App_watchOS Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "App_watchOS Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0F32AD342EF6A4C7F6324B36AB349105 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0F5BD97AF0F94A15A5B7DDB75C0C7CDF /* Standalone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Standalone.swift; sourceTree = "<group>"; };
+		102A08142A31E44F4ED52649F22BB71E /* base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = base.xcconfig; sourceTree = "<group>"; };
+		108BB29172D27BE3BD1E7F3536D14EAD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		1313F043F19B484A5046E0748579814C /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		13EEAB58665D79C15184D9D0DEE29087 /* App_iOS_UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_iOS_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		148B7C933698BCC4F1DBA979CF051F81 /* XPC_Service.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XPC_Service.m; sourceTree = "<group>"; };
+		16D662EE577E4CD6AFF39D66C382B13F /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = config.xcconfig; sourceTree = "<group>"; };
+		187E665975BB5611AF0F27E15659D85C /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		1D0C79A8C750EC0DE748C463D6992773 /* StaticLibrary_ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticLibrary_ObjC.m; sourceTree = "<group>"; };
+		22237B8EBD9E6BE8EBC8735F5AA17192 /* XPC Service.xpc */ = {isa = PBXFileReference; includeInIndex = 0; path = "XPC Service.xpc"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2233774B86539B1574D206B07A805A8F /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkFile.swift; sourceTree = "<group>"; };
+		2E1E747C7BC434ADB80CC269B7B595DC /* Headers */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Headers; sourceTree = SOURCE_ROOT; };
+		33F6DCDC37D2E66543D4965D829900E1 /* App_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		34F13B632328979093CE6056379353F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3571E41E19A5AB8AAAB04109D524DB4F /* StandaloneAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = StandaloneAssets.xcassets; sourceTree = "<group>"; };
+		3797E591F302ECC0AA2FC607B190E2C8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		38F1191E5B85DC882B8ABE8561D4A3AE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3D8A2D4363866877B91401560806DD1D /* XPC_ServiceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPC_ServiceProtocol.h; sourceTree = "<group>"; };
+		3EF21DF245F66BEF5446AAEF769A4194 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		41FC82ED1C4C3B7B3D7B2FB721574442 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		42B95EB66A17FBA091F50601196CAA83 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4BF4D16042A80576D259160C97AD2C2E /* Model 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 3.xcdatamodel"; sourceTree = "<group>"; };
+		4D0BF47DF71A6DBA33ED23FD22D023EF /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		5116B3B58070BCD09F1487BAFC210EE0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		57FF8864B8EBAB5777DC12E62D66732F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		587B9E9A3533E965CA602B763210583F /* TestProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectUITests.swift; sourceTree = "<group>"; };
+		5A2B916A11DCC2565241359FD0114B0C /* StaticLibrary_ObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticLibrary_ObjC.h; sourceTree = "<group>"; };
+		6177CC6263783487E93F7F4D07620345 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyFramework.h; sourceTree = "<group>"; };
+		6AC91042453E18DF74BA1C0F957D87DC /* StaticLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticLibrary.swift; sourceTree = "<group>"; };
+		6B1603BA83AA0C7B94E45168D7E684C4 /* ResourceFolder */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ResourceFolder; path = Resources/ResourceFolder; sourceTree = SOURCE_ROOT; };
+		6BBE762F36D94AB6FFBFE834A99277EA /* SomeFile */ = {isa = PBXFileReference; path = SomeFile; sourceTree = "<group>"; };
+		70A8E15C81E454DC950C59F092CC1049 /* SomeXPCService.xpc */ = {isa = PBXFileReference; path = SomeXPCService.xpc; sourceTree = "<group>"; };
+		72A14C887EF7E9C8CBE914ACC4DDF4D4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		73E7D4B860A5B6B80540E64703192744 /* SomeFramework.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SomeFramework.framework; path = Vendor/SomeFramework.framework; sourceTree = "<group>"; };
+		77C0C341F1865224E059608627CC2D82 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7ACBAD7D485AA4E2542B9E0F9908D5B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7B5068D64404C61A67A184584E13804D /* MyBundle.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = MyBundle.bundle; sourceTree = "<group>"; };
+		7C176A8297AC2F5207352BA80F60ADB0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		7D67F1C1BFBACE101DE7DB5179F2DCEA /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7DE38C10AB71A47B786D5BF205BA002F /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
+		7F1A2F579A6F79C62DDA05712E2AB1F7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		7FDC16E1938AA114B67D87A9822E86D7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
+		814822136AF3C64428D69DD62246E8A2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		8A9274BE42A03DC5DA1FAD04992ED6E3 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8CAF6C55B555E3E1352645B630CCB23E /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
+		9A87A926D563773658FB87FEEE4DD132 /* iMessageApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = iMessageApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9F27382DD66E26C059E26EFE8D6BEF4D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		A0DC40025AB59B688E758829FB7EDB95 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A3F6BCB5FEFB16F1BA368059F4B1505A /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
+		A4C3FE6B986506724DAB5D0FC4361D53 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		A680BE9F68A255B0FB291AE6F0A2B045 /* App_watchOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_watchOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AB055761199DF36DB0C629A608A4EF3A /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B17B8D9C9B391332CD176A355AD24669 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LocalizedStoryboard.storyboard; sourceTree = "<group>"; };
+		B1C33BB070583BE3B0EC0E68083FE89C /* App_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B419F22EB75EDD4AB9B92F32F7D39755 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B76E17CE3574081D5BF45B449F3F46DB /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
+		BA040F1F7D6CA08878323A551349F18D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BB178D03E75929F3F5B10C56838882EC /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
+		C2F3574CCEF023755DDB1A06C6FE315C /* Mintfile */ = {isa = PBXFileReference; path = Mintfile; sourceTree = "<group>"; };
+		C5ABEA2284F13483EFDF7C0E050F0450 /* MessagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
+		C7809CE9FE9852C2AA87ACE57B5DEF9E /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.module; path = module.modulemap; sourceTree = "<group>"; };
+		C934C1F7A68CCD0AB6B384782470EE7B /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
+		C9DDE1B06BCC1CDE0ECF15895A14CD45 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CA8718C7CD3BE86D9B1F51203A548A51 /* MoreUnder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreUnder.swift; sourceTree = "<group>"; };
+		CB77A637470A3CDA2BDDBE9948AB9716 /* App_iOS_Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_iOS_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		D132EA69984F32DA9DC727B6360D9F12 /* TestProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectTests.swift; sourceTree = "<group>"; };
+		D296BB7355994040E197A1EE5B41F583 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
+		D629E142AB87C681D4EC90F7106F7299 /* iMessageExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = iMessageExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6C89D80B5458D8929F5C1274C83014E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D70BE0C05E5779A077793BE613BE34E3 /* Model 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 2.xcdatamodel"; sourceTree = "<group>"; };
+		D8A016580A3B8F72B820BFBF93749CD7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D8D8907E2CDA1295D0D94F53FCD6939F /* StaticLibrary_Swift.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = StaticLibrary_Swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		E42335D1200CB7B8B91E962FF77B8337 /* Base */ = {isa = PBXFileReference; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		E55F45EACB0F382722D61C8D518BF80D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E9672EF8FE1DDC8DE070512979C33058 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
+		EF92E90B6F1D583382BD85BEE4CD1896 /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		F0D48A913C087D049C8EDDD79DCFA404 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
+		F2950763C4C568CC85021D185A35C1FB /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.module; path = module.modulemap; sourceTree = "<group>"; };
+		FC60FF5527FEDF545816FFCF26619677 /* Folder */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Folder; sourceTree = SOURCE_ROOT; };
+		FD05F36F95D6F098A76F220BA08E154C /* XPC_Service.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPC_Service.h; sourceTree = "<group>"; };
+		FDB2B6A77D39CD5602F2125F01DEF025 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
+		FED40A89162E446494DDE7C74F29A61D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		FBP_18D4325BBE506E88E1C742F57AECB0CD /* Frameworks */ = {
+		117840B4DBC04099F6779D006B7C8555 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_D2532BE2FA7D664875AD6E29A22269C0 /* Contacts.framework in Frameworks */,
-				BF_F8D73622DA7CFF30DB9AD17C08C63655 /* Framework2.framework in Frameworks */,
-				BF_0378AD9857D61219363F74B2FA308B5A /* Framework.framework in Frameworks */,
-				BF_B8E824A58BFE0B81E16BB26087FDC8B4 /* Result.framework in Frameworks */,
-				BF_42C8B667C3B7417C14B063AF0F16C1A6 /* StaticLibrary_ObjC.a in Frameworks */,
-				BF_93A4E1A93C7DB4289E526466D547E55E /* SomeFramework.framework in Frameworks */,
+				FBDBC020EE959F32F0FF0E6252028356 /* Contacts.framework in Frameworks */,
+				6CE2C63470E541C3A04F3E9ED6B3F10B /* Framework2.framework in Frameworks */,
+				DE50B077EE4BFABAF128321B2A13886F /* Framework.framework in Frameworks */,
+				29A79F030DD325754FD2C82C4A6E0AE6 /* Result.framework in Frameworks */,
+				53B2D7C4FD56D5D1D8AF16B23110235D /* StaticLibrary_ObjC.a in Frameworks */,
+				EA0D7CDB58D81E7D92E731535E41FB5E /* SomeFramework.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_1BDCD6E0245ED2400E6FE9AC9C334DE4 /* Frameworks */ = {
+		2E6FCCFC594BE9FEB74FA2F01F56F4FE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_BD2537A230BFC8A86681F0AF34C929DA /* Result.framework in Frameworks */,
+				8BD6E6E86A37882FB7C802E33DD03105 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_4E773D46F6F726BBC0032C576D02FCB7 /* Frameworks */ = {
+		5EFF61D0A49AA8EABD72DF4449BCEADE /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_9743BCF98E3EF021AB384652DA126416 /* Contacts.framework in Frameworks */,
-				BF_6E2D4086A22C12D516A06AE66DC48D16 /* Framework.framework in Frameworks */,
-				BF_230439786C4C6849F488A5FADC6A42A5 /* Result.framework in Frameworks */,
-				BF_36BCFE51A59D5EAE19684491C9F5427F /* StaticLibrary_ObjC.a in Frameworks */,
-				BF_486398284252AEE9001DD72E5E710D93 /* libc++.tbd in Frameworks */,
+				FE4C8407830C0189E1F61AFBEF16398B /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_71D96680A2FBE24C4C8BD0B5E55FE034 /* Frameworks */ = {
+		9B861C58E640BD4AD391900CF0C4ABEC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_ED8BB47A2229EC3BEE544608267FB82D /* Result.framework in Frameworks */,
+				5CB4C10148DD10D82B5ADBBDAD52BCD1 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_935BCDE6C86D2D59A945DC1E6886D7C3 /* Frameworks */ = {
+		A6E1C88C073F8CC6B5B072B6CD1F331F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_B5446C54E942A18E025D2061A88004A4 /* Result.framework in Frameworks */,
+				A1144E47C6EFE30830087F384717526E /* Contacts.framework in Frameworks */,
+				82D432D23D2ACC56338BE911465E6F89 /* Framework.framework in Frameworks */,
+				F7ECF245988DABA0164DFF08607F6C31 /* Result.framework in Frameworks */,
+				C3B73C7A69119513C543ED75DAB1C492 /* StaticLibrary_ObjC.a in Frameworks */,
+				0F7F220834A3E2B344322B64DB5140DF /* libc++.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_98B76E46D78FD48FB47A41B8891665BC /* Frameworks */ = {
+		C2323597C6777A02E1FF671C303DD89C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_86F2552DA1E230901EC4CB1A40399019 /* Result.framework in Frameworks */,
+				EFBDE105D3397BE7AAC207B8AD3CC8BB /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		G_089F5A7E7FB159719FE19B5E84B85D5D /* App_watchOS Extension */ = {
+		0A989C35EEBD58B9B98C41A75CE9CE00 /* iMessage MessagesExtension */ = {
 			isa = PBXGroup;
 			children = (
-				FR_B243640A6F73B3F3D33ABD05ABDBC26B /* Assets.xcassets */,
-				FR_DBB69305458B16774C88720CDD3978E5 /* ExtensionDelegate.swift */,
-				FR_3744DA35690747A918CC896E2354C59D /* Info.plist */,
-				FR_CC3A24A5C8E1815346752C5AB0745176 /* InterfaceController.swift */,
-				FR_BB49B398F9291781A60DA963A0BF168C /* NotificationController.swift */,
-				FR_7C782E8FBF41DE8BB1E3789DF2C8C1F7 /* PushNotificationPayload.apns */,
-			);
-			path = "App_watchOS Extension";
-			sourceTree = "<group>";
-		};
-		G_0D2DDBB1C39493B8B0EAF9CC23272F2D /* Framework */ = {
-			isa = PBXGroup;
-			children = (
-				FR_261C31660333EF514356EFCBDB368EAB /* FrameworkFile.swift */,
-				FR_F861CF6DF133AAD164CBE6DF2C7CEBFF /* Info.plist */,
-				FR_A957DAE2193BE1E970F452BFEFF3EBF6 /* MyFramework.h */,
-			);
-			path = Framework;
-			sourceTree = "<group>";
-		};
-		G_23236546763854F4301D7847EBA0A2BF /* XPC Service */ = {
-			isa = PBXGroup;
-			children = (
-				FR_98BB4C8D33EB0E666C136ACD08B21EB3 /* Info.plist */,
-				FR_F5436E663145426483F206F8A61400BC /* main.m */,
-				FR_07C0A7866967FA47B3F2777BF4AB694A /* XPC_Service.h */,
-				FR_7F4496C534F2DF8C4FB9A8D52414990B /* XPC_Service.m */,
-				FR_81A08F81FED7C42DC346B9611ECD21AA /* XPC_ServiceProtocol.h */,
-			);
-			path = "XPC Service";
-			sourceTree = "<group>";
-		};
-		G_26EB72A03E79484F94412C6DF07B2C65 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				FR_CEAE8D9C3F3920D6EADE5455C188EAAE /* Result.framework */,
-			);
-			path = iOS;
-			sourceTree = "<group>";
-		};
-		G_2C00D0D23CBE29FF5F6DFEB95CBF2ECA /* UnderFileGroup */ = {
-			isa = PBXGroup;
-			children = (
-				FR_AC5B2FCE520D5306B254D5857E15B6CB /* MoreUnder.swift */,
-			);
-			path = UnderFileGroup;
-			sourceTree = "<group>";
-		};
-		G_322C327C1DB8AE7E0B99EF59318DFE22 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				FR_291D6D09ACADC420638E83BEE89DFFEB /* MyBundle.bundle */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		G_3569DDFAF0CD0D2E17F8D05B12F9A7BA /* tvOS */ = {
-			isa = PBXGroup;
-			children = (
-				FR_8B770F475242D91FC20289A3B35CD165 /* Result.framework */,
-			);
-			path = tvOS;
-			sourceTree = "<group>";
-		};
-		G_373C03E19EC66ABB051FC35B4E57A52E /* App_iOS_UITests */ = {
-			isa = PBXGroup;
-			children = (
-				FR_0823766D9A1DAB5D3F9CC04A9B35FA3E /* Info.plist */,
-				FR_5CFDEA59B939FA9F3CA4F775B9E6AD2B /* TestProjectUITests.swift */,
-			);
-			path = App_iOS_UITests;
-			sourceTree = "<group>";
-		};
-		G_415E92CCC7C77CD8BB161FA75E8B66EF /* iMessage MessagesExtension */ = {
-			isa = PBXGroup;
-			children = (
-				FR_16B791CFA2095097A17CC216977DF6EF /* Assets.xcassets */,
-				FR_E3314150DA4CEFF65D69CF7DB678E845 /* Info.plist */,
-				VG_06DC429EEFBBA25BC3EE1AA1B4062C10 /* MainInterface.storyboard */,
-				FR_5FEC20FF753341FD0483E2E4C622DB05 /* MessagesViewController.swift */,
+				B419F22EB75EDD4AB9B92F32F7D39755 /* Assets.xcassets */,
+				0F32AD342EF6A4C7F6324B36AB349105 /* Info.plist */,
+				B47B80AF9EAE0ADB4FA469CFDB7ABB8F /* MainInterface.storyboard */,
+				C5ABEA2284F13483EFDF7C0E050F0450 /* MessagesViewController.swift */,
 			);
 			path = "iMessage MessagesExtension";
 			sourceTree = "<group>";
 		};
-		G_4401384B8D17D0B62305BE82DE0660D2 /* App_iOS_Tests */ = {
+		0D039F2E62354C7C8E283BE65E4F9BD5 /* App_iOS_UITests */ = {
 			isa = PBXGroup;
 			children = (
-				FR_CB1D0F4BB53B8DEE921C6E232193A62B /* Info.plist */,
-				FR_D7B45FAEE40EE622B4FA9192609F9717 /* TestProjectTests.swift */,
+				72A14C887EF7E9C8CBE914ACC4DDF4D4 /* Info.plist */,
+				587B9E9A3533E965CA602B763210583F /* TestProjectUITests.swift */,
 			);
-			path = App_iOS_Tests;
+			path = App_iOS_UITests;
 			sourceTree = "<group>";
 		};
-		G_4A1045347B09A484656D26436E35FDCC /* StaticLibrary_ObjC */ = {
+		12809A79ACE69F501A5FE815B43985BD /* Carthage */ = {
 			isa = PBXGroup;
 			children = (
-				G_AFE0E055A99B8BF7C44E69B9B69889C8 /* Module */,
-				FR_D0BE69522DB875ADB041E9135E0767CA /* StaticLibrary_ObjC.h */,
-				FR_C2A280C4FA602E6610BCFB820602B69E /* StaticLibrary_ObjC.m */,
-			);
-			path = StaticLibrary_ObjC;
-			sourceTree = "<group>";
-		};
-		G_54CAD56F6F3EAD10E9DB8D50B52D09F3 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				G_A1CE8BFBEAC6AFDC64D7068C3CE11421 /* Carthage */,
-				FR_9A09F93850576AF57455BE58FD53C42F /* Contacts.framework */,
-				FR_6A3D8067EBC18CB321826EB21FEBD094 /* libc++.tbd */,
-				FR_2F56FD7A1F7782467AC9F315B6133468 /* SomeFramework.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		G_68375B6CA3E19FBBA0246B55B60849C0 /* App_macOS */ = {
-			isa = PBXGroup;
-			children = (
-				FR_4DB225C7FF39C16EEFD9A1A5595FCDBC /* AppDelegate.swift */,
-				FR_A55A35F549FD72775C37ED05342812AA /* Assets.xcassets */,
-				FR_3ED99EEAF978C071491E281B8EAFD249 /* Info.plist */,
-				VG_14B7B5469AA17939993A2B25E775D391 /* Main.storyboard */,
-				FR_25BDF725104C5E280D45CBF33F54C72C /* ViewController.swift */,
-			);
-			path = App_macOS;
-			sourceTree = "<group>";
-		};
-		G_77F9CDD1713BAEF02DF44C1EA19D86B8 /* Mac */ = {
-			isa = PBXGroup;
-			children = (
-				FR_11478908A963CED036DABEF21D85DF01 /* Result.framework */,
-			);
-			path = Mac;
-			sourceTree = "<group>";
-		};
-		G_7C1E92BE8CA995A6B0952C8AE6F5ADF9 /* App_watchOS */ = {
-			isa = PBXGroup;
-			children = (
-				FR_ED407ECED0DF010B1E787D238EA91A5D /* Assets.xcassets */,
-				FR_DACDD51068A6E1B7D2470F3E27E5EB2C /* Info.plist */,
-				VG_6542B94EE7DA40CD30BC54DED26C61C7 /* Interface.storyboard */,
-			);
-			path = App_watchOS;
-			sourceTree = "<group>";
-		};
-		G_81658721738C48797F805CC891E70B6F /* Configs */ = {
-			isa = PBXGroup;
-			children = (
-				FR_F5353B71B99044C8C37D7601A8107195 /* base.xcconfig */,
-				FR_22A431E337CB22CE70E39135206EDE27 /* config.xcconfig */,
-			);
-			path = Configs;
-			sourceTree = "<group>";
-		};
-		G_8F5765334752A7E52B1E63ACAC466729 /* App */ = {
-			isa = PBXGroup;
-			children = (
-				FR_E7BC65B06A0819B53634C5CD51946D98 /* App.entitlements */,
-				FR_B993F75B001AB1C272CE83CACC06F0E5 /* AppDelegate.swift */,
-				FR_A0867B127ACF3ED382EB2FD5133D3EA8 /* Assets.xcassets */,
-				FR_05405007CB77B2E003B19B89401C12AB /* Info.plist */,
-				VG_F256536BB07CF3E64C4DD934F75BED9C /* LaunchScreen.storyboard */,
-				VG_BE436BDD64E90EFB600D47AC69B49DD3 /* Localizable.strings */,
-				VG_C247AA37E9057916EDDC65C7B55E2F38 /* Localizable.stringsdict */,
-				VG_FE6D89DA2D7E7F58340D566590FF221C /* LocalizedStoryboard.storyboard */,
-				VG_30676EBEE9BE54AA26CAE69BE744CAE8 /* Main.storyboard */,
-				VG_EB676136B9F946373D4796800CC00AD4 /* Model.xcdatamodeld */,
-				FR_9B4B00A3CDADD50167B2393562AEBAB2 /* module.modulemap */,
-				FR_752FB5DFFBC490CFB9742549A0C48527 /* ViewController.swift */,
-			);
-			name = App;
-			path = App_iOS;
-			sourceTree = "<group>";
-		};
-		G_9DEB15811B31C2D4D4B63339FBE33149 /* FileGroup */ = {
-			isa = PBXGroup;
-			children = (
-				G_2C00D0D23CBE29FF5F6DFEB95CBF2ECA /* UnderFileGroup */,
-			);
-			path = FileGroup;
-			sourceTree = "<group>";
-		};
-		G_9E36E5E1B7BEC6A8D683D2E36CE21BCE /* CopyFiles */ = {
-			isa = PBXGroup;
-			children = (
-				FR_DBD29CA78CDBBEF69B2C39C6D23BBDA1 /* Empty.h */,
-			);
-			path = CopyFiles;
-			sourceTree = "<group>";
-		};
-		G_A1CE8BFBEAC6AFDC64D7068C3CE11421 /* Carthage */ = {
-			isa = PBXGroup;
-			children = (
-				G_26EB72A03E79484F94412C6DF07B2C65 /* iOS */,
-				G_77F9CDD1713BAEF02DF44C1EA19D86B8 /* Mac */,
-				G_3569DDFAF0CD0D2E17F8D05B12F9A7BA /* tvOS */,
-				G_CC8E08E619EF6EA96B28904C6651F6B8 /* watchOS */,
+				DBF93518FC96D95A5455271356EB57FF /* iOS */,
+				912A7321F662FE41BAAEED67F628711F /* Mac */,
+				D557819B1EE5B42A0A3DD4D1F3D982C4 /* tvOS */,
+				2935454D05445817952E145D261767D4 /* watchOS */,
 			);
 			name = Carthage;
 			path = Carthage/Build;
 			sourceTree = "<group>";
 		};
-		G_AFE0E055A99B8BF7C44E69B9B69889C8 /* Module */ = {
+		1A57D1EE1FBC13598F6B5CB018E7D348 /* Framework */ = {
 			isa = PBXGroup;
 			children = (
-				FR_96127F4D9D804B89024AB846F0961621 /* module.modulemap */,
+				2A5F527F2590C149565181748C7DBECD /* FrameworkFile.swift */,
+				34F13B632328979093CE6056379353F1 /* Info.plist */,
+				6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */,
 			);
-			path = Module;
+			path = Framework;
 			sourceTree = "<group>";
 		};
-		G_B0D2DFD450BCF614AA46E474644F2CE3 /* Products */ = {
+		1F2DE413CF2CB54988158172BF8B5864 /* App */ = {
 			isa = PBXGroup;
 			children = (
-				FR_EBD99C110BD7AE780C87A31CF2E4E7DB /* App_iOS_Tests.xctest */,
-				FR_257D977B4221AB25C1EC0ACD6128A89B /* App_iOS_UITests.xctest */,
-				FR_89162821C7F86126DC7F165E93E0DD23 /* App_iOS.app */,
-				FR_640ADF15D2B92FDC35556B2E0934C21C /* App_macOS.app */,
-				FR_545DDE4AB557C8FAAD87775CD4271BDF /* App_watchOS Extension.appex */,
-				FR_30E7940EF436086816B40DAC068BD238 /* App_watchOS.app */,
-				FR_EFD283107EDF836BF0D9F4EB3F9A0016 /* Framework.framework */,
-				FR_099E2C49D4A0B799E78B39C47FBEADF7 /* Framework.framework */,
-				FR_D5FDE9E6362055E854CE1D3980716A4C /* Framework.framework */,
-				FR_654475F320EF1630562C841CA8B6938A /* Framework.framework */,
-				FR_1EA1EAB0CB9BD96BC550879E58911B12 /* Framework2.framework */,
-				FR_0A30B76CD8B0A84B8C488FABC16C4682 /* Framework2.framework */,
-				FR_3B708FF662F6F7D8E4FABBB1B3F33604 /* Framework2.framework */,
-				FR_A0DA89632C14F8DF99F15196E6EBB7D5 /* Framework2.framework */,
-				FR_3305E7E3B08D04C667D02BD29D3A45A9 /* iMessageApp.app */,
-				FR_0570C52FB0BC489485EAF0CE7B7119A1 /* iMessageExtension.appex */,
-				FR_36044227861B95AC5060E7D063BED65A /* StaticLibrary_ObjC.a */,
-				FR_1C00E09FA3D2CDB962FE8D5584853E0D /* StaticLibrary_ObjC.a */,
-				FR_5A840A83C22F13EBFE051C061E549F95 /* StaticLibrary_ObjC.a */,
-				FR_ABEBA07AEF9FB6D7F5B6D94FD76FF330 /* StaticLibrary_ObjC.a */,
-				FR_426E58636FD3B81A8F45788D3E65BC50 /* StaticLibrary_Swift.a */,
-				FR_1FA381C639CE4923ED6845790A5DF9D2 /* XPC Service.xpc */,
+				F0D48A913C087D049C8EDDD79DCFA404 /* App.entitlements */,
+				7F1A2F579A6F79C62DDA05712E2AB1F7 /* AppDelegate.swift */,
+				3797E591F302ECC0AA2FC607B190E2C8 /* Assets.xcassets */,
+				C9DDE1B06BCC1CDE0ECF15895A14CD45 /* Info.plist */,
+				CE1F06D99242F4223D081F0DF78367F3 /* LaunchScreen.storyboard */,
+				9E17D598D98065767A04740F5E729CCA /* Localizable.strings */,
+				65C8D6D1DDC1512D396C07B712F31188 /* Localizable.stringsdict */,
+				0C6BA0D12467A13EC012C728D9169681 /* LocalizedStoryboard.storyboard */,
+				814D72C2B921F60B759C2D4BB2604550 /* Main.storyboard */,
+				306796628DD52FA55E833B65DD4F2A22 /* Model.xcdatamodeld */,
+				C7809CE9FE9852C2AA87ACE57B5DEF9E /* module.modulemap */,
+				0704B6CAFBB53E0EBB08F6B385901D43 /* ViewController.swift */,
 			);
-			name = Products;
+			name = App;
+			path = App_iOS;
 			sourceTree = "<group>";
 		};
-		G_CBE9DB02095FA0DF8A7ECE76A4BD81A4 = {
+		2935454D05445817952E145D261767D4 /* watchOS */ = {
 			isa = PBXGroup;
 			children = (
-				G_8F5765334752A7E52B1E63ACAC466729 /* App */,
-				G_4401384B8D17D0B62305BE82DE0660D2 /* App_iOS_Tests */,
-				G_373C03E19EC66ABB051FC35B4E57A52E /* App_iOS_UITests */,
-				G_68375B6CA3E19FBBA0246B55B60849C0 /* App_macOS */,
-				G_7C1E92BE8CA995A6B0952C8AE6F5ADF9 /* App_watchOS */,
-				G_089F5A7E7FB159719FE19B5E84B85D5D /* App_watchOS Extension */,
-				G_81658721738C48797F805CC891E70B6F /* Configs */,
-				G_9E36E5E1B7BEC6A8D683D2E36CE21BCE /* CopyFiles */,
-				G_9DEB15811B31C2D4D4B63339FBE33149 /* FileGroup */,
-				G_0D2DDBB1C39493B8B0EAF9CC23272F2D /* Framework */,
-				G_DFE333D63D37FEA4C705A105F9FE0C2A /* iMessage */,
-				G_415E92CCC7C77CD8BB161FA75E8B66EF /* iMessage MessagesExtension */,
-				G_322C327C1DB8AE7E0B99EF59318DFE22 /* Resources */,
-				G_D0428A559D8B50225BCD0A3640D8B431 /* StandaloneFiles */,
-				G_4A1045347B09A484656D26436E35FDCC /* StaticLibrary_ObjC */,
-				G_CC2410394CB552EF47011133E3A148F5 /* StaticLibrary_Swift */,
-				G_EEC8BB7E2370237E3F5D64AA1BD42CC9 /* Vendor */,
-				G_23236546763854F4301D7847EBA0A2BF /* XPC Service */,
-				FR_3B4065B548BFD8CFB3D1153F7106DDA3 /* Folder */,
-				FR_3DD4DE355C21662A9169EE41C44F73E3 /* Headers */,
-				FR_5E4B4E53251DE2294715A48CC249EBFD /* Mintfile */,
-				FR_1B0304C0E4DC73614BAA550E4A80D41C /* ResourceFolder */,
-				FR_C86A7EAE4DFF4327D1E7D32A597CA4AC /* SomeFile */,
-				G_54CAD56F6F3EAD10E9DB8D50B52D09F3 /* Frameworks */,
-				G_B0D2DFD450BCF614AA46E474644F2CE3 /* Products */,
+				BB178D03E75929F3F5B10C56838882EC /* Result.framework */,
+			);
+			path = watchOS;
+			sourceTree = "<group>";
+		};
+		293D0FF827366B513839236A28819597 = {
+			isa = PBXGroup;
+			children = (
+				1F2DE413CF2CB54988158172BF8B5864 /* App */,
+				FC81A3ED177CE9DA68D099410B3A6769 /* App_iOS_Tests */,
+				0D039F2E62354C7C8E283BE65E4F9BD5 /* App_iOS_UITests */,
+				EE78B4FBD0137D1975C47D7609278F26 /* App_macOS */,
+				BAE6C12745737019DC9E98BFF1E88D59 /* App_watchOS */,
+				795B8D70B674C850B57DD39DCD4B3C66 /* App_watchOS Extension */,
+				6DBE0EE90642BB3F6E58AD43196A5ED1 /* Configs */,
+				3F2E22B7AB20FA42CD205C2AA67B98EA /* CopyFiles */,
+				5CBCE0E2A145046265FE99E25F5025E7 /* FileGroup */,
+				1A57D1EE1FBC13598F6B5CB018E7D348 /* Framework */,
+				B370CE9C04C41EBC52D4E4EA1F3EB767 /* iMessage */,
+				0A989C35EEBD58B9B98C41A75CE9CE00 /* iMessage MessagesExtension */,
+				9EDF27BB8A57733E6639D36D66958B76 /* Resources */,
+				9DB22CB08CFAA455518700DBA5CAD7DE /* StandaloneFiles */,
+				BDA839814AF73F01F771051894A708E8 /* StaticLibrary_ObjC */,
+				CBDAC144248EE9D3838C6AAA35F55CB5 /* StaticLibrary_Swift */,
+				3FEA12CF227D41EF50E5C2DB21B84FBB /* Vendor */,
+				80C3A0E524EC1ABCB9149EA22136F282 /* XPC Service */,
+				FC60FF5527FEDF545816FFCF26619677 /* Folder */,
+				2E1E747C7BC434ADB80CC269B7B595DC /* Headers */,
+				C2F3574CCEF023755DDB1A06C6FE315C /* Mintfile */,
+				6B1603BA83AA0C7B94E45168D7E684C4 /* ResourceFolder */,
+				6BBE762F36D94AB6FFBFE834A99277EA /* SomeFile */,
+				FC1515684236259C50A7747F607DC8A2 /* Frameworks */,
+				AC523591AC7BE9275003D2DB7E14C098 /* Products */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
 			tabWidth = 2;
 			usesTabs = 0;
 		};
-		G_CC2410394CB552EF47011133E3A148F5 /* StaticLibrary_Swift */ = {
+		2EEFFE9D49F84DE5D5AFA553B804F66C /* Module */ = {
 			isa = PBXGroup;
 			children = (
-				FR_CCC97AF230188CAF9B4A66324891CCAD /* StaticLibrary.swift */,
+				F2950763C4C568CC85021D185A35C1FB /* module.modulemap */,
 			);
-			path = StaticLibrary_Swift;
+			path = Module;
 			sourceTree = "<group>";
 		};
-		G_CC8E08E619EF6EA96B28904C6651F6B8 /* watchOS */ = {
+		3F2E22B7AB20FA42CD205C2AA67B98EA /* CopyFiles */ = {
 			isa = PBXGroup;
 			children = (
-				FR_DC1C8DE46218F90A3F4FD5F8DE4F0ABB /* Result.framework */,
+				068EDF47F0B087F6A4052AC08A2FA1E4 /* Empty.h */,
 			);
-			path = watchOS;
+			path = CopyFiles;
 			sourceTree = "<group>";
 		};
-		G_D0428A559D8B50225BCD0A3640D8B431 /* StandaloneFiles */ = {
+		3FEA12CF227D41EF50E5C2DB21B84FBB /* Vendor */ = {
 			isa = PBXGroup;
 			children = (
-				FR_82E3C6C060C4487B5177509917C3FAE3 /* Standalone.swift */,
-				FR_C6A9DE885CAF350F6C9D0AC6F7324CD3 /* StandaloneAssets.xcassets */,
+				70A8E15C81E454DC950C59F092CC1049 /* SomeXPCService.xpc */,
+			);
+			path = Vendor;
+			sourceTree = "<group>";
+		};
+		5CBCE0E2A145046265FE99E25F5025E7 /* FileGroup */ = {
+			isa = PBXGroup;
+			children = (
+				68829F7392F2B367129BA0E72B32FF9A /* UnderFileGroup */,
+			);
+			path = FileGroup;
+			sourceTree = "<group>";
+		};
+		68829F7392F2B367129BA0E72B32FF9A /* UnderFileGroup */ = {
+			isa = PBXGroup;
+			children = (
+				CA8718C7CD3BE86D9B1F51203A548A51 /* MoreUnder.swift */,
+			);
+			path = UnderFileGroup;
+			sourceTree = "<group>";
+		};
+		6DBE0EE90642BB3F6E58AD43196A5ED1 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				102A08142A31E44F4ED52649F22BB71E /* base.xcconfig */,
+				16D662EE577E4CD6AFF39D66C382B13F /* config.xcconfig */,
+			);
+			path = Configs;
+			sourceTree = "<group>";
+		};
+		795B8D70B674C850B57DD39DCD4B3C66 /* App_watchOS Extension */ = {
+			isa = PBXGroup;
+			children = (
+				108BB29172D27BE3BD1E7F3536D14EAD /* Assets.xcassets */,
+				8CAF6C55B555E3E1352645B630CCB23E /* ExtensionDelegate.swift */,
+				9F27382DD66E26C059E26EFE8D6BEF4D /* Info.plist */,
+				A3F6BCB5FEFB16F1BA368059F4B1505A /* InterfaceController.swift */,
+				C934C1F7A68CCD0AB6B384782470EE7B /* NotificationController.swift */,
+				E9672EF8FE1DDC8DE070512979C33058 /* PushNotificationPayload.apns */,
+			);
+			path = "App_watchOS Extension";
+			sourceTree = "<group>";
+		};
+		80C3A0E524EC1ABCB9149EA22136F282 /* XPC Service */ = {
+			isa = PBXGroup;
+			children = (
+				BA040F1F7D6CA08878323A551349F18D /* Info.plist */,
+				187E665975BB5611AF0F27E15659D85C /* main.m */,
+				FD05F36F95D6F098A76F220BA08E154C /* XPC_Service.h */,
+				148B7C933698BCC4F1DBA979CF051F81 /* XPC_Service.m */,
+				3D8A2D4363866877B91401560806DD1D /* XPC_ServiceProtocol.h */,
+			);
+			path = "XPC Service";
+			sourceTree = "<group>";
+		};
+		912A7321F662FE41BAAEED67F628711F /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				D296BB7355994040E197A1EE5B41F583 /* Result.framework */,
+			);
+			path = Mac;
+			sourceTree = "<group>";
+		};
+		9DB22CB08CFAA455518700DBA5CAD7DE /* StandaloneFiles */ = {
+			isa = PBXGroup;
+			children = (
+				0F5BD97AF0F94A15A5B7DDB75C0C7CDF /* Standalone.swift */,
+				3571E41E19A5AB8AAAB04109D524DB4F /* StandaloneAssets.xcassets */,
 			);
 			path = StandaloneFiles;
 			sourceTree = "<group>";
 		};
-		G_DFE333D63D37FEA4C705A105F9FE0C2A /* iMessage */ = {
+		9EDF27BB8A57733E6639D36D66958B76 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				FR_B537FEE8515090D3BA0F5CFF3BC76BB1 /* Assets.xcassets */,
-				FR_41E1155D8A7FDD97B783A1D5B3AD2C5B /* Info.plist */,
+				7B5068D64404C61A67A184584E13804D /* MyBundle.bundle */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		AC523591AC7BE9275003D2DB7E14C098 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				CB77A637470A3CDA2BDDBE9948AB9716 /* App_iOS_Tests.xctest */,
+				13EEAB58665D79C15184D9D0DEE29087 /* App_iOS_UITests.xctest */,
+				B1C33BB070583BE3B0EC0E68083FE89C /* App_iOS.app */,
+				33F6DCDC37D2E66543D4965D829900E1 /* App_macOS.app */,
+				0D09D243DBCF9D32E239F1E8A64D75AB /* App_watchOS Extension.appex */,
+				A680BE9F68A255B0FB291AE6F0A2B045 /* App_watchOS.app */,
+				8A9274BE42A03DC5DA1FAD04992ED6E3 /* Framework.framework */,
+				41FC82ED1C4C3B7B3D7B2FB721574442 /* Framework.framework */,
+				7D67F1C1BFBACE101DE7DB5179F2DCEA /* Framework.framework */,
+				6177CC6263783487E93F7F4D07620345 /* Framework.framework */,
+				3EF21DF245F66BEF5446AAEF769A4194 /* Framework2.framework */,
+				2233774B86539B1574D206B07A805A8F /* Framework2.framework */,
+				A0DC40025AB59B688E758829FB7EDB95 /* Framework2.framework */,
+				AB055761199DF36DB0C629A608A4EF3A /* Framework2.framework */,
+				9A87A926D563773658FB87FEEE4DD132 /* iMessageApp.app */,
+				D629E142AB87C681D4EC90F7106F7299 /* iMessageExtension.appex */,
+				4D0BF47DF71A6DBA33ED23FD22D023EF /* StaticLibrary_ObjC.a */,
+				056A43A09CE7E88D578696D83330E45F /* StaticLibrary_ObjC.a */,
+				1313F043F19B484A5046E0748579814C /* StaticLibrary_ObjC.a */,
+				EF92E90B6F1D583382BD85BEE4CD1896 /* StaticLibrary_ObjC.a */,
+				D8D8907E2CDA1295D0D94F53FCD6939F /* StaticLibrary_Swift.a */,
+				22237B8EBD9E6BE8EBC8735F5AA17192 /* XPC Service.xpc */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B370CE9C04C41EBC52D4E4EA1F3EB767 /* iMessage */ = {
+			isa = PBXGroup;
+			children = (
+				42B95EB66A17FBA091F50601196CAA83 /* Assets.xcassets */,
+				7ACBAD7D485AA4E2542B9E0F9908D5B2 /* Info.plist */,
 			);
 			path = iMessage;
 			sourceTree = "<group>";
 		};
-		G_EEC8BB7E2370237E3F5D64AA1BD42CC9 /* Vendor */ = {
+		BAE6C12745737019DC9E98BFF1E88D59 /* App_watchOS */ = {
 			isa = PBXGroup;
 			children = (
-				FR_4EB4AAACD714C13E5BC894C71B954299 /* SomeXPCService.xpc */,
+				D8A016580A3B8F72B820BFBF93749CD7 /* Assets.xcassets */,
+				FED40A89162E446494DDE7C74F29A61D /* Info.plist */,
+				C872631362DDBAFCE71E5C66EDD61432 /* Interface.storyboard */,
 			);
-			path = Vendor;
+			path = App_watchOS;
+			sourceTree = "<group>";
+		};
+		BDA839814AF73F01F771051894A708E8 /* StaticLibrary_ObjC */ = {
+			isa = PBXGroup;
+			children = (
+				2EEFFE9D49F84DE5D5AFA553B804F66C /* Module */,
+				5A2B916A11DCC2565241359FD0114B0C /* StaticLibrary_ObjC.h */,
+				1D0C79A8C750EC0DE748C463D6992773 /* StaticLibrary_ObjC.m */,
+			);
+			path = StaticLibrary_ObjC;
+			sourceTree = "<group>";
+		};
+		CBDAC144248EE9D3838C6AAA35F55CB5 /* StaticLibrary_Swift */ = {
+			isa = PBXGroup;
+			children = (
+				6AC91042453E18DF74BA1C0F957D87DC /* StaticLibrary.swift */,
+			);
+			path = StaticLibrary_Swift;
+			sourceTree = "<group>";
+		};
+		D557819B1EE5B42A0A3DD4D1F3D982C4 /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				B76E17CE3574081D5BF45B449F3F46DB /* Result.framework */,
+			);
+			path = tvOS;
+			sourceTree = "<group>";
+		};
+		DBF93518FC96D95A5455271356EB57FF /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				0C5AC2545AE4D4F7F44E2E9B53F03FF0 /* Result.framework */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		EE78B4FBD0137D1975C47D7609278F26 /* App_macOS */ = {
+			isa = PBXGroup;
+			children = (
+				09B82F603D981398F38D762E418E8BB9 /* AppDelegate.swift */,
+				E55F45EACB0F382722D61C8D518BF80D /* Assets.xcassets */,
+				38F1191E5B85DC882B8ABE8561D4A3AE /* Info.plist */,
+				74FBDFA5CB063F6001AD8ACD1776F055 /* Main.storyboard */,
+				A4C3FE6B986506724DAB5D0FC4361D53 /* ViewController.swift */,
+			);
+			path = App_macOS;
+			sourceTree = "<group>";
+		};
+		FC1515684236259C50A7747F607DC8A2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				12809A79ACE69F501A5FE815B43985BD /* Carthage */,
+				FDB2B6A77D39CD5602F2125F01DEF025 /* Contacts.framework */,
+				0BB1B49A91B892152D68ED76D9D4E759 /* libc++.tbd */,
+				73E7D4B860A5B6B80540E64703192744 /* SomeFramework.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		FC81A3ED177CE9DA68D099410B3A6769 /* App_iOS_Tests */ = {
+			isa = PBXGroup;
+			children = (
+				77C0C341F1865224E059608627CC2D82 /* Info.plist */,
+				D132EA69984F32DA9DC727B6360D9F12 /* TestProjectTests.swift */,
+			);
+			path = App_iOS_Tests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		HBP_1A14716AFB45FE3C40861AEC5BFC7160 /* Headers */ = {
+		0D09E5BA6B8442DC0ABB8AA6E5E95A01 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_0A6C302954FF03411D6F2704ECF5C738 /* MyFramework.h in Headers */,
+				8BCF9B1A396126583737A6687CF20696 /* Headers in Headers */,
+				03FC73E479EBD3CFF4E55BBC6CC82311 /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_28AB146B2409C5AB0F7A57873541C794 /* Headers */ = {
+		2D9AE1B5509A67E70270EF742601DD26 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_390908C547D6F8520DF9AA0CC5A98EB1 /* Headers in Headers */,
-				BF_BEFDF47CD7D88221A9C166BD65BF2013 /* MyFramework.h in Headers */,
+				2DE309130A6F5A7E2E7E13169357C316 /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_5B487D2A0AEF5F301CF0DD29039EC911 /* Headers */ = {
+		54B4D7ADCE0441B5A91DE22D16E71363 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_4EBBAD70FA73DDC89BD933866B90DD08 /* MyFramework.h in Headers */,
+				E7555C1BCBCF88204907587DBD341663 /* Headers in Headers */,
+				E48B36322124BDE8EE3AF22EB3B2B47C /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_7854F8DBCA44D8AB407768095D725CA7 /* Headers */ = {
+		5A0FEF527F632170E10430F59E1E0650 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_EC0616A0D18A2F723D2AF50287C43669 /* Headers in Headers */,
-				BF_569CC068CD4B7BCE35E974D7B61566DB /* MyFramework.h in Headers */,
+				262B4F15CB0780B21C37D89F5EA9FE80 /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_98CC32EF86CB88CC66AA4CD229EB6072 /* Headers */ = {
+		5DCBD97EC23B8FCB39B95029FBA1893B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_9830FFD35765AACD86D1B619E22830D6 /* Headers in Headers */,
-				BF_3B680DD27CFCD491675F1BF257A95A24 /* MyFramework.h in Headers */,
+				54D6B532658C2616DA4AD8CDDB1BBB89 /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_9DD85101234CF2E78A49044D618D1D80 /* Headers */ = {
+		85324A7388DEC869665BFA99B311D2DA /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_7C9646667C0D479544A2207DEE3E930B /* Headers in Headers */,
-				BF_33EA0F8B2ADA2D24A683FCD8D6235B10 /* MyFramework.h in Headers */,
+				7A3C2B80CE0F5D42B7684BF5928B1694 /* Headers in Headers */,
+				BA3997DDBE08311586C3B9DA73F8DC49 /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_A3CA1B21BE2C36844B1C6BA4D2A20394 /* Headers */ = {
+		AEC8E1CFD02926FADE734D8292E60AC3 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_E35C9C198B45406E64439FF96C17F056 /* MyFramework.h in Headers */,
+				BC45B351474BD07D6C4BCD66327FFBFE /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		HBP_D19BC27B3521E3ED15AB860A9AC22D2A /* Headers */ = {
+		F21F013CBD830972394A3A137855616E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_B6E31790D07B981E52CD5BC9049FE303 /* MyFramework.h in Headers */,
+				D8859E56A17FCD26C7ED6548C81B1324 /* Headers in Headers */,
+				46DA8D104900945921DF4E7DDF584C25 /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXLegacyTarget section */
-		LT_5A51AFB390A610885D62F601DE321E4E /* Legacy */ = {
+		72C923899DE05F128187216043D8D89C /* Legacy */ = {
 			isa = PBXLegacyTarget;
-			buildConfigurationList = CL_F8A83116F913B5DD0538C3680E08BDDB /* Build configuration list for PBXLegacyTarget "Legacy" */;
+			buildConfigurationList = BE0FF81B67730F081F45BC783F30F309 /* Build configuration list for PBXLegacyTarget "Legacy" */;
 			buildPhases = (
-				SBP_C18D008976BE0EFD3D3A3C68FB79D271 /* Sources */,
+				AF7B22EF5863A5280B53589627536629 /* Sources */,
 			);
 			buildToolPath = /usr/bin/true;
 			dependencies = (
@@ -963,178 +963,62 @@
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		NT_15609BCEEB00CBCC4C42110EB0366A6F /* StaticLibrary_ObjC_macOS */ = {
+		020A320BB3736FCDE6CC4E703EE69AC0 /* App_macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_3BB54CFB2F2EFE7302C0B0709BD0AE04 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_macOS" */;
+			buildConfigurationList = 77CE5B5E5DEAC820254D484CB8646E93 /* Build configuration list for PBXNativeTarget "App_macOS" */;
 			buildPhases = (
-				CFBP_712E86A86BBF89DB5B5F3874B24B8996 /* CopyFiles */,
-				SBP_52AE5DCFB4487297D6889C7F014AD281 /* Sources */,
+				96BB43F4706B031DA45166E893A97CF8 /* Sources */,
+				77D35586228BF8AB74152BB5141C7720 /* Resources */,
+				FB79B30FEA6073A29B4D9FCC48B7B747 /* CopyFiles */,
+				A6E1C88C073F8CC6B5B072B6CD1F331F /* Frameworks */,
+				F8CDEFED6ED131A09041F995E056117D /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				1859F1314EC7027A8131D085A5E21FA3 /* PBXTargetDependency */,
+				D6F6D46B8C151E1522FA272A76CB6A9D /* PBXTargetDependency */,
+				D3937F3AF2B9928532AFF9D0ECE87944 /* PBXTargetDependency */,
 			);
-			name = StaticLibrary_ObjC_macOS;
-			productName = StaticLibrary_ObjC_macOS;
-			productReference = FR_1C00E09FA3D2CDB962FE8D5584853E0D /* StaticLibrary_ObjC.a */;
-			productType = "com.apple.product-type.library.static";
+			name = App_macOS;
+			productName = App_macOS;
+			productReference = 33F6DCDC37D2E66543D4965D829900E1 /* App_macOS.app */;
+			productType = "com.apple.product-type.application";
 		};
-		NT_193BAF154270D1C21E269EDF2A1BD3F6 /* App_iOS_Tests */ = {
+		0867B0DACEF28C11442DE8F70C48D1AC /* App_iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_89763567DCA601C83E4C78A9917D81AD /* Build configuration list for PBXNativeTarget "App_iOS_Tests" */;
+			buildConfigurationList = 62D7BB889799B73F7E8B798FE670D384 /* Build configuration list for PBXNativeTarget "App_iOS" */;
 			buildPhases = (
-				SBP_70B2F11AAC526FDB99D68212C2C92CE6 /* Sources */,
-				CFBP_2FE0B34CC045616C815F2675387DA9D5 /* Embed Frameworks */,
+				6F573D15DE1F149EF128C492B6C7AE6D /* Sources */,
+				8508BA1B733839E314AF2853B15D233B /* Resources */,
+				865AAD9909027AC34D1374EA5877AE78 /* CopyFiles */,
+				37182EC208DBF03DB1BAF452E1D2C836 /* Carthage */,
+				117840B4DBC04099F6779D006B7C8555 /* Frameworks */,
+				FE78CC3322C9C2DB1D64EAAA793C45CA /* Embed Frameworks */,
+				807155B9081529D99AAB474392826D85 /* Embed Watch Content */,
+				71A4CC6ECC8522178F566E7B3209B4DB /* Strip Unused Architectures from Frameworks */,
+				CBE633966E8F3819F15270A367192198 /* MyScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_402541000CCC58970431E41C3D928AB8 /* PBXTargetDependency */,
+				2FD6450C81585E718B2EBC4465662938 /* PBXTargetDependency */,
+				B7430AD5B07F6CC89ECAA2385B5F87BC /* PBXTargetDependency */,
+				BDD1939286F86804687733B99027F2DE /* PBXTargetDependency */,
+				EF2602D791B586844A7828A8371070CA /* PBXTargetDependency */,
+				64C42059624EE2C92C0FE59914B7FDBF /* PBXTargetDependency */,
 			);
-			name = App_iOS_Tests;
-			productName = App_iOS_Tests;
-			productReference = FR_EBD99C110BD7AE780C87A31CF2E4E7DB /* App_iOS_Tests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
+			name = App_iOS;
+			productName = App_iOS;
+			productReference = B1C33BB070583BE3B0EC0E68083FE89C /* App_iOS.app */;
+			productType = "com.apple.product-type.application";
 		};
-		NT_23509FD082D1F788E6D6431F509B11AF /* XPC Service */ = {
+		13E8C5AB873CEE21E18E552F5E94B768 /* StaticLibrary_ObjC_iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_6993244897DFCCF1F61A6136FDBE3C01 /* Build configuration list for PBXNativeTarget "XPC Service" */;
+			buildConfigurationList = 56BF985F253DD84AD7C3753800E07F6D /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_iOS" */;
 			buildPhases = (
-				SBP_669CBAFD2D7234A2BEDCEAA4949ED575 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "XPC Service";
-			productName = "XPC Service";
-			productReference = FR_1FA381C639CE4923ED6845790A5DF9D2 /* XPC Service.xpc */;
-			productType = "com.apple.product-type.xpc-service";
-		};
-		NT_2940463C85DCD0660288786BC66F2C4C /* StaticLibrary_Swift */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_159255858B3EEC02844A3059326A6B93 /* Build configuration list for PBXNativeTarget "StaticLibrary_Swift" */;
-			buildPhases = (
-				SBP_3DD17ED231CE07543581040F32049525 /* Sources */,
-				SSBP_4A83147402B05D3C84D21F0487315914 /* Copy Swift Objective-C Interface Header */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = StaticLibrary_Swift;
-			productName = StaticLibrary_Swift;
-			productReference = FR_426E58636FD3B81A8F45788D3E65BC50 /* StaticLibrary_Swift.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_34A020E43FBBD797051205235CD82B70 /* StaticLibrary_ObjC_watchOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_2E30D27084B352548CCAA3500158519B /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_watchOS" */;
-			buildPhases = (
-				CFBP_4DFB7882C9F8BAB250BB0A6B9457B4CC /* CopyFiles */,
-				SBP_924258C7A9F27B13508604CAF625E0D3 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = StaticLibrary_ObjC_watchOS;
-			productName = StaticLibrary_ObjC_watchOS;
-			productReference = FR_ABEBA07AEF9FB6D7F5B6D94FD76FF330 /* StaticLibrary_ObjC.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_38A9FE87056942A2746E0FF025B52A91 /* App_watchOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_C50D7BB75115E8561A0975DE1B65E088 /* Build configuration list for PBXNativeTarget "App_watchOS" */;
-			buildPhases = (
-				SBP_ED63FCA00BD617EFF125ECDF9D24FAD8 /* Sources */,
-				RBP_5623703FDC4F6DF4679D8BAF27518F2F /* Resources */,
-				SSBP_7F147E7ED45BAAE2186975B7FF9EB08A /* Carthage */,
-				CFBP_469B033759EACBB99ECBF1008677C590 /* Embed App Extensions */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_2A43F973A3E1CF675A967054BA52074B /* PBXTargetDependency */,
-			);
-			name = App_watchOS;
-			productName = App_watchOS;
-			productReference = FR_30E7940EF436086816B40DAC068BD238 /* App_watchOS.app */;
-			productType = "com.apple.product-type.application.watchapp2";
-		};
-		NT_5245AB6D3B3CFBC95AEBADF6E0C593B8 /* App_watchOS Extension */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_333C6C3162FB671343E806257FB2A411 /* Build configuration list for PBXNativeTarget "App_watchOS Extension" */;
-			buildPhases = (
-				SBP_49F3C650EA105D1EF50817673A8DB33A /* Sources */,
-				RBP_1BFB64F249645ABF48C3CCDF8D5FA094 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "App_watchOS Extension";
-			productName = "App_watchOS Extension";
-			productReference = FR_545DDE4AB557C8FAAD87775CD4271BDF /* App_watchOS Extension.appex */;
-			productType = "com.apple.product-type.watchkit2-extension";
-		};
-		NT_66B6A18138FD1FB5ECF3FC67B20FF3D3 /* Framework2_tvOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_A55E6C4018D2631D41C660DBF2113765 /* Build configuration list for PBXNativeTarget "Framework2_tvOS" */;
-			buildPhases = (
-				HBP_A3CA1B21BE2C36844B1C6BA4D2A20394 /* Headers */,
-				SBP_DB9B8E1504ED9DD92AE41067C53B5082 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Framework2_tvOS;
-			productName = Framework2_tvOS;
-			productReference = FR_3B708FF662F6F7D8E4FABBB1B3F33604 /* Framework2.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		NT_6A4FC6EE80FB2821AB96D51C3BC8966E /* iMessageExtension */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_3ABBEC1A6EFC98F40894F5E4769650EF /* Build configuration list for PBXNativeTarget "iMessageExtension" */;
-			buildPhases = (
-				SBP_110D7B4160D965B7964619BF78E01DE2 /* Sources */,
-				RBP_A5B7C086E8F07F5FEE9B99375E375819 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = iMessageExtension;
-			productName = iMessageExtension;
-			productReference = FR_0570C52FB0BC489485EAF0CE7B7119A1 /* iMessageExtension.appex */;
-			productType = "com.apple.product-type.app-extension.messages";
-		};
-		NT_6A7B08EB167FD3A759C339FDBED7E019 /* Framework_watchOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_674C71F7D7B679C67A944F0110840758 /* Build configuration list for PBXNativeTarget "Framework_watchOS" */;
-			buildPhases = (
-				HBP_98CC32EF86CB88CC66AA4CD229EB6072 /* Headers */,
-				SBP_8990272D7DD45CFBDAB18690861BD4E8 /* Sources */,
-				FBP_71D96680A2FBE24C4C8BD0B5E55FE034 /* Frameworks */,
-				SSBP_B07F447D73408EA48C54A8E7F5B8D575 /* MyScript */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_205ABD699FA8E05C47D73E8EB2D0F9EF /* PBXTargetDependency */,
-			);
-			name = Framework_watchOS;
-			productName = Framework_watchOS;
-			productReference = FR_654475F320EF1630562C841CA8B6938A /* Framework.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		NT_6AEE12F93D449E249F5348BBF35D3053 /* StaticLibrary_ObjC_iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_F6ECF2D45799DBBB48DE9AE80AC280AA /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_iOS" */;
-			buildPhases = (
-				CFBP_0B6C520DAC94DDCE678BE15C53528F25 /* CopyFiles */,
-				SBP_D6209A702C851D0CFD1CC2B225986D45 /* Sources */,
+				7FAF0BBB3DE701EBE5DBE810BBE743E3 /* CopyFiles */,
+				EA88FE285DA490166635BE98068E01D9 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -1142,103 +1026,136 @@
 			);
 			name = StaticLibrary_ObjC_iOS;
 			productName = StaticLibrary_ObjC_iOS;
-			productReference = FR_36044227861B95AC5060E7D063BED65A /* StaticLibrary_ObjC.a */;
+			productReference = 4D0BF47DF71A6DBA33ED23FD22D023EF /* StaticLibrary_ObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		NT_6BD068FAAC6AA35C090C48147B94EC6E /* iMessageApp */ = {
+		19BFB84599B0AA1275A9662DCB5C0E50 /* StaticLibrary_Swift */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_AA475AE6741D5744A91627E7FAF4C986 /* Build configuration list for PBXNativeTarget "iMessageApp" */;
+			buildConfigurationList = 4A036BD16A0E9D22AE065AC9D8232B5B /* Build configuration list for PBXNativeTarget "StaticLibrary_Swift" */;
 			buildPhases = (
-				SBP_20DDAC7BCD11ECA8B08695FE5D7314A9 /* Sources */,
-				RBP_9291220ECDCB98B69BB31C3E875042EC /* Resources */,
-				CFBP_AD91D17C63B2CD9AE7EFB9EFD62A8223 /* Embed App Extensions */,
+				97C367BB898AC3F3B2DB1DD8B4BA1C29 /* Sources */,
+				194EE782F10A8F7ABD1A4AEB7C7FE978 /* Copy Swift Objective-C Interface Header */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_846DB03B9778D6C8E81FE52A5A212420 /* PBXTargetDependency */,
 			);
-			name = iMessageApp;
-			productName = iMessageApp;
-			productReference = FR_3305E7E3B08D04C667D02BD29D3A45A9 /* iMessageApp.app */;
-			productType = "com.apple.product-type.application.messages";
+			name = StaticLibrary_Swift;
+			productName = StaticLibrary_Swift;
+			productReference = D8D8907E2CDA1295D0D94F53FCD6939F /* StaticLibrary_Swift.a */;
+			productType = "com.apple.product-type.library.static";
 		};
-		NT_7D108AE86BED8C9CCF52C2646FA4C5DE /* Framework_iOS */ = {
+		1C26A6A0BC446191F311D470FDFF54F8 /* iMessageExtension */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_9FEF3E411E281B1820B2B067FC1C1B85 /* Build configuration list for PBXNativeTarget "Framework_iOS" */;
+			buildConfigurationList = ED1A174BA92C6E5172B519B7B6716A24 /* Build configuration list for PBXNativeTarget "iMessageExtension" */;
 			buildPhases = (
-				HBP_28AB146B2409C5AB0F7A57873541C794 /* Headers */,
-				SBP_0CB30551A2D40126958D8D6DAF6922E2 /* Sources */,
-				FBP_98B76E46D78FD48FB47A41B8891665BC /* Frameworks */,
-				SSBP_13B42B84708A6ABC082BE00176F5DCB2 /* MyScript */,
+				5B3245836D7FA67E79EA1731372F18C9 /* Sources */,
+				1C008C34DA06FEE7841B0AC3AF1BB584 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_117F878FC368C83443CEC1707531F7F2 /* PBXTargetDependency */,
 			);
-			name = Framework_iOS;
-			productName = Framework_iOS;
-			productReference = FR_EFD283107EDF836BF0D9F4EB3F9A0016 /* Framework.framework */;
+			name = iMessageExtension;
+			productName = iMessageExtension;
+			productReference = D629E142AB87C681D4EC90F7106F7299 /* iMessageExtension.appex */;
+			productType = "com.apple.product-type.app-extension.messages";
+		};
+		208179651927D1138D19B5AD54E29D2B /* App_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6B5C5F08C0EF06457756E379776B4C6F /* Build configuration list for PBXNativeTarget "App_watchOS" */;
+			buildPhases = (
+				91C895DE8170C96A75D29426BA2BC597 /* Sources */,
+				B7B71FA7D279029BF7A7FC7C08E41BB0 /* Resources */,
+				261B4BE58AA60B68A81874E3318793F3 /* Carthage */,
+				C765431E5FF4B02F59DE79B068D2CB68 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0BF8700E8CCE91434585CBA7E7C7736A /* PBXTargetDependency */,
+			);
+			name = App_watchOS;
+			productName = App_watchOS;
+			productReference = A680BE9F68A255B0FB291AE6F0A2B045 /* App_watchOS.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		307AE3FA155FFD09B74AE351B15321B6 /* App_watchOS Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3F3C272D2EA61F6B88B80D440755448B /* Build configuration list for PBXNativeTarget "App_watchOS Extension" */;
+			buildPhases = (
+				AE7971E1CA54D23C264E6541EA9BAE1B /* Sources */,
+				4A6E8F3A477AA5F67A8EB733DFAD8387 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "App_watchOS Extension";
+			productName = "App_watchOS Extension";
+			productReference = 0D09D243DBCF9D32E239F1E8A64D75AB /* App_watchOS Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
+		536ACF18E4603B59207D43CE68E02CBF /* Framework_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 658628E35283172E17BFC6A35BE18143 /* Build configuration list for PBXNativeTarget "Framework_tvOS" */;
+			buildPhases = (
+				F21F013CBD830972394A3A137855616E /* Headers */,
+				9EC3C2991C5C1EE119E39533F752AA31 /* Sources */,
+				5EFF61D0A49AA8EABD72DF4449BCEADE /* Frameworks */,
+				BA454AAC926EDFCDA9226CBCACCBEDB1 /* MyScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				197C9E15A390E6E7876A7A69E0CAC789 /* PBXTargetDependency */,
+			);
+			name = Framework_tvOS;
+			productName = Framework_tvOS;
+			productReference = 7D67F1C1BFBACE101DE7DB5179F2DCEA /* Framework.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		NT_87DF09E78830E7EB3C00B6134A2D5A5D /* Framework2_macOS */ = {
+		53A3B531E3947D8A8722745EA59EBB5B /* Framework_macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_289609080F2D20D506C8A587BC92807B /* Build configuration list for PBXNativeTarget "Framework2_macOS" */;
+			buildConfigurationList = D60A551D881B4B91F4535B78058154DF /* Build configuration list for PBXNativeTarget "Framework_macOS" */;
 			buildPhases = (
-				HBP_5B487D2A0AEF5F301CF0DD29039EC911 /* Headers */,
-				SBP_C469AFC0C383156AF5C80EBBC089D9FC /* Sources */,
+				54B4D7ADCE0441B5A91DE22D16E71363 /* Headers */,
+				D1F422E9C4DD531AA88418C9F755A5D2 /* Sources */,
+				C2323597C6777A02E1FF671C303DD89C /* Frameworks */,
+				3D0637F4554EAD6FA48105BF0609954D /* MyScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-			);
-			name = Framework2_macOS;
-			productName = Framework2_macOS;
-			productReference = FR_0A30B76CD8B0A84B8C488FABC16C4682 /* Framework2.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		NT_9D53AF351F8DAE25354F2391248DFCCA /* Framework_macOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_7A3206BF9A92D4552AE40D148897BB3E /* Build configuration list for PBXNativeTarget "Framework_macOS" */;
-			buildPhases = (
-				HBP_7854F8DBCA44D8AB407768095D725CA7 /* Headers */,
-				SBP_EA528A5DC6D79AA397B25949B07AE70F /* Sources */,
-				FBP_935BCDE6C86D2D59A945DC1E6886D7C3 /* Frameworks */,
-				SSBP_C8F56E533BE956498E644805330168EB /* MyScript */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_BBB2D0EDFD9EF8193F1864D1F3D5F97A /* PBXTargetDependency */,
+				61C16530841EB21C795E8F6AFFE507AB /* PBXTargetDependency */,
 			);
 			name = Framework_macOS;
 			productName = Framework_macOS;
-			productReference = FR_099E2C49D4A0B799E78B39C47FBEADF7 /* Framework.framework */;
+			productReference = 41FC82ED1C4C3B7B3D7B2FB721574442 /* Framework.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		NT_9F72C903B42E1AA3B88F97B917231B15 /* Framework2_iOS */ = {
+		578C80E461E675508CED5DC3F45C99C7 /* StaticLibrary_ObjC_macOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_0562279D56EF60E8CCC0973D2C663637 /* Build configuration list for PBXNativeTarget "Framework2_iOS" */;
+			buildConfigurationList = 752BB3C1A601770BDD9AC01ECB78E01C /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_macOS" */;
 			buildPhases = (
-				HBP_D19BC27B3521E3ED15AB860A9AC22D2A /* Headers */,
-				SBP_84E9A8BE77910B67B3F2DCD5916DC498 /* Sources */,
+				3217EBDE07BBCBDE3C16CEDC81DB57CD /* CopyFiles */,
+				247A4E3947EC2AFB733A1B00BCEF9EC2 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = Framework2_iOS;
-			productName = Framework2_iOS;
-			productReference = FR_1EA1EAB0CB9BD96BC550879E58911B12 /* Framework2.framework */;
-			productType = "com.apple.product-type.framework";
+			name = StaticLibrary_ObjC_macOS;
+			productName = StaticLibrary_ObjC_macOS;
+			productReference = 056A43A09CE7E88D578696D83330E45F /* StaticLibrary_ObjC.a */;
+			productType = "com.apple.product-type.library.static";
 		};
-		NT_A3933B4002C44B46F34B238F654D1362 /* Framework2_watchOS */ = {
+		6ED01BC471A8C3642258E1787026EDED /* Framework2_watchOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_E92E1636D45B284E44D38EB3EF7C98C9 /* Build configuration list for PBXNativeTarget "Framework2_watchOS" */;
+			buildConfigurationList = 7E4887637B4FA5B8E2F349CA4B36BDBE /* Build configuration list for PBXNativeTarget "Framework2_watchOS" */;
 			buildPhases = (
-				HBP_1A14716AFB45FE3C40861AEC5BFC7160 /* Headers */,
-				SBP_48868408A19D9BBE4A58CA4FAE00C0D4 /* Sources */,
+				5DCBD97EC23B8FCB39B95029FBA1893B /* Headers */,
+				21327378A4B2AF2B952D6DF1BDAAF25E /* Sources */,
 			);
 			buildRules = (
 			);
@@ -1246,82 +1163,84 @@
 			);
 			name = Framework2_watchOS;
 			productName = Framework2_watchOS;
-			productReference = FR_A0DA89632C14F8DF99F15196E6EBB7D5 /* Framework2.framework */;
+			productReference = AB055761199DF36DB0C629A608A4EF3A /* Framework2.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		NT_B91A6EACD6F5192FECA2E95FD531D0CA /* App_macOS */ = {
+		71B5187E710718C1A205D4DCD90D6962 /* Framework_watchOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_D72660834ED9ED4EB0E973ABC256E014 /* Build configuration list for PBXNativeTarget "App_macOS" */;
+			buildConfigurationList = 4A8774E3B4F5C9B98E0D0CF9EC17CF91 /* Build configuration list for PBXNativeTarget "Framework_watchOS" */;
 			buildPhases = (
-				SBP_7EE428F1F0444ACB29B3C5259C04FF6D /* Sources */,
-				RBP_BA57258FD71062047F5503B4B160FE15 /* Resources */,
-				CFBP_CC737A6BF6243B189B109606B0C4B5A2 /* CopyFiles */,
-				FBP_4E773D46F6F726BBC0032C576D02FCB7 /* Frameworks */,
-				CFBP_CB2355266C8BAA9C97863011F3DE05A2 /* Embed Frameworks */,
+				85324A7388DEC869665BFA99B311D2DA /* Headers */,
+				077D11E42A8E90CAB8A95DF21687CF45 /* Sources */,
+				2E6FCCFC594BE9FEB74FA2F01F56F4FE /* Frameworks */,
+				85D42C01B0821B87A49F32BD523EAE58 /* MyScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_B8F32B4B3CC431FE0EC1C4E7D096E3AC /* PBXTargetDependency */,
-				TD_35F382102AABCCCEFADCBC201E5B1CE1 /* PBXTargetDependency */,
-				TD_C762D8FBA80775A921AA5B50422E9349 /* PBXTargetDependency */,
+				520DAD99269660E2D0313AB847BF1100 /* PBXTargetDependency */,
 			);
-			name = App_macOS;
-			productName = App_macOS;
-			productReference = FR_640ADF15D2B92FDC35556B2E0934C21C /* App_macOS.app */;
-			productType = "com.apple.product-type.application";
+			name = Framework_watchOS;
+			productName = Framework_watchOS;
+			productReference = 6177CC6263783487E93F7F4D07620345 /* Framework.framework */;
+			productType = "com.apple.product-type.framework";
 		};
-		NT_BEB0891E36797FE2214A0A9D516D408D /* App_iOS */ = {
+		7D3D92034F4F203C140574F08DF5F38F /* StaticLibrary_ObjC_watchOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_C7673A8886407721BA5BFA1B18F184D4 /* Build configuration list for PBXNativeTarget "App_iOS" */;
+			buildConfigurationList = 0129D8A8DCD54069136D90F7F9F29C1A /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_watchOS" */;
 			buildPhases = (
-				SBP_77EF8BC7FC3D693C9C0C1CB51984F3E2 /* Sources */,
-				RBP_85DF5DDC76E0E2A78CAFC9A3EC508232 /* Resources */,
-				CFBP_D7E07645BC437C4DFBB212DFC4F3B09E /* CopyFiles */,
-				SSBP_7F8DED07519BA4B70C40A9A755844874 /* Carthage */,
-				FBP_18D4325BBE506E88E1C742F57AECB0CD /* Frameworks */,
-				CFBP_1C40B0777F31334440F91C2DB34EF404 /* Embed Frameworks */,
-				CFBP_961F46C30E720E886AEFD11D45DDA199 /* Embed Watch Content */,
-				SSBP_062CBBF024005F57EECA660F9C7B0C7D /* Strip Unused Architectures from Frameworks */,
-				SSBP_376C0662E4E8416C049A50660864798B /* MyScript */,
+				924D7F0A22013EE6F06E74009AB5D420 /* CopyFiles */,
+				6D2FCEFCAFB24526BD458A2D8EEC24F0 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_0C5CE0308CB64DB986A853307CCF8A95 /* PBXTargetDependency */,
-				TD_94E481CDF62CDA1E9B37D1DA08E5A5AF /* PBXTargetDependency */,
-				TD_4013C738E59E1CA40B4A982AF74E8604 /* PBXTargetDependency */,
-				TD_266243C3BBC1C83485E1B43C0FFC3626 /* PBXTargetDependency */,
-				TD_743D7CD7BB700A16A02A7A4A1E02D845 /* PBXTargetDependency */,
 			);
-			name = App_iOS;
-			productName = App_iOS;
-			productReference = FR_89162821C7F86126DC7F165E93E0DD23 /* App_iOS.app */;
-			productType = "com.apple.product-type.application";
+			name = StaticLibrary_ObjC_watchOS;
+			productName = StaticLibrary_ObjC_watchOS;
+			productReference = EF92E90B6F1D583382BD85BEE4CD1896 /* StaticLibrary_ObjC.a */;
+			productType = "com.apple.product-type.library.static";
 		};
-		NT_D4BAEEEC88124103C8DFF41FCE206DCE /* App_iOS_UITests */ = {
+		834F55973F05AC8A18144DB04FF6F2C7 /* iMessageApp */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_DB66C428B606518C825ECFF73A5EF059 /* Build configuration list for PBXNativeTarget "App_iOS_UITests" */;
+			buildConfigurationList = 1FC6945BE13C2202A2BCA3BC51569CF7 /* Build configuration list for PBXNativeTarget "iMessageApp" */;
 			buildPhases = (
-				SBP_3848ADAF2343866973E57344A1054BE3 /* Sources */,
-				CFBP_3BE6FE084D6BE913354F37B1DD9A8D92 /* Embed Frameworks */,
+				D067D70CFD13DFBED478C2287D172491 /* Sources */,
+				61001E265009194959C2CF36DD7B04E5 /* Resources */,
+				2F0735A423E554B267BBA0A5FA4E9D99 /* Embed App Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_98EB63C93477EA15558367FBAB5797CE /* PBXTargetDependency */,
+				47BF97F766B01CDB0B24B7CF7606B727 /* PBXTargetDependency */,
 			);
-			name = App_iOS_UITests;
-			productName = App_iOS_UITests;
-			productReference = FR_257D977B4221AB25C1EC0ACD6128A89B /* App_iOS_UITests.xctest */;
-			productType = "com.apple.product-type.bundle.ui-testing";
+			name = iMessageApp;
+			productName = iMessageApp;
+			productReference = 9A87A926D563773658FB87FEEE4DD132 /* iMessageApp.app */;
+			productType = "com.apple.product-type.application.messages";
 		};
-		NT_D4C3E345E90AF9F6CBE8CF226FCFBCD6 /* StaticLibrary_ObjC_tvOS */ = {
+		8B9A14DC280CCE013CC8644093599CB1 /* Framework2_tvOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_91682ADED17A2C81A700A67F5D70BA1F /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_tvOS" */;
+			buildConfigurationList = EF0A56586AB1ED900B70D5BC3C15FDFD /* Build configuration list for PBXNativeTarget "Framework2_tvOS" */;
 			buildPhases = (
-				CFBP_CC1EF1963551F7E08925519982C248B9 /* CopyFiles */,
-				SBP_645418A0FA6E3F5727685DE191C6B793 /* Sources */,
+				AEC8E1CFD02926FADE734D8292E60AC3 /* Headers */,
+				8FD76C583F8C166F974F4BE25C1A8058 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Framework2_tvOS;
+			productName = Framework2_tvOS;
+			productReference = A0DC40025AB59B688E758829FB7EDB95 /* Framework2.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		93542A75A613F00FDB5C9C63B5101409 /* StaticLibrary_ObjC_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 906B8E5233EE4169E84ABAF37433F2A2 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_tvOS" */;
+			buildPhases = (
+				06FAE8D6834F982AA934B3E847C58D16 /* CopyFiles */,
+				9BFB2E19F4777ACBEF89589A55057522 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -1329,54 +1248,135 @@
 			);
 			name = StaticLibrary_ObjC_tvOS;
 			productName = StaticLibrary_ObjC_tvOS;
-			productReference = FR_5A840A83C22F13EBFE051C061E549F95 /* StaticLibrary_ObjC.a */;
+			productReference = 1313F043F19B484A5046E0748579814C /* StaticLibrary_ObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		NT_FA652FEB38562C3A5C93D5EC7ED09776 /* Framework_tvOS */ = {
+		AE3F93DB94E7208F2F1D9A78B91C1BC8 /* Framework_iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_11BB9F4DF26D98C0A2C8E1668356269F /* Build configuration list for PBXNativeTarget "Framework_tvOS" */;
+			buildConfigurationList = 50DA67E9A951C40D9536609DD12FA6CC /* Build configuration list for PBXNativeTarget "Framework_iOS" */;
 			buildPhases = (
-				HBP_9DD85101234CF2E78A49044D618D1D80 /* Headers */,
-				SBP_9DB756A33A199E4D91CE6E6E2A5A706C /* Sources */,
-				FBP_1BDCD6E0245ED2400E6FE9AC9C334DE4 /* Frameworks */,
-				SSBP_1B2C6BA1C514471EF42FB7E03ACD8C83 /* MyScript */,
+				0D09E5BA6B8442DC0ABB8AA6E5E95A01 /* Headers */,
+				40A4456A24F99A01E340C0326EA77547 /* Sources */,
+				9B861C58E640BD4AD391900CF0C4ABEC /* Frameworks */,
+				43E9CD3CEA3FE8944C659368A6522737 /* MyScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_79BA73EB5832255541811162BB2B0218 /* PBXTargetDependency */,
+				9D55DD4ABD2763AEF9DB5CC7E5B896FF /* PBXTargetDependency */,
 			);
-			name = Framework_tvOS;
-			productName = Framework_tvOS;
-			productReference = FR_D5FDE9E6362055E854CE1D3980716A4C /* Framework.framework */;
+			name = Framework_iOS;
+			productName = Framework_iOS;
+			productReference = 8A9274BE42A03DC5DA1FAD04992ED6E3 /* Framework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		CE7D183D3752B5B35D2D8E6DC832BED5 /* Framework2_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A0EF0B71AD44055E8749C42210FBBE8 /* Build configuration list for PBXNativeTarget "Framework2_iOS" */;
+			buildPhases = (
+				2D9AE1B5509A67E70270EF742601DD26 /* Headers */,
+				A000A0FFF2503ADC8D74D2DF7746ED92 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Framework2_iOS;
+			productName = Framework2_iOS;
+			productReference = 3EF21DF245F66BEF5446AAEF769A4194 /* Framework2.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DC2F16BAA6E13B44AB62F8887D4CE3FA /* App_iOS_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F888428CB91ACDDAAE8C8F217D586ACD /* Build configuration list for PBXNativeTarget "App_iOS_Tests" */;
+			buildPhases = (
+				9719917A0F173B1BCC95FBA19161B2CB /* Sources */,
+				A8688B5E0D1C2F35AD20BB852C7EEF98 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CC46E93CF9B822363AF3CF4D517E8C9F /* PBXTargetDependency */,
+			);
+			name = App_iOS_Tests;
+			productName = App_iOS_Tests;
+			productReference = CB77A637470A3CDA2BDDBE9948AB9716 /* App_iOS_Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		E7815F2F0D9CDECF9185AAF3A6B474C1 /* XPC Service */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D379D1BBEF24ED05EB6ADEB3E5322641 /* Build configuration list for PBXNativeTarget "XPC Service" */;
+			buildPhases = (
+				20C333B691034362EAF1EE82DDAF85DA /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "XPC Service";
+			productName = "XPC Service";
+			productReference = 22237B8EBD9E6BE8EBC8735F5AA17192 /* XPC Service.xpc */;
+			productType = "com.apple.product-type.xpc-service";
+		};
+		F674B2CFC4738EEC49BAD0DA9A22DB35 /* App_iOS_UITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 68CC35789B0DB020E2CFC517D39151D2 /* Build configuration list for PBXNativeTarget "App_iOS_UITests" */;
+			buildPhases = (
+				7334BD12862A3CED4BE1C6B5DC1452C8 /* Sources */,
+				08DA9F1F0ED13AC054003B27D5F7A95E /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				43E4E88E4E294E1AFF021081A774739F /* PBXTargetDependency */,
+			);
+			name = App_iOS_UITests;
+			productName = App_iOS_UITests;
+			productReference = 13EEAB58665D79C15184D9D0DEE29087 /* App_iOS_UITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		FC26AF2506D3B2B40DE8A5F887952CE1 /* Framework2_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 02E5A42C8065AF7CCB48FACEF125FAB6 /* Build configuration list for PBXNativeTarget "Framework2_macOS" */;
+			buildPhases = (
+				5A0FEF527F632170E10430F59E1E0650 /* Headers */,
+				54CB4F4E5136170EA8B9AFA52473DA67 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Framework2_macOS;
+			productName = Framework2_macOS;
+			productReference = 2233774B86539B1574D206B07A805A8F /* Framework2.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */ = {
+		0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1000;
 				TargetAttributes = {
-					AT_D40C01B2BAD29EDEA392714DFB69FE8F = {
+					020A320BB3736FCDE6CC4E703EE69AC0 = {
+						ProvisioningStyle = Automatic;
+					};
+					0867B0DACEF28C11442DE8F70C48D1AC = {
+						ProvisioningStyle = Automatic;
+					};
+					BF3693DCA6182D7AEC410AFC08078F33 = {
 						CUSTOM = value;
 					};
-					NT_193BAF154270D1C21E269EDF2A1BD3F6 = {
-						TestTargetID = NT_BEB0891E36797FE2214A0A9D516D408D;
+					DC2F16BAA6E13B44AB62F8887D4CE3FA = {
+						TestTargetID = 0867B0DACEF28C11442DE8F70C48D1AC;
 					};
-					NT_B91A6EACD6F5192FECA2E95FD531D0CA = {
-						ProvisioningStyle = Automatic;
-					};
-					NT_BEB0891E36797FE2214A0A9D516D408D = {
-						ProvisioningStyle = Automatic;
-					};
-					NT_D4BAEEEC88124103C8DFF41FCE206DCE = {
-						TestTargetID = NT_BEB0891E36797FE2214A0A9D516D408D;
+					F674B2CFC4738EEC49BAD0DA9A22DB35 = {
+						TestTargetID = 0867B0DACEF28C11442DE8F70C48D1AC;
 					};
 				};
 			};
-			buildConfigurationList = CL_85167C2DED9F1F2F7D5162C1DD252426 /* Build configuration list for PBXProject "Project" */;
+			buildConfigurationList = D91E14E36EC0B415578456F264E0161E /* Build configuration list for PBXProject "Project" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -1384,159 +1384,103 @@
 				Base,
 				en,
 			);
-			mainGroup = G_CBE9DB02095FA0DF8A7ECE76A4BD81A4;
+			mainGroup = 293D0FF827366B513839236A28819597;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				NT_BEB0891E36797FE2214A0A9D516D408D /* App_iOS */,
-				NT_193BAF154270D1C21E269EDF2A1BD3F6 /* App_iOS_Tests */,
-				NT_D4BAEEEC88124103C8DFF41FCE206DCE /* App_iOS_UITests */,
-				NT_B91A6EACD6F5192FECA2E95FD531D0CA /* App_macOS */,
-				NT_38A9FE87056942A2746E0FF025B52A91 /* App_watchOS */,
-				NT_5245AB6D3B3CFBC95AEBADF6E0C593B8 /* App_watchOS Extension */,
-				NT_9F72C903B42E1AA3B88F97B917231B15 /* Framework2_iOS */,
-				NT_87DF09E78830E7EB3C00B6134A2D5A5D /* Framework2_macOS */,
-				NT_66B6A18138FD1FB5ECF3FC67B20FF3D3 /* Framework2_tvOS */,
-				NT_A3933B4002C44B46F34B238F654D1362 /* Framework2_watchOS */,
-				NT_7D108AE86BED8C9CCF52C2646FA4C5DE /* Framework_iOS */,
-				NT_9D53AF351F8DAE25354F2391248DFCCA /* Framework_macOS */,
-				NT_FA652FEB38562C3A5C93D5EC7ED09776 /* Framework_tvOS */,
-				NT_6A7B08EB167FD3A759C339FDBED7E019 /* Framework_watchOS */,
-				LT_5A51AFB390A610885D62F601DE321E4E /* Legacy */,
-				NT_6AEE12F93D449E249F5348BBF35D3053 /* StaticLibrary_ObjC_iOS */,
-				NT_15609BCEEB00CBCC4C42110EB0366A6F /* StaticLibrary_ObjC_macOS */,
-				NT_D4C3E345E90AF9F6CBE8CF226FCFBCD6 /* StaticLibrary_ObjC_tvOS */,
-				NT_34A020E43FBBD797051205235CD82B70 /* StaticLibrary_ObjC_watchOS */,
-				NT_2940463C85DCD0660288786BC66F2C4C /* StaticLibrary_Swift */,
-				AT_D40C01B2BAD29EDEA392714DFB69FE8F /* SuperTarget */,
-				NT_23509FD082D1F788E6D6431F509B11AF /* XPC Service */,
-				NT_6BD068FAAC6AA35C090C48147B94EC6E /* iMessageApp */,
-				NT_6A4FC6EE80FB2821AB96D51C3BC8966E /* iMessageExtension */,
+				0867B0DACEF28C11442DE8F70C48D1AC /* App_iOS */,
+				DC2F16BAA6E13B44AB62F8887D4CE3FA /* App_iOS_Tests */,
+				F674B2CFC4738EEC49BAD0DA9A22DB35 /* App_iOS_UITests */,
+				020A320BB3736FCDE6CC4E703EE69AC0 /* App_macOS */,
+				208179651927D1138D19B5AD54E29D2B /* App_watchOS */,
+				307AE3FA155FFD09B74AE351B15321B6 /* App_watchOS Extension */,
+				CE7D183D3752B5B35D2D8E6DC832BED5 /* Framework2_iOS */,
+				FC26AF2506D3B2B40DE8A5F887952CE1 /* Framework2_macOS */,
+				8B9A14DC280CCE013CC8644093599CB1 /* Framework2_tvOS */,
+				6ED01BC471A8C3642258E1787026EDED /* Framework2_watchOS */,
+				AE3F93DB94E7208F2F1D9A78B91C1BC8 /* Framework_iOS */,
+				53A3B531E3947D8A8722745EA59EBB5B /* Framework_macOS */,
+				536ACF18E4603B59207D43CE68E02CBF /* Framework_tvOS */,
+				71B5187E710718C1A205D4DCD90D6962 /* Framework_watchOS */,
+				72C923899DE05F128187216043D8D89C /* Legacy */,
+				13E8C5AB873CEE21E18E552F5E94B768 /* StaticLibrary_ObjC_iOS */,
+				578C80E461E675508CED5DC3F45C99C7 /* StaticLibrary_ObjC_macOS */,
+				93542A75A613F00FDB5C9C63B5101409 /* StaticLibrary_ObjC_tvOS */,
+				7D3D92034F4F203C140574F08DF5F38F /* StaticLibrary_ObjC_watchOS */,
+				19BFB84599B0AA1275A9662DCB5C0E50 /* StaticLibrary_Swift */,
+				BF3693DCA6182D7AEC410AFC08078F33 /* SuperTarget */,
+				E7815F2F0D9CDECF9185AAF3A6B474C1 /* XPC Service */,
+				834F55973F05AC8A18144DB04FF6F2C7 /* iMessageApp */,
+				1C26A6A0BC446191F311D470FDFF54F8 /* iMessageExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		RBP_1BFB64F249645ABF48C3CCDF8D5FA094 /* Resources */ = {
+		1C008C34DA06FEE7841B0AC3AF1BB584 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_FA5F3C87A2571E0F39637D118B6C6F8F /* Assets.xcassets in Resources */,
+				21B9D91DC3573A47C3298339795D0D2A /* Assets.xcassets in Resources */,
+				7C9152ACD50B4F96C205B0DDEFD7D6D3 /* MainInterface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_5623703FDC4F6DF4679D8BAF27518F2F /* Resources */ = {
+		4A6E8F3A477AA5F67A8EB733DFAD8387 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_ABA4EA32A6DB022806126D9C1418BBA3 /* Assets.xcassets in Resources */,
-				BF_19C973A29D9994B1E0655B1AFC5528AD /* Interface.storyboard in Resources */,
+				F08C4D2A18A75CC292F45F1FB8E06CDE /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_85DF5DDC76E0E2A78CAFC9A3EC508232 /* Resources */ = {
+		61001E265009194959C2CF36DD7B04E5 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_EBC45940911A4942BA04AE1285BF3802 /* Assets.xcassets in Resources */,
-				BF_B57F9691AD12CA8AE5528A2BAB9E4A43 /* LaunchScreen.storyboard in Resources */,
-				BF_AC2CE59D56846478FDFBB376FF9F9DC0 /* Localizable.strings in Resources */,
-				BF_65835F9276FF0DB8E27D098367F9D03C /* Localizable.stringsdict in Resources */,
-				BF_47FBEFEA08B9642C1F711EDA77FC8C89 /* LocalizedStoryboard.storyboard in Resources */,
-				BF_47A75C8A7EF15658238E254C846C5C6B /* Main.storyboard in Resources */,
-				BF_A8A5905BCA8872B2D7B0EF6326B33077 /* MyBundle.bundle in Resources */,
-				BF_149B8FD8F114C531F675E01FBE814609 /* ResourceFolder in Resources */,
-				BF_E2D02DDEDD7DC21831F50A6EAA71E528 /* StandaloneAssets.xcassets in Resources */,
-				BF_F3D57DA3E1F8A539BDD72E02A8C23FC6 /* iMessageApp.app in Resources */,
+				BBB8CB2B1E70458EF477A9084959FEF5 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_9291220ECDCB98B69BB31C3E875042EC /* Resources */ = {
+		77D35586228BF8AB74152BB5141C7720 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_9D9B97D239384F4CE6E73852E027B787 /* Assets.xcassets in Resources */,
+				C95B9FB572B661497D2EC9BD728667A8 /* Assets.xcassets in Resources */,
+				44D5928E07962D68D84D775AF3F59D81 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_A5B7C086E8F07F5FEE9B99375E375819 /* Resources */ = {
+		8508BA1B733839E314AF2853B15D233B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_D6588CD7B83034816FFD3A7DB10DAD78 /* Assets.xcassets in Resources */,
-				BF_EA0063B4FC2A0980A746D35A8DF71CED /* MainInterface.storyboard in Resources */,
+				862C296BFE176C091397763A66610C41 /* Assets.xcassets in Resources */,
+				1E105E72C258FF9843B21D8A3F520CFB /* LaunchScreen.storyboard in Resources */,
+				D8C50B10DC463A32C288C1A88FDCECC2 /* Localizable.strings in Resources */,
+				6CD98D352BB52EB22E352454E74CA42C /* Localizable.stringsdict in Resources */,
+				53E84BFC6E79B3CFDF2EDB28E2E6F7D2 /* LocalizedStoryboard.storyboard in Resources */,
+				87C8C972BF12378AD6D85C79760FB151 /* Main.storyboard in Resources */,
+				CBAC0459E3DCD72B512329E604C46B2E /* MyBundle.bundle in Resources */,
+				8493DEA48BF40EFFAC6FBD459C0E9EE4 /* ResourceFolder in Resources */,
+				36F2B8CC97BD885A59E4FBA6EBC8EB22 /* StandaloneAssets.xcassets in Resources */,
+				EF285B90A968453FA1CB0CDE8C0AD440 /* iMessageApp.app in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_BA57258FD71062047F5503B4B160FE15 /* Resources */ = {
+		B7B71FA7D279029BF7A7FC7C08E41BB0 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_51D370314B5DA8E002A908021E459F50 /* Assets.xcassets in Resources */,
-				BF_52C8E2C5962601534CE6F00B88FDB048 /* Main.storyboard in Resources */,
+				0D281787B630CE62E91F9F7219EFF40D /* Assets.xcassets in Resources */,
+				A4A2DCF0818C891E44C2BA675B91B5CF /* Interface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		SSBP_062CBBF024005F57EECA660F9C7B0C7D /* Strip Unused Architectures from Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Strip Unused Architectures from Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-			shellPath = /bin/sh;
-			shellScript = "################################################################################\n#\n# Copyright 2015 Realm Inc.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n################################################################################\n\n# This script strips all non-valid architectures from dynamic libraries in\n# the application's `Frameworks` directory.\n#\n# The following environment variables are required:\n#\n# BUILT_PRODUCTS_DIR\n# FRAMEWORKS_FOLDER_PATH\n# VALID_ARCHS\n# EXPANDED_CODE_SIGN_IDENTITY\n\n\n# Signs a framework with the provided identity\ncode_sign() {\n  # Use the current code_sign_identitiy\n  echo \"Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}\"\n  echo \"/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements $1\"\n  /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \"$1\"\n}\n\n# Set working directory to product’s embedded frameworks\ncd \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\n\nif [ \"$ACTION\" = \"install\" ]; then\n  echo \"Copy .bcsymbolmap files to .xcarchive\"\n  find . -name '*.bcsymbolmap' -type f -exec mv {} \"${CONFIGURATION_BUILD_DIR}\" \\;\nelse\n  # Delete *.bcsymbolmap files from framework bundle unless archiving\n  find . -name '*.bcsymbolmap' -type f -exec rm -rf \"{}\" +\\;\nfi\n\necho \"Stripping frameworks\"\n\nfor file in $(find . -type f -perm +111); do\n  # Skip non-dynamic libraries\n  if ! [[ \"$(file \"$file\")\" == *\"dynamically linked shared library\"* ]]; then\n    continue\n  fi\n  # Get architectures for current file\n  archs=\"$(lipo -info \"${file}\" | rev | cut -d ':' -f1 | rev)\"\n  stripped=\"\"\n  for arch in $archs; do\n    if ! [[ \"${VALID_ARCHS}\" == *\"$arch\"* ]]; then\n      # Strip non-valid architectures in-place\n      lipo -remove \"$arch\" -output \"$file\" \"$file\" || exit 1\n      stripped=\"$stripped $arch\"\n    fi\n  done\n  if [[ \"$stripped\" != \"\" ]]; then\n    echo \"Stripped $file of architectures:$stripped\"\n    if [ \"${CODE_SIGNING_REQUIRED}\" == \"YES\" ]; then\n      code_sign \"${file}\"\n    fi\n  fi\ndone\n";
-		};
-		SSBP_13B42B84708A6ABC082BE00176F5DCB2 /* MyScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = MyScript;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script\"\n";
-		};
-		SSBP_1B2C6BA1C514471EF42FB7E03ACD8C83 /* MyScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = MyScript;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script\"\n";
-		};
-		SSBP_376C0662E4E8416C049A50660864798B /* MyScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = MyScript;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script!\"\n";
-		};
-		SSBP_4A83147402B05D3C84D21F0487315914 /* Copy Swift Objective-C Interface Header */ = {
+		194EE782F10A8F7ABD1A4AEB7C7FE978 /* Copy Swift Objective-C Interface Header */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1552,7 +1496,7 @@
 			shellPath = /bin/sh;
 			shellScript = "ditto \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 		};
-		SSBP_7F147E7ED45BAAE2186975B7FF9EB08A /* Carthage */ = {
+		261B4BE58AA60B68A81874E3318793F3 /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1568,7 +1512,7 @@
 			shellPath = /bin/sh;
 			shellScript = "carthage copy-frameworks\n";
 		};
-		SSBP_7F8DED07519BA4B70C40A9A755844874 /* Carthage */ = {
+		37182EC208DBF03DB1BAF452E1D2C836 /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1584,7 +1528,91 @@
 			shellPath = /bin/sh;
 			shellScript = "carthage copy-frameworks\n";
 		};
-		SSBP_831D7D5A30B0F736E1E92F7B5CF9428F /* MyScript */ = {
+		3D0637F4554EAD6FA48105BF0609954D /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script\"\n";
+		};
+		43E9CD3CEA3FE8944C659368A6522737 /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script\"\n";
+		};
+		71A4CC6ECC8522178F566E7B3209B4DB /* Strip Unused Architectures from Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Strip Unused Architectures from Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "################################################################################\n#\n# Copyright 2015 Realm Inc.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n################################################################################\n\n# This script strips all non-valid architectures from dynamic libraries in\n# the application's `Frameworks` directory.\n#\n# The following environment variables are required:\n#\n# BUILT_PRODUCTS_DIR\n# FRAMEWORKS_FOLDER_PATH\n# VALID_ARCHS\n# EXPANDED_CODE_SIGN_IDENTITY\n\n\n# Signs a framework with the provided identity\ncode_sign() {\n  # Use the current code_sign_identitiy\n  echo \"Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}\"\n  echo \"/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements $1\"\n  /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \"$1\"\n}\n\n# Set working directory to product’s embedded frameworks\ncd \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\n\nif [ \"$ACTION\" = \"install\" ]; then\n  echo \"Copy .bcsymbolmap files to .xcarchive\"\n  find . -name '*.bcsymbolmap' -type f -exec mv {} \"${CONFIGURATION_BUILD_DIR}\" \\;\nelse\n  # Delete *.bcsymbolmap files from framework bundle unless archiving\n  find . -name '*.bcsymbolmap' -type f -exec rm -rf \"{}\" +\\;\nfi\n\necho \"Stripping frameworks\"\n\nfor file in $(find . -type f -perm +111); do\n  # Skip non-dynamic libraries\n  if ! [[ \"$(file \"$file\")\" == *\"dynamically linked shared library\"* ]]; then\n    continue\n  fi\n  # Get architectures for current file\n  archs=\"$(lipo -info \"${file}\" | rev | cut -d ':' -f1 | rev)\"\n  stripped=\"\"\n  for arch in $archs; do\n    if ! [[ \"${VALID_ARCHS}\" == *\"$arch\"* ]]; then\n      # Strip non-valid architectures in-place\n      lipo -remove \"$arch\" -output \"$file\" \"$file\" || exit 1\n      stripped=\"$stripped $arch\"\n    fi\n  done\n  if [[ \"$stripped\" != \"\" ]]; then\n    echo \"Stripped $file of architectures:$stripped\"\n    if [ \"${CODE_SIGNING_REQUIRED}\" == \"YES\" ]; then\n      code_sign \"${file}\"\n    fi\n  fi\ndone\n";
+		};
+		85D42C01B0821B87A49F32BD523EAE58 /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script\"\n";
+		};
+		BA454AAC926EDFCDA9226CBCACCBEDB1 /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script\"\n";
+		};
+		CBE633966E8F3819F15270A367192198 /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script!\"\n";
+		};
+		CF3AABFD4A48983B322677DAACDF6B95 /* MyScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1598,411 +1626,404 @@
 			shellPath = /bin/sh;
 			shellScript = "echo \"do the thing\"";
 		};
-		SSBP_B07F447D73408EA48C54A8E7F5B8D575 /* MyScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = MyScript;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script\"\n";
-		};
-		SSBP_C8F56E533BE956498E644805330168EB /* MyScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = MyScript;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "echo \"You ran a script\"\n";
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		SBP_0CB30551A2D40126958D8D6DAF6922E2 /* Sources */ = {
+		077D11E42A8E90CAB8A95DF21687CF45 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_E6B3BA0A3A687598FB5CCDF0524E1B10 /* FrameworkFile.swift in Sources */,
+				C511BD950B937DB0F2FC5DDD0ED96D20 /* FrameworkFile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_110D7B4160D965B7964619BF78E01DE2 /* Sources */ = {
+		20C333B691034362EAF1EE82DDAF85DA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_76825DD9B3B10103CDAB9D235BDF6A91 /* MessagesViewController.swift in Sources */,
+				7EC05429C10D0A00A8AE38CADF3F5DCA /* XPC_Service.m in Sources */,
+				CF187FEB832DA1662FCB636FCC9C7926 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_20DDAC7BCD11ECA8B08695FE5D7314A9 /* Sources */ = {
+		21327378A4B2AF2B952D6DF1BDAAF25E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4E1D7AEB1B385E219995CB9C703F4DAC /* FrameworkFile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_3848ADAF2343866973E57344A1054BE3 /* Sources */ = {
+		247A4E3947EC2AFB733A1B00BCEF9EC2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_1EC32E6544284999188A140FB5FC6E67 /* TestProjectUITests.swift in Sources */,
+				6544AAAD64A06DA3D891642A337C1730 /* StaticLibrary_ObjC.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_3DD17ED231CE07543581040F32049525 /* Sources */ = {
+		40A4456A24F99A01E340C0326EA77547 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_DBF3047DCE71CB2E7B9AC7367F44F8DB /* StaticLibrary.swift in Sources */,
+				BAC0E24AC446937ADEE256F08C17D0EC /* FrameworkFile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_48868408A19D9BBE4A58CA4FAE00C0D4 /* Sources */ = {
+		54CB4F4E5136170EA8B9AFA52473DA67 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_5C6407EDAC3D88B020BCB46724DC1D14 /* FrameworkFile.swift in Sources */,
+				E011E6F68007B6479AF63E8E7433C0C4 /* FrameworkFile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_49F3C650EA105D1EF50817673A8DB33A /* Sources */ = {
+		5B3245836D7FA67E79EA1731372F18C9 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_A29F8B04C9DD9ADE1EF5AFDAAA0130D2 /* ExtensionDelegate.swift in Sources */,
-				BF_5336CD16DBDB1654D75AA91B922DEAD6 /* InterfaceController.swift in Sources */,
-				BF_CD062A97959629BD672893FDAE89A1E9 /* NotificationController.swift in Sources */,
+				03F389DFD30F3CE5A441925C10CAED46 /* MessagesViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_52AE5DCFB4487297D6889C7F014AD281 /* Sources */ = {
+		6D2FCEFCAFB24526BD458A2D8EEC24F0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_77C9BB7BED4F5970D02E69312259FE09 /* StaticLibrary_ObjC.m in Sources */,
+				74E74F67565A0084FFA3E17C735B09EF /* StaticLibrary_ObjC.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_645418A0FA6E3F5727685DE191C6B793 /* Sources */ = {
+		6F573D15DE1F149EF128C492B6C7AE6D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_D0676C98017B6FDD96A733CB851645DE /* StaticLibrary_ObjC.m in Sources */,
+				9CB4F00B54E46A4F9E477ABBD94C4C25 /* AppDelegate.swift in Sources */,
+				D7BFCCEFB53658505D03C6A9A5F0A0FA /* Model.xcdatamodeld in Sources */,
+				36152E299B36BCA0F25AD1FC9B002835 /* MoreUnder.swift in Sources */,
+				74D29BA5C4116670E4585FA413AF8460 /* Standalone.swift in Sources */,
+				13C624ABA05AC67129468002144005A9 /* ViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_669CBAFD2D7234A2BEDCEAA4949ED575 /* Sources */ = {
+		7334BD12862A3CED4BE1C6B5DC1452C8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_FA28229372AB6236883309181258AF26 /* XPC_Service.m in Sources */,
-				BF_FD13F69A90FB1D5676B97A8C77D710B4 /* main.m in Sources */,
+				AF083D3FCE667FF0E55C291CB9B99328 /* TestProjectUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_70B2F11AAC526FDB99D68212C2C92CE6 /* Sources */ = {
+		8FD76C583F8C166F974F4BE25C1A8058 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_B2B4B15D6F7B242DBDA39939111282F9 /* TestProjectTests.swift in Sources */,
+				5BEF6520D576C03A372B55F47E0C9DBB /* FrameworkFile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_77EF8BC7FC3D693C9C0C1CB51984F3E2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_021628792D80050372F6E56A6C3D0561 /* AppDelegate.swift in Sources */,
-				BF_9A74AED05E2F61530BFA0F7D23AF0112 /* Model.xcdatamodeld in Sources */,
-				BF_FF7EBDFA4462D2983743C84CE99D9714 /* MoreUnder.swift in Sources */,
-				BF_47FF83A37355E90F93C0F5B2CFBCE317 /* Standalone.swift in Sources */,
-				BF_F12E44D8E7F617E8A5FD8E1A342E5FAD /* ViewController.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_7EE428F1F0444ACB29B3C5259C04FF6D /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_81711FB79375EB743254B809B4E246E0 /* AppDelegate.swift in Sources */,
-				BF_F7AC9F45ED37FCD5A749FD6F5F4518AF /* Standalone.swift in Sources */,
-				BF_98DEE7FD578AA439550E0023A2ECE8D0 /* ViewController.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_84E9A8BE77910B67B3F2DCD5916DC498 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_3080067722B357BFC053D89CCDBF5397 /* FrameworkFile.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_8990272D7DD45CFBDAB18690861BD4E8 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_8610CB66872BC72C1690EBD8D102FBC0 /* FrameworkFile.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_924258C7A9F27B13508604CAF625E0D3 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_E228A4D3997297780216722D71AC9FE5 /* StaticLibrary_ObjC.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_9DB756A33A199E4D91CE6E6E2A5A706C /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_729EB1C88A5E43B2342099D81B301F4D /* FrameworkFile.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_C18D008976BE0EFD3D3A3C68FB79D271 /* Sources */ = {
+		91C895DE8170C96A75D29426BA2BC597 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_C469AFC0C383156AF5C80EBBC089D9FC /* Sources */ = {
+		96BB43F4706B031DA45166E893A97CF8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_3811C1771AF5342AD8F9FEB63A3465B5 /* FrameworkFile.swift in Sources */,
+				704298EAAB9D0F8C8471EE1F149F82AC /* AppDelegate.swift in Sources */,
+				D5221D8AE288C1875C03AD3AE9DB6411 /* Standalone.swift in Sources */,
+				446723391DA2F5E9AD4CE064EF80F99A /* ViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_D6209A702C851D0CFD1CC2B225986D45 /* Sources */ = {
+		9719917A0F173B1BCC95FBA19161B2CB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_C9D24A56926211130F4E25B5D9972B58 /* StaticLibrary_ObjC.m in Sources */,
+				A3A3D2042DF93D8FBF171C1B0C8DA244 /* TestProjectTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_DB9B8E1504ED9DD92AE41067C53B5082 /* Sources */ = {
+		97C367BB898AC3F3B2DB1DD8B4BA1C29 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_D3D64E2595369BBDEF03E07543AE2779 /* FrameworkFile.swift in Sources */,
+				EEDCCB9427FA46F272DFC190FCCBE77A /* StaticLibrary.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_EA528A5DC6D79AA397B25949B07AE70F /* Sources */ = {
+		9BFB2E19F4777ACBEF89589A55057522 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_4D56F3F4D081A77C11325B96DD34D8E1 /* FrameworkFile.swift in Sources */,
+				3A9B6CE17CFDF8537B52B1AFC4668973 /* StaticLibrary_ObjC.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_ED63FCA00BD617EFF125ECDF9D24FAD8 /* Sources */ = {
+		9EC3C2991C5C1EE119E39533F752AA31 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				824FECDE01A22CDE6C288C1969A645E9 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A000A0FFF2503ADC8D74D2DF7746ED92 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A06CFF585E242ADFB8CDDBA43E73115 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AE7971E1CA54D23C264E6541EA9BAE1B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5CAADD8469B81616A79CECD7DC2F58B5 /* ExtensionDelegate.swift in Sources */,
+				3E7ABFF8EC0A3EC912899F469BF5A126 /* InterfaceController.swift in Sources */,
+				7E84045B3F49256D14A8E8C1FF19490A /* NotificationController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AF7B22EF5863A5280B53589627536629 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D067D70CFD13DFBED478C2287D172491 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1F422E9C4DD531AA88418C9F755A5D2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8670A20B54D6E96461DD53EBCB0644EC /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA88FE285DA490166635BE98068E01D9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3C96F8384CC8C6401A0EE14727C5D323 /* StaticLibrary_ObjC.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		TD_0C5CE0308CB64DB986A853307CCF8A95 /* PBXTargetDependency */ = {
+		0BF8700E8CCE91434585CBA7E7C7736A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_38A9FE87056942A2746E0FF025B52A91 /* App_watchOS */;
-			targetProxy = CIP_6D60DD975DE7829AEA72BD4098DE13E6 /* PBXContainerItemProxy */;
+			target = 307AE3FA155FFD09B74AE351B15321B6 /* App_watchOS Extension */;
+			targetProxy = F2E7F07F956B38B4B4FE8C62A4F22580 /* PBXContainerItemProxy */;
 		};
-		TD_117F878FC368C83443CEC1707531F7F2 /* PBXTargetDependency */ = {
+		16C98D48AA905F0ACDB2677E8E10558D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_6AEE12F93D449E249F5348BBF35D3053 /* StaticLibrary_ObjC_iOS */;
-			targetProxy = CIP_1F8C8F9FAC75236BB2F60C3BCAE41C55 /* PBXContainerItemProxy */;
+			target = 0867B0DACEF28C11442DE8F70C48D1AC /* App_iOS */;
+			targetProxy = 886557AFA819F7C3EC08283AF902D647 /* PBXContainerItemProxy */;
 		};
-		TD_205ABD699FA8E05C47D73E8EB2D0F9EF /* PBXTargetDependency */ = {
+		1859F1314EC7027A8131D085A5E21FA3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_34A020E43FBBD797051205235CD82B70 /* StaticLibrary_ObjC_watchOS */;
-			targetProxy = CIP_47399FDE0885501C87782313489C95A3 /* PBXContainerItemProxy */;
+			target = 53A3B531E3947D8A8722745EA59EBB5B /* Framework_macOS */;
+			targetProxy = 25DA50745F9940A4FAB501F710F7886E /* PBXContainerItemProxy */;
 		};
-		TD_266243C3BBC1C83485E1B43C0FFC3626 /* PBXTargetDependency */ = {
+		197C9E15A390E6E7876A7A69E0CAC789 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_6AEE12F93D449E249F5348BBF35D3053 /* StaticLibrary_ObjC_iOS */;
-			targetProxy = CIP_1AEF07B9F6A9BC9605E82F26AE7BFE15 /* PBXContainerItemProxy */;
+			target = 93542A75A613F00FDB5C9C63B5101409 /* StaticLibrary_ObjC_tvOS */;
+			targetProxy = D8E7CFCA90E697A5E3D856E17A865EDC /* PBXContainerItemProxy */;
 		};
-		TD_2A43F973A3E1CF675A967054BA52074B /* PBXTargetDependency */ = {
+		2FD6450C81585E718B2EBC4465662938 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_5245AB6D3B3CFBC95AEBADF6E0C593B8 /* App_watchOS Extension */;
-			targetProxy = CIP_5F2FD3F0AED59431B4F98D7238CAA733 /* PBXContainerItemProxy */;
+			target = 208179651927D1138D19B5AD54E29D2B /* App_watchOS */;
+			targetProxy = FED461798C856A866AC3B22F8F40B6E4 /* PBXContainerItemProxy */;
 		};
-		TD_35F382102AABCCCEFADCBC201E5B1CE1 /* PBXTargetDependency */ = {
+		43E4E88E4E294E1AFF021081A774739F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_15609BCEEB00CBCC4C42110EB0366A6F /* StaticLibrary_ObjC_macOS */;
-			targetProxy = CIP_64ED071F49DC88F8192387D7A18827F1 /* PBXContainerItemProxy */;
+			target = 0867B0DACEF28C11442DE8F70C48D1AC /* App_iOS */;
+			targetProxy = 763FB8D4F0CDA2971921394807FE4623 /* PBXContainerItemProxy */;
 		};
-		TD_4013C738E59E1CA40B4A982AF74E8604 /* PBXTargetDependency */ = {
+		47BF97F766B01CDB0B24B7CF7606B727 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_7D108AE86BED8C9CCF52C2646FA4C5DE /* Framework_iOS */;
-			targetProxy = CIP_DC690C90FF2F615A1EB93D9803F8D905 /* PBXContainerItemProxy */;
+			target = 1C26A6A0BC446191F311D470FDFF54F8 /* iMessageExtension */;
+			targetProxy = 14A6C07F14B40638A00E0CF40992D84F /* PBXContainerItemProxy */;
 		};
-		TD_402541000CCC58970431E41C3D928AB8 /* PBXTargetDependency */ = {
+		520DAD99269660E2D0313AB847BF1100 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_BEB0891E36797FE2214A0A9D516D408D /* App_iOS */;
-			targetProxy = CIP_73A78E804E93B79E9ED934358CDD7D9D /* PBXContainerItemProxy */;
+			target = 7D3D92034F4F203C140574F08DF5F38F /* StaticLibrary_ObjC_watchOS */;
+			targetProxy = FB1C6EFD8B6003738E55DF998093397E /* PBXContainerItemProxy */;
 		};
-		TD_743D7CD7BB700A16A02A7A4A1E02D845 /* PBXTargetDependency */ = {
+		61C16530841EB21C795E8F6AFFE507AB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_6BD068FAAC6AA35C090C48147B94EC6E /* iMessageApp */;
-			targetProxy = CIP_5E9F76628F77E820EB9AA60A282D8691 /* PBXContainerItemProxy */;
+			target = 578C80E461E675508CED5DC3F45C99C7 /* StaticLibrary_ObjC_macOS */;
+			targetProxy = DB55C4664A117055BA46376BD622A680 /* PBXContainerItemProxy */;
 		};
-		TD_79BA73EB5832255541811162BB2B0218 /* PBXTargetDependency */ = {
+		64C42059624EE2C92C0FE59914B7FDBF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_D4C3E345E90AF9F6CBE8CF226FCFBCD6 /* StaticLibrary_ObjC_tvOS */;
-			targetProxy = CIP_1C3D8F2BF099A773651CF8A195466469 /* PBXContainerItemProxy */;
+			target = 834F55973F05AC8A18144DB04FF6F2C7 /* iMessageApp */;
+			targetProxy = CEA3F70DEEC34DCA66DB1E0EFA84942B /* PBXContainerItemProxy */;
 		};
-		TD_846DB03B9778D6C8E81FE52A5A212420 /* PBXTargetDependency */ = {
+		9C162664CD744CFC1AA23F81C4BE5566 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_6A4FC6EE80FB2821AB96D51C3BC8966E /* iMessageExtension */;
-			targetProxy = CIP_B5B71FB9D5064D7E05E9E44827A87775 /* PBXContainerItemProxy */;
+			target = AE3F93DB94E7208F2F1D9A78B91C1BC8 /* Framework_iOS */;
+			targetProxy = D2ADEBFCC2EBFB67A6A763400BA65C92 /* PBXContainerItemProxy */;
 		};
-		TD_94E481CDF62CDA1E9B37D1DA08E5A5AF /* PBXTargetDependency */ = {
+		9D55DD4ABD2763AEF9DB5CC7E5B896FF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_9F72C903B42E1AA3B88F97B917231B15 /* Framework2_iOS */;
-			targetProxy = CIP_862C50E687ABB75CCDF71F1157709A4D /* PBXContainerItemProxy */;
+			target = 13E8C5AB873CEE21E18E552F5E94B768 /* StaticLibrary_ObjC_iOS */;
+			targetProxy = 22F895524FF6719804A47F116C4BA59B /* PBXContainerItemProxy */;
 		};
-		TD_98EB63C93477EA15558367FBAB5797CE /* PBXTargetDependency */ = {
+		B7430AD5B07F6CC89ECAA2385B5F87BC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_BEB0891E36797FE2214A0A9D516D408D /* App_iOS */;
-			targetProxy = CIP_291A38592460740F400A80DE5DBA9679 /* PBXContainerItemProxy */;
+			target = CE7D183D3752B5B35D2D8E6DC832BED5 /* Framework2_iOS */;
+			targetProxy = A4C9F7E41E936ED3DB506ED144393C22 /* PBXContainerItemProxy */;
 		};
-		TD_B8AB4064784522A5F3760CB1372D1BCD /* PBXTargetDependency */ = {
+		BDD1939286F86804687733B99027F2DE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_BEB0891E36797FE2214A0A9D516D408D /* App_iOS */;
-			targetProxy = CIP_4FA1F11884BC4F5DBDFAC1FBEC60AFC1 /* PBXContainerItemProxy */;
+			target = AE3F93DB94E7208F2F1D9A78B91C1BC8 /* Framework_iOS */;
+			targetProxy = CD04B2F75AFB4C4E0E81FD50AA666C20 /* PBXContainerItemProxy */;
 		};
-		TD_B8F32B4B3CC431FE0EC1C4E7D096E3AC /* PBXTargetDependency */ = {
+		CC46E93CF9B822363AF3CF4D517E8C9F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_9D53AF351F8DAE25354F2391248DFCCA /* Framework_macOS */;
-			targetProxy = CIP_CA46A507405C3CBD7579D2C9A3F8719E /* PBXContainerItemProxy */;
+			target = 0867B0DACEF28C11442DE8F70C48D1AC /* App_iOS */;
+			targetProxy = 6325BA6A4CFF5F72679F35D8942CA681 /* PBXContainerItemProxy */;
 		};
-		TD_BBB2D0EDFD9EF8193F1864D1F3D5F97A /* PBXTargetDependency */ = {
+		D3937F3AF2B9928532AFF9D0ECE87944 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_15609BCEEB00CBCC4C42110EB0366A6F /* StaticLibrary_ObjC_macOS */;
-			targetProxy = CIP_C82ED1EBAD4D7218ED9694EB7BF4DE74 /* PBXContainerItemProxy */;
+			target = E7815F2F0D9CDECF9185AAF3A6B474C1 /* XPC Service */;
+			targetProxy = 67F63874B91EB0AD7BFE9C2260EED1D0 /* PBXContainerItemProxy */;
 		};
-		TD_C762D8FBA80775A921AA5B50422E9349 /* PBXTargetDependency */ = {
+		D6F6D46B8C151E1522FA272A76CB6A9D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_23509FD082D1F788E6D6431F509B11AF /* XPC Service */;
-			targetProxy = CIP_BAAD03920C86C2839C3C93FDA5568ECE /* PBXContainerItemProxy */;
+			target = 578C80E461E675508CED5DC3F45C99C7 /* StaticLibrary_ObjC_macOS */;
+			targetProxy = 46CEA5545DFE17B465A6C2715FC7D92C /* PBXContainerItemProxy */;
 		};
-		TD_D056799E80FFF41247BAE692D01142F0 /* PBXTargetDependency */ = {
+		EF2602D791B586844A7828A8371070CA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_7D108AE86BED8C9CCF52C2646FA4C5DE /* Framework_iOS */;
-			targetProxy = CIP_A760C88E6F24D3F06081AEBDEB8AE54B /* PBXContainerItemProxy */;
+			target = 13E8C5AB873CEE21E18E552F5E94B768 /* StaticLibrary_ObjC_iOS */;
+			targetProxy = 73C27A037CFB6A421B7824FEDFA0C989 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		VG_06DC429EEFBBA25BC3EE1AA1B4062C10 /* MainInterface.storyboard */ = {
+		0C6BA0D12467A13EC012C728D9169681 /* LocalizedStoryboard.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
-				FR_7C8280C3C5E1D43BBB12A5F0156A8305 /* Base */,
+				B17B8D9C9B391332CD176A355AD24669 /* Base */,
+				0B193CC6D2B3003418A550B6B0D1F6AA /* en */,
 			);
-			name = MainInterface.storyboard;
+			name = LocalizedStoryboard.storyboard;
 			sourceTree = "<group>";
 		};
-		VG_14B7B5469AA17939993A2B25E775D391 /* Main.storyboard */ = {
+		65C8D6D1DDC1512D396C07B712F31188 /* Localizable.stringsdict */ = {
 			isa = PBXVariantGroup;
 			children = (
-				FR_7532DD7B78451A5040048474AC4FBCCC /* Base */,
-			);
-			name = Main.storyboard;
-			sourceTree = "<group>";
-		};
-		VG_30676EBEE9BE54AA26CAE69BE744CAE8 /* Main.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				FR_C5682A1371F91CBD1254C115F0439F12 /* Base */,
-			);
-			name = Main.storyboard;
-			sourceTree = "<group>";
-		};
-		VG_6542B94EE7DA40CD30BC54DED26C61C7 /* Interface.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				FR_2649A01C17A7301DD72EA826604ED8AA /* Base */,
-			);
-			name = Interface.storyboard;
-			sourceTree = "<group>";
-		};
-		VG_BE436BDD64E90EFB600D47AC69B49DD3 /* Localizable.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				FR_62ECE5A3D0F25415CB50A28226B91EBE /* Base */,
-				FR_11E95FCD1DEB0C8A01A053518C1DAA8E /* en */,
-			);
-			name = Localizable.strings;
-			sourceTree = "<group>";
-		};
-		VG_C247AA37E9057916EDDC65C7B55E2F38 /* Localizable.stringsdict */ = {
-			isa = PBXVariantGroup;
-			children = (
-				FR_4B58A01ABBE8E0A56B7B5A539C9BF5C7 /* Base */,
-				FR_BCEF8D29C9B93D3160D8D76DD368C8AD /* en */,
+				E42335D1200CB7B8B91E962FF77B8337 /* Base */,
+				020E4DA91C9132845CAFDC5D91A750AF /* en */,
 			);
 			name = Localizable.stringsdict;
 			sourceTree = "<group>";
 		};
-		VG_F256536BB07CF3E64C4DD934F75BED9C /* LaunchScreen.storyboard */ = {
+		74FBDFA5CB063F6001AD8ACD1776F055 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
-				FR_C73B96CEEE97DE429C638EBD9C2F3D2B /* Base */,
+				814822136AF3C64428D69DD62246E8A2 /* Base */,
 			);
-			name = LaunchScreen.storyboard;
+			name = Main.storyboard;
 			sourceTree = "<group>";
 		};
-		VG_FE6D89DA2D7E7F58340D566590FF221C /* LocalizedStoryboard.storyboard */ = {
+		814D72C2B921F60B759C2D4BB2604550 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
-				FR_A51DE87AC269BC36016F9CAC32B4ECB2 /* Base */,
-				FR_35B9B5E8A2ED60FBB9CED8AE515B16B5 /* en */,
+				5116B3B58070BCD09F1487BAFC210EE0 /* Base */,
 			);
-			name = LocalizedStoryboard.storyboard;
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		9E17D598D98065767A04740F5E729CCA /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				7C176A8297AC2F5207352BA80F60ADB0 /* Base */,
+				D6C89D80B5458D8929F5C1274C83014E /* en */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		B47B80AF9EAE0ADB4FA469CFDB7ABB8F /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				089EC08C7E2D830C5916FDD909257364 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+		C872631362DDBAFCE71E5C66EDD61432 /* Interface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				7FDC16E1938AA114B67D87A9822E86D7 /* Base */,
+			);
+			name = Interface.storyboard;
+			sourceTree = "<group>";
+		};
+		CE1F06D99242F4223D081F0DF78367F3 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				57FF8864B8EBAB5777DC12E62D66732F /* Base */,
+			);
+			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		BC_0198386D4EF48A4C053820EEEE1936CB /* Test Debug */ = {
+		00AF278082A5D7C2A655586749873CE8 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		00FD318C7418F3351FC0074451FC8AF5 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/watchOS",
 				);
-				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = "Test Debug";
 		};
-		BC_0271561C28AF4A74C6924A2187BC8487 /* Test Release */ = {
+		015D35ADD269DCBEA53B52A34A4CB440 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -2024,9 +2045,85 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
+			name = "Staging Release";
+		};
+		01BF8C6D1C21955BA7E803E8E76EAE33 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Staging Release";
+		};
+		02EB0C0230E6616EC8057F1CB1EEAD3D /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Staging Debug";
+		};
+		04172E0BDC7C512A23A51C76B325F8D0 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Staging Release";
+		};
+		058734C3B593A26E24211133F43C16EF /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
 			name = "Test Release";
 		};
-		BC_032D44BB36CD1AC13FFFAC654631D432 /* Production Debug */ = {
+		06E4383A2687EAD5877836CD308F610F /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"\"Vendor\"",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		079E494F34C3CAFB8F9E44B3D43EEB31 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -2035,33 +2132,211 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = appletvos;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
+				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Production Debug";
 		};
-		BC_057931652E9069AFF23BA573B6564BE5 /* Production Debug */ = {
+		082A10B9E5EAC6E783EAB9B05B200B33 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Production Debug";
+		};
+		0AB9030B7E8A8BBA74CCB1A946488B9A /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Test Debug";
+		};
+		0C66F8A2D0CB0D802A327EB47C62BFCF /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Test Release";
+		};
+		0CE2F7B8A955BE108A66FF68A60E7F63 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Test Release";
+		};
+		0EFE33A4C09DCF9FE1519D3703549835 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Staging Release";
+		};
+		10E250D1DC79E11058B933F905968160 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		1341099486D8FE68A99CB5FE4AB85779 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Test Debug";
+		};
+		13FF53C2B3637EA82E3DF577DD665399 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Production Debug";
 		};
-		BC_079D311B8C64F17C816583A1A4D84F42 /* Staging Release */ = {
+		1539437BBB98703535876E359712A22F /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Staging Debug";
+		};
+		15A9BF8518A5155B879C8DAFA1C396EB /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		15F79278F4ABD33584FC69E4392176FF /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		184E4078B13FE1CC6A11BD529C15AA7E /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Production Release";
+		};
+		196FEEE6C4B0DDE53AD16BD6E5645F0E /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
@@ -2080,199 +2355,20 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
 				SDKROOT = macosx;
 			};
-			name = "Staging Release";
-		};
-		BC_0B1CBABAB9579A064729249F5E1B7B84 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
 			name = "Test Debug";
 		};
-		BC_0B57E3E0E8C194293ABFEEF97F104F30 /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Release";
-		};
-		BC_0D53E4051E21792867D5FA4A11B751AB /* Production Release */ = {
+		1D61DC7F5309F4C8B7692D8522B99481 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = appletvos;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-			};
-			name = "Production Release";
-		};
-		BC_0D96F61E117D6A8D2353B0E7CB445AEA /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Release";
-		};
-		BC_0E087681CE92CC2069F9E562ECC9FD23 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				MY_SETTING = hello;
-			};
-			name = "Staging Debug";
-		};
-		BC_0E104167F96EA087A23DFBE2430D5612 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Production Debug";
-		};
-		BC_11CBEB05340DE3C8F396B359A9144039 /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = "XPC Service/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
-				SDKROOT = macosx;
-			};
-			name = "Staging Release";
-		};
-		BC_120D6C5C7E4D1D6566CBD71E11C3DF37 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Debug";
-		};
-		BC_1603C1C58A4D6AE1BD0707D13D2C8F44 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Test Release";
 		};
-		BC_161B10E65E0BE143A17EADFA5EE88B3D /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"\"Vendor\"",
-				);
-				INFOPLIST_FILE = App_iOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Debug";
-		};
-		BC_16E1FCDA9DB6E70091B54603E4E6F58B /* Test Release */ = {
+		20803EC42C26E4EA13474E5A694068D1 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
@@ -2287,16 +2383,109 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
-			name = "Test Release";
+			name = "Production Debug";
 		};
-		BC_1841B61F3F85EC24C4AACBC5C025BD08 /* Production Debug */ = {
+		236247F0F85C9D342FAEE803854E5159 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		2569D399CA3C4828EF87AD78F013FF7C /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		25E62244CD9C539F614224DFDFBFB78D /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		2630B88F53876A9AD7B61A4E3B8671F4 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Test Debug";
+		};
+		26BACA32C62C38FAB45F532D54C340EE /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				MY_SETTING = hello;
 			};
-			name = "Production Debug";
+			name = "Test Debug";
 		};
-		BC_19CBA184C0BDC24CE3657C025A8FC279 /* Staging Release */ = {
+		278E3C762E54ADDA52F9E68793ED6AFB /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = "Production Release";
+		};
+		2F1CDD64CD0684A2B09D6ED398F2640B /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -2304,68 +2493,351 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
-				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
 				TEST_TARGET_NAME = App_iOS;
 			};
-			name = "Staging Release";
+			name = "Staging Debug";
 		};
-		BC_19E3B21D0DA59BAF1B99899A35858D52 /* Test Release */ = {
+		2F88193D8069519CD36F649B2E68FD74 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				BUNDLE_ID_SUFFIX = .test;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
-				VALIDATE_PRODUCT = YES;
-				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Test Debug";
+		};
+		366C92A637FDA940E6BCB591EC2E6D5E /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		36C4B3A6EACCB88098CE13D7E597918E /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = "Test Release";
 		};
-		BC_1CF7F7BC6E19981DCBBFE6FE2D9FCB62 /* Production Release */ = {
+		3764AEC1D64BC7805DC7390019AF6C3A /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		3DEEA480EDDC83405CFB9BBA0EBCA9BF /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
+		3FFEE1ED324166B88F5F9A451E59A29C /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
+			};
+			name = "Test Release";
+		};
+		401097AC487BBA8C7B2B4938968C263A /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		4089B74CA10172B8ED2D004B8B4F5ECC /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		40A3301910021B57051D1BD5CDE2006B /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MY_SETTING = hello;
+			};
+			name = "Production Debug";
+		};
+		4621C6C8A78FBB1CF4078178688742F9 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
+			};
+			name = "Production Release";
+		};
+		4662A9062E19E6BC30C9E0A1BFA83798 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		49322BF02F4F345A1339EF7A96CF3167 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Test Debug";
+		};
+		4A0624A4FC88A7E232411C956533E4BA /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		4B389C6B6140EE7DE69A248A8047A3DA /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		4BCE080A33E3A2F26D1DBEEB6ECC1D95 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Production Release";
+		};
+		4D86BBA6893D41140152B8CCDE62CC7B /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = IMessage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		4EBCDEB4013FDB072034346710E33B2C /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Production Debug";
+		};
+		511E983641E821858100107BAD873D91 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = IMessage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		5180F6C101C0335213FB28E58799AF2A /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		522E20DF286BE38B925CC57EA276B771 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		53C3CC585BF0EAB4CA31AD3EEA8FE4D9 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		545342CFDF7810F2EBFFFC5EEE5B87A6 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
@@ -2389,7 +2861,261 @@
 			};
 			name = "Production Release";
 		};
-		BC_1D9A30F2A4E9057FD8A7101D4AA4F47D /* Test Debug */ = {
+		55DA94C85E0E63D3AD593A08A2A8DAC7 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		5675C7C51DC1B8D63CBAE30AAF4E911D /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		580039D71F71A98572051157B9CEFDCA /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		5822FCD48FCC177980F672D4783A1A0E /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		5876AA17762F3248F4FD66E1FB07A931 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = IMessage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		589D05992FDC35F6BE05695828D404AE /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		5A9C67C1F423247AE1541F63C53C88B5 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		5FAA92426D53E239CDB39102D61ADD93 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Test Debug";
+		};
+		62F50207E03F6D9813514977AFA9314E /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		64BEC335CD4016B9BC59F3C9EACDA68E /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Production Release";
+		};
+		65A21512F2B980615DF51D77519DBAE0 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		6645E6A343F71C3E91656BE99B8DC559 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
+		66DBF782276810342031776DAAEB6C6D /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		6A11812952F34525D14A410446BDD796 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -2399,9 +3125,726 @@
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
+			name = "Staging Debug";
+		};
+		6B5A31340B8CF5849805CA3D0DF48215 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Staging Debug";
+		};
+		6C201A244077B7B453E15C1AF74D2070 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = IMessage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
 			name = "Test Debug";
 		};
-		BC_209579D4C144FB697FDD46843485CC6A /* Production Debug */ = {
+		72EDF2E14A4CE916F4E2B01B5CB7984B /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		74E52B213DA9EAFA77BC05D0E0A19090 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Staging Debug";
+		};
+		77B8B41EBA5D778EB3AF89DCA0AD65E8 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		7931F229200F89B8CDC8A5E3B755C52E /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"\"Vendor\"",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		79FA19BACBA7B6C15E0399C0438D0133 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		7B2A1BE6CA654E9903A4C6802DBCE440 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+			};
+			name = "Staging Release";
+		};
+		7B4F942EA48FC1FED21AA2EE8C1F44C9 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Test Release";
+		};
+		7C473021DB2A2D88B535FBD60A5D1A0A /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		7E101F97604A0990174A46CD53FEEAF5 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Staging Release";
+		};
+		7E81F863EF51334FDDCC8A39DC90B0B7 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Production Release";
+		};
+		7F86E00770E76CA3412A03BD236C4D8E /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Staging Release";
+		};
+		817AFA080A41D783F5801C5A63BFEF87 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = "Test Debug";
+		};
+		81AE120E23F0108E77BBCE228EB54DC0 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		8269ABE82BCBF550C38494DF5C3465D0 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		862658ACA3BF7AE7FA22870C96CCF7FE /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		8C9F67C7AA56DBE79F0F2640CE7FAC51 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		92602C025633FBA848F91812F4CD6D45 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Production Debug";
+		};
+		943D402E936EC5BD391F9FD0C7D926EA /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
+			};
+			name = "Production Debug";
+		};
+		9666BFAAA42CE2DC7E368E7DEFAA6225 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		96B8ADD171694B9A9E3ABC7EFB5F4D1B /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = "Production Debug";
+		};
+		97009625463EC8B19F53007A9D102A56 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
+			};
+			name = "Staging Debug";
+		};
+		982EA5A9273899567804B40D5E98CF39 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		9A891313A139893990989BDDFA989F3A /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		9AFD84FE41E84631927FC8918C7A276F /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		9E38571B33C3CE5CA10C8452AE897DF8 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		9FCB2F3977FC0F94393F86FEC15F50E2 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		A0AA826373CDC7E0A8797430E86FA0AA /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		A2EBD902E6DE2B2BD12C4484D36B6B76 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Production Debug";
+		};
+		A59DDFBFCF18C44A993CFB00FED2841F /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		A696B22A9734326DBFD20EC8065B6ACF /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MY_SETTING = hello;
+			};
+			name = "Staging Release";
+		};
+		A79632AF4FFC93B0940CE8E3FB93B600 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MY_SETTING = hello;
+			};
+			name = "Production Release";
+		};
+		A861DE7670417FA256F4E459462B198D /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		A91B13C5688E9BCC925C702A6740B026 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		AA4F4236D960D3ACE683A8158218D2FC /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		AABC1E325EADF86C5137D659051CC749 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+			};
+			name = "Production Release";
+		};
+		AC8E8FEA35961580D23185B296BA137F /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Test Release";
+		};
+		AE37A01B34B4B956E784082C03DEB579 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"\"Vendor\"",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		AE8DA78BA7A7194BD625DD45A1AFC4BA /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		AF25BBA6E0AD56CA13A3F6C6FC1BBCF1 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		B008685BA25BB8FD771F0AE3B59FA06C /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"\"Vendor\"",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		B18D58177F363DF071A9AF955A1FE5AC /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		B24243F387A725EAFE802321255BC6F4 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Production Debug";
+		};
+		B3B2FEA08FA4ACD18FDF9BC26A6F9613 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2460,441 +3903,7 @@
 			};
 			name = "Production Debug";
 		};
-		BC_22D59B57A805B62A266F803CCDD49C26 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Release";
-		};
-		BC_24042033AF9D3DEDAD53ACAF1C2BB0B2 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Release";
-		};
-		BC_27A94FA771ABEE02868BCED0690C89E1 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Debug";
-		};
-		BC_291E5C210DD53C3B3A4C6057C2B9652A /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_iOS;
-			};
-			name = "Production Release";
-		};
-		BC_2D532F03F57D7D107FDAC3EF23DBFBFE /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Debug";
-		};
-		BC_2DB4D72679A12506C6A8B4728F130B7D /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Release";
-		};
-		BC_2F352436A75D33C6D3337012367BE90C /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
-				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Release";
-		};
-		BC_3134697E7D6C32A5C4376C581C189D6B /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Release";
-		};
-		BC_313481FFED1411A2B5969B70EBA94383 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Debug";
-		};
-		BC_3CCE54849732E01493DDDB7D86E033D4 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = App_watchOS/Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
-			};
-			name = "Staging Debug";
-		};
-		BC_3D9C1A83637AB10D5FFC5D4F8331091E /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
-				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Debug";
-		};
-		BC_42C4FEAD23C2FE1A906F4D37F43182AB /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = App_watchOS/Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
-			};
-			name = "Production Release";
-		};
-		BC_4346300D78CE0EC28B467470E8C4DB2E /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Release";
-		};
-		BC_46EDEC047C02E1E271BADF861EFB2F8D /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-			};
-			name = "Test Release";
-		};
-		BC_4AC83F754F5BB02C3019E8AE2303E966 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Production Release";
-		};
-		BC_4F7A9BAD8AB16D47ECA510689FB5F899 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = "XPC Service/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
-				SDKROOT = macosx;
-			};
-			name = "Staging Debug";
-		};
-		BC_50C3D866E3B57D83181A8F04E553F557 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				INFOPLIST_FILE = IMessage/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Debug";
-		};
-		BC_53BBB90244275C55B50604E0DC26809E /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-			};
-			name = "Staging Debug";
-		};
-		BC_541CCB32267A890B3BABCE62FFE461E2 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Release";
-		};
-		BC_54F3754420D0F7418AB42235B1D71751 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Debug";
-		};
-		BC_56B4C0BD8630088AECC29D1D7064530F /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Staging Debug";
-		};
-		BC_57D3973CA01D421550D834AFA79D2B4B /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				MY_SETTING = hello;
-			};
-			name = "Test Release";
-		};
-		BC_58D5B708B08789E2DFD4D60A906AAA6E /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Release";
-		};
-		BC_5901F7B4A1799821B3061B5EA7C4A033 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
-			};
-			name = "Production Debug";
-		};
-		BC_5951C33138E508D3E6CA672980D5F2B6 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				INFOPLIST_FILE = IMessage/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Debug";
-		};
-		BC_5996DB19FBFE69C54C671E0624798C4B /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Debug";
-		};
-		BC_5A05C344BCA2E54DFF945E68ECC21064 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Debug";
-		};
-		BC_5B12F047BB0206FED25C955314A29B18 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Release";
-		};
-		BC_5BC104FB79C437B79CC9D676B3B964D2 /* Production Release */ = {
+		B928E061A126AC8D17D81D1E4DC11629 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -2916,151 +3925,44 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = "Production Release";
-		};
-		BC_5CA18B8A4079FC28EF3A05BDC5E4D501 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
 			name = "Staging Debug";
 		};
-		BC_5CBE4F01DBB084436375039EFEDDE6E4 /* Production Debug */ = {
+		B9BEDF424FEFB1047765C3C6B718FC6A /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-			};
-			name = "Production Debug";
-		};
-		BC_5D33E2C3F29594425D03B339108871CF /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Debug";
-		};
-		BC_5D7B920759B10537602230A4B5520551 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Production Release";
 		};
-		BC_606DC3CBE672B2D9CA4B68FF6F55762D /* Production Debug */ = {
+		BBA736CF3FB466E323EA84621521053D /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Debug";
-		};
-		BC_6396C78E99C21A774B9819DC09D88BD7 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
-				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Staging Debug";
-		};
-		BC_63E4D52E21696EFA858D20EA01500612 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-			};
-			name = "Test Debug";
-		};
-		BC_656BA4FF26F3FB2ECFA5F81D7E133C94 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Debug";
-		};
-		BC_679AB0D3CA0237CCB4B711609C0CB16A /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
-				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
 			};
-			name = "Production Release";
+			name = "Test Release";
 		};
-		BC_6851DF4113AFF271AA5DD6D587181A03 /* Production Release */ = {
+		C0D5765142C68AF68B954B3F748538C2 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -3111,7 +4013,76 @@
 			};
 			name = "Production Release";
 		};
-		BC_689C05D134F6C4AB2A86666C7C2D1E8F /* Staging Release */ = {
+		C4397CDA0D458BAD55C911B0A4DC7868 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+			};
+			name = "Staging Debug";
+		};
+		C59E649CEDC0E973B28B57A4F0841506 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_ID_SUFFIX = .test;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = "Test Release";
+		};
+		C7EF8D96FA7893ADD61CF4C0432F4C36 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -3127,21 +4098,9 @@
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
 				TEST_TARGET_NAME = App_iOS;
 			};
-			name = "Staging Release";
+			name = "Production Debug";
 		};
-		BC_69E8021CB05224B9CAC27F6AFA1763CA /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-			};
-			name = "Staging Debug";
-		};
-		BC_6A4D0B334934E5E4901A4164AD2DF70A /* Staging Release */ = {
+		C96EA1AD4B3ABB8A49B98BC25E24E03A /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -3152,21 +4111,72 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
 				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
 				PRODUCT_NAME = Framework;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		CA08CB7E7DBBC99CDC7F2C2E282437DF /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		CBE9D80AD0719511A13A889E867077CC /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
 			};
 			name = "Staging Release";
 		};
-		BC_6D1ED651D660692438EF3196506DC5AD /* Test Release */ = {
+		D24E68EE5DE052219B036D6333C8A07C /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		D37EB6FE8C8C4040A394F1E9E247EC63 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MY_SETTING = hello;
+			};
+			name = "Test Release";
+		};
+		D8267FD376089FF4497ED3F13C467F10 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -3189,299 +4199,57 @@
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = "Test Release";
+			name = "Staging Release";
 		};
-		BC_6EDDF7399F4EE2E8226F9D006C31ACB1 /* Production Release */ = {
+		D9A0609EE6F341CD4E8758C1841CC3EF /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
+				PRODUCT_NAME = Framework;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Production Release";
-		};
-		BC_71D19FC08A12CCAB1A85C7A5320A451A /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = "Test Debug";
-		};
-		BC_724E9BA97FC0605F596460587FFD4C61 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Debug";
-		};
-		BC_7477F8344D6D7313C39D897C1864F1B7 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
-				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
 			name = "Test Release";
 		};
-		BC_7527094FD7492E6A964EC95E7378EF22 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
-				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Debug";
-		};
-		BC_791A2E3F88BE34E647BEE192E06BBA74 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-			};
-			name = "Test Debug";
-		};
-		BC_7A2C8B05671807E16D816BD7F0436418 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				INFOPLIST_FILE = IMessage/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Release";
-		};
-		BC_7BA9BA11D163D5F132FE6FFBA4DA1AB8 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Release";
-		};
-		BC_7D0687E6BFF4B05D03341A00447B5070 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Release";
-		};
-		BC_80331E927C4BB7E48B375DB00FD90281 /* Production Debug */ = {
+		DC80DC0AF0B4F2B51DAB0A5276F79F05 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				COMBINE_HIDPI_IMAGES = YES;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"\"Vendor\"",
 				);
-				INFOPLIST_FILE = App_macOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
-				SDKROOT = macosx;
-			};
-			name = "Production Debug";
-		};
-		BC_80FA279C7B3455A79612ECAB12C9E8F6 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = "XPC Service/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
-				SDKROOT = macosx;
-			};
-			name = "Test Release";
-		};
-		BC_833320F190FC427049CDF16E1B1AF316 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Test Release";
 		};
-		BC_83922E2AEA387FB9ABF402C3F401DBA1 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Release";
-		};
-		BC_8433EE3901A89DD2CDDE9F61906433E5 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-			};
-			name = "Test Release";
-		};
-		BC_853248A59437336C149C6DD8E6E4A208 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = App_watchOS/Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
-			};
-			name = "Production Debug";
-		};
-		BC_85A9D050B594B6F44602E90470E75818 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Debug";
-		};
-		BC_8624FCCF5B865B80E0B21BA20FA0FAC5 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Release";
-		};
-		BC_865AB65A39A201C7BF448737D287EF85 /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Release";
-		};
-		BC_874C935D654D12F1F106CBEFBC4D2074 /* Staging Debug */ = {
+		E24703CFCCBD727B3FE08F51C14A0CC8 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -3492,166 +4260,21 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
 				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
 				PRODUCT_NAME = Framework;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Debug";
-		};
-		BC_8895B9B729A8000331A682AF912CA229 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Debug";
-		};
-		BC_88D810589CFF611B0D20C0CB47822274 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
-				PRODUCT_NAME = Framework2;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Debug";
-		};
-		BC_89C8C1848F2559C9E46F22CB83CDB25A /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Release";
-		};
-		BC_904676A8DD86F548E50090FAA97FD9E1 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				MY_SETTING = hello;
-			};
-			name = "Production Release";
-		};
-		BC_9081CEAEC2FCC555B0BFC28B4EEDF0D6 /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Release";
-		};
-		BC_917ABD477C99455FF6BE1A89107FDEC9 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Test Release";
 		};
-		BC_919006DE8A7D104D16D1D4C0AB2CC241 /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = App_watchOS/Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
-			};
-			name = "Staging Release";
-		};
-		BC_9360F45D8F5B06962ACEBF423299C71B /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-			};
-			name = "Staging Release";
-		};
-		BC_93685F04BC9D8657E5D7B62B22E043AF /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				INFOPLIST_FILE = IMessage/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Release";
-		};
-		BC_96931434222054E6D7469B6B4EC67E87 /* Staging Debug */ = {
+		E29961CFB084F6C1BF2CCCAE414F9D55 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -3711,349 +4334,7 @@
 			};
 			name = "Staging Debug";
 		};
-		BC_98CCC502104C412E1F48BB2F610EA45E /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Release";
-		};
-		BC_9B4D15D591EA1FDE03F33A0EE5B01DAB /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Release";
-		};
-		BC_9CAC5683B65F9EA32F4A78810EAE488B /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
-				INFOPLIST_FILE = "IMessage MessagesExtension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Debug";
-		};
-		BC_9CDD286FAE4CE2FC296246C95A178023 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_iOS;
-			};
-			name = "Production Debug";
-		};
-		BC_9EA5ADC667D6445EB2976A3CA508E70D /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Staging Release";
-		};
-		BC_9F1E5E527BE355504381023DED9562C9 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Debug";
-		};
-		BC_9F549905032A4927CF6B843899EF5775 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = "XPC Service/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
-				SDKROOT = macosx;
-			};
-			name = "Production Debug";
-		};
-		BC_A3FC5819178DDC45D4D2249ECCCA158D /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Debug";
-		};
-		BC_A46551B496D75A9F6D5FF83C2308DC79 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
-			};
-			name = "Test Debug";
-		};
-		BC_A61B5D8B6C38C2B4C738A48343FB4CDA /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				BUNDLE_ID_SUFFIX = .staging;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.2;
-				VALIDATE_PRODUCT = YES;
-				WATCHOS_DEPLOYMENT_TARGET = 4.0;
-			};
-			name = "Staging Release";
-		};
-		BC_ACF9A90E6BEFB16076EE5B78A3711D41 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Test Release";
-		};
-		BC_AE11EA7D0985D3AD750BDB7F362B6726 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"\"Vendor\"",
-				);
-				INFOPLIST_FILE = App_iOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Debug";
-		};
-		BC_B0011E28621230A66DBE3070C59108D4 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Release";
-		};
-		BC_B19AA9EDCE45F13CA00B669DADF86395 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				INFOPLIST_FILE = IMessage/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Debug";
-		};
-		BC_B2819DF0E90F3F3341B2B3A828778827 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Production Debug";
-		};
-		BC_B290BF236EBF078304DB54D0CE99B85A /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_iOS;
-			};
-			name = "Test Debug";
-		};
-		BC_B2EA5B6CE006C3C8DB5A6AC3A2C78E59 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				MY_SETTING = hello;
-			};
-			name = "Test Debug";
-		};
-		BC_B3B360DE1D00D5D3DE54D0467886EEDD /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Debug";
-		};
-		BC_B3CC7B17DDF2C081536FC92CF25981BD /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Debug";
-		};
-		BC_B44CB3772859FEECDAFDCD4B2FFA2E26 /* Test Debug */ = {
+		E3E69C722D5BBAF4C8EF4D29EFE9C6CB /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -4063,115 +4344,39 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Debug";
-		};
-		BC_B52BB5E51BF8953D7DA1F42BA3803D2E /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
 				);
-				INFOPLIST_FILE = App_macOS/Info.plist;
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
 				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = "Test Debug";
+			name = "Test Release";
 		};
-		BC_B6F81B24E04D91DFE5F36AAF99FCFA5D /* Staging Debug */ = {
+		E3FC19CE2B78DA85314CB6A53F65577F /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
 				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Staging Debug";
 		};
-		BC_BBA77AE6DA089F82907B6DFC338A6F37 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Debug";
-		};
-		BC_BC88A6EBF48BB9B821C5B8001678AC2E /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Release";
-		};
-		BC_BFFBE0C278E007152F06241181A3457E /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = appletvos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Debug";
-		};
-		BC_C07EA83764F4BDE5F0059DC49805D92B /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				MY_SETTING = hello;
-			};
-			name = "Staging Release";
-		};
-		BC_C38327E8FC090ADC83AA700666F26B0E /* Production Debug */ = {
+		E4257B4F823EE947AADAD19594355998 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -4181,51 +4386,9 @@
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
-			name = "Production Debug";
+			name = "Staging Release";
 		};
-		BC_C507150F28216FCF1029C0C97677DBE5 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
-				INFOPLIST_FILE = App_macOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
-				SDKROOT = macosx;
-			};
-			name = "Test Release";
-		};
-		BC_C5288877BBCE2FA6BA4D3FACBFF3BA7F /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
-				INFOPLIST_FILE = App_macOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
-				SDKROOT = macosx;
-			};
-			name = "Production Release";
-		};
-		BC_C60CBFC5B28D2B8906EAF4D4D3C81597 /* Staging Release */ = {
+		E514F031B181A327296DB27BD4008504 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -4247,372 +4410,31 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
-			name = "Staging Release";
-		};
-		BC_C7D3757F2E3D9743FDC0CA97F807919C /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"\"Vendor\"",
-				);
-				INFOPLIST_FILE = App_iOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
 			name = "Production Debug";
 		};
-		BC_C9DCD449062A9160795D3701B9D2286E /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = "XPC Service/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
-				SDKROOT = macosx;
-			};
-			name = "Production Release";
-		};
-		BC_CD673788A57DF4BFEB50B4F1581C742E /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				INFOPLIST_FILE = IMessage/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Release";
-		};
-		BC_CECBF50DBAC4771C31C83814C20D07B2 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"\"Vendor\"",
-				);
-				INFOPLIST_FILE = App_iOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Release";
-		};
-		BC_D02EB4360B13F2E445DB48AD85FDFCE6 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Release";
-		};
-		BC_D4F031939A239C28219748EFD83D30AA /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				INFOPLIST_FILE = "XPC Service/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
-				SDKROOT = macosx;
-			};
-			name = "Test Debug";
-		};
-		BC_D4FC53C776F8F2638D1D294F70517658 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Test Debug";
-		};
-		BC_DA0BB134B708A4D257F250D3FA757711 /* Test Release */ = {
+		E5854B94A71A091D61E6ACD30A11414F /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
 				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Release";
-		};
-		BC_DA5027F5182F7A40FB94FD282B57BC3E /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"\"Vendor\"",
-				);
-				INFOPLIST_FILE = App_iOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Release";
-		};
-		BC_DD94802386549D49D781D0BF313007D4 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
-				PRODUCT_NAME = Framework2;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Debug";
-		};
-		BC_DF27A9642DF4C47995FB0B0F4F6C2A98 /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
-				PRODUCT_NAME = Framework2;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Release";
-		};
-		BC_E254C909463A5ADF59BD226772066ADA /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_iOS;
-			};
-			name = "Test Release";
-		};
-		BC_E52BEBA72F64BEC8F09733B49F7BA392 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
-			};
-			name = "Production Release";
-		};
-		BC_E6F51B0AAB0A7B33D902BD20A14E355C /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Staging Debug";
 		};
-		BC_E8AE376BBD8C86CFB51C9D5A490FDDBE /* Staging Debug */ = {
+		E599549D1B1432302031A9047D6BBA43 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_iOS;
-			};
-			name = "Staging Debug";
-		};
-		BC_E90B182AC1AF70BB78598DADECF9254B /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Test Debug";
-		};
-		BC_E9A1D87B4DB80BCC61D6B5F59D81865D /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-			};
-			name = "Test Release";
-		};
-		BC_F1A1A29B491BDE527B8095C7420311D9 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = App_watchOS/Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
-			};
-			name = "Test Debug";
-		};
-		BC_F7D27DC0894036434C159F86616307EF /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = "Staging Release";
 		};
-		BC_F81BA31D0E5421AC0DDFB2D799C84E2E /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COMBINE_HIDPI_IMAGES = YES;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
-				PRODUCT_NAME = StaticLibrary_ObjC;
-				SDKROOT = macosx;
-				SKIP_INSTALL = YES;
-			};
-			name = "Staging Release";
-		};
-		BC_F947CECE4A424652DB631A640F423950 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
-				INFOPLIST_FILE = App_macOS/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
-				SDKROOT = macosx;
-			};
-			name = "Staging Debug";
-		};
-		BC_F9F3A5E30D3C940B7D85E1AE59A6B3D8 /* Production Debug */ = {
+		E683F74557A3FC7BD78CAB2B693320B5 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -4633,33 +4455,9 @@
 			};
 			name = "Production Debug";
 		};
-		BC_FAA6D28DC24848759E58A2552BD37359 /* Production Debug */ = {
+		E95B2CE470959F04BE6AACA9D985D3A6 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/watchOS",
-				);
-				INFOPLIST_FILE = Framework/Info.plist;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
-				PRODUCT_NAME = Framework;
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
-				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Debug";
-		};
-		BC_FBF3614A1E9EDDE43929E81FDBD8B4B8 /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_22A431E337CB22CE70E39135206EDE27 /* config.xcconfig */;
+			baseConfigurationReference = 16D662EE577E4CD6AFF39D66C382B13F /* config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BUNDLE_ID_SUFFIX = .test;
@@ -4718,7 +4516,18 @@
 			};
 			name = "Test Debug";
 		};
-		BC_FF1009503385A37130A5A131E70F0B18 /* Production Release */ = {
+		EA62022185E4BCDA6786EC0DAA7AADE0 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = IMessage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		EC3A16C2887B72837F84904A8E8C21ED /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
@@ -4730,7 +4539,19 @@
 			};
 			name = "Production Release";
 		};
-		BC_FF3600FA7FDB235869A6CB7BBDBD8C86 /* Production Release */ = {
+		EC9867399E6694681F8903B1A69AF80A /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		EDAF427566F715F739A4A1E1775508DD /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -4741,339 +4562,518 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
 				PRODUCT_NAME = Framework2;
-				SDKROOT = watchos;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = 4;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Production Release";
+		};
+		F3AC6A112F81D0958A316D820549143D /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+			};
+			name = "Test Release";
+		};
+		F443D526C71E9F3481F46EC0CB121C4C /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		F75CC02D1BB9B39C329A9B433B047005 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Staging Release";
+		};
+		F961247BCE59D147388CA72104126125 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = IMessage/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
+		F9AA169AF7F8FB31037CB416C26412DE /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				MY_SETTING = hello;
+			};
+			name = "Staging Debug";
+		};
+		F9F2DA45FBEAF1528EC026FBD97BD11E /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		FBC34FE61DA25D0516C15B601475D94C /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_ID_SUFFIX = .staging;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = "Staging Release";
+		};
+		FE029D76C57D0661E4B8F13B132169CA /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		FE46BDDF158F46B264958EA53707827B /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		CL_0562279D56EF60E8CCC0973D2C663637 /* Build configuration list for PBXNativeTarget "Framework2_iOS" */ = {
+		0129D8A8DCD54069136D90F7F9F29C1A /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_watchOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_F9F3A5E30D3C940B7D85E1AE59A6B3D8 /* Production Debug */,
-				BC_4346300D78CE0EC28B467470E8C4DB2E /* Production Release */,
-				BC_DD94802386549D49D781D0BF313007D4 /* Staging Debug */,
-				BC_89C8C1848F2559C9E46F22CB83CDB25A /* Staging Release */,
-				BC_54F3754420D0F7418AB42235B1D71751 /* Test Debug */,
-				BC_3134697E7D6C32A5C4376C581C189D6B /* Test Release */,
+				B24243F387A725EAFE802321255BC6F4 /* Production Debug */,
+				7E81F863EF51334FDDCC8A39DC90B0B7 /* Production Release */,
+				74E52B213DA9EAFA77BC05D0E0A19090 /* Staging Debug */,
+				7F86E00770E76CA3412A03BD236C4D8E /* Staging Release */,
+				49322BF02F4F345A1339EF7A96CF3167 /* Test Debug */,
+				058734C3B593A26E24211133F43C16EF /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_11BB9F4DF26D98C0A2C8E1668356269F /* Build configuration list for PBXNativeTarget "Framework_tvOS" */ = {
+		02E5A42C8065AF7CCB48FACEF125FAB6 /* Build configuration list for PBXNativeTarget "Framework2_macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_032D44BB36CD1AC13FFFAC654631D432 /* Production Debug */,
-				BC_B0011E28621230A66DBE3070C59108D4 /* Production Release */,
-				BC_A3FC5819178DDC45D4D2249ECCCA158D /* Staging Debug */,
-				BC_0B57E3E0E8C194293ABFEEF97F104F30 /* Staging Release */,
-				BC_0B1CBABAB9579A064729249F5E1B7B84 /* Test Debug */,
-				BC_1603C1C58A4D6AE1BD0707D13D2C8F44 /* Test Release */,
+				15A9BF8518A5155B879C8DAFA1C396EB /* Production Debug */,
+				9AFD84FE41E84631927FC8918C7A276F /* Production Release */,
+				8269ABE82BCBF550C38494DF5C3465D0 /* Staging Debug */,
+				F443D526C71E9F3481F46EC0CB121C4C /* Staging Release */,
+				A59DDFBFCF18C44A993CFB00FED2841F /* Test Debug */,
+				5675C7C51DC1B8D63CBAE30AAF4E911D /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_159255858B3EEC02844A3059326A6B93 /* Build configuration list for PBXNativeTarget "StaticLibrary_Swift" */ = {
+		1FC6945BE13C2202A2BCA3BC51569CF7 /* Build configuration list for PBXNativeTarget "iMessageApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_606DC3CBE672B2D9CA4B68FF6F55762D /* Production Debug */,
-				BC_9B4D15D591EA1FDE03F33A0EE5B01DAB /* Production Release */,
-				BC_5CA18B8A4079FC28EF3A05BDC5E4D501 /* Staging Debug */,
-				BC_98CCC502104C412E1F48BB2F610EA45E /* Staging Release */,
-				BC_5996DB19FBFE69C54C671E0624798C4B /* Test Debug */,
-				BC_541CCB32267A890B3BABCE62FFE461E2 /* Test Release */,
+				511E983641E821858100107BAD873D91 /* Production Debug */,
+				EA62022185E4BCDA6786EC0DAA7AADE0 /* Production Release */,
+				5876AA17762F3248F4FD66E1FB07A931 /* Staging Debug */,
+				4D86BBA6893D41140152B8CCDE62CC7B /* Staging Release */,
+				6C201A244077B7B453E15C1AF74D2070 /* Test Debug */,
+				F961247BCE59D147388CA72104126125 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_289609080F2D20D506C8A587BC92807B /* Build configuration list for PBXNativeTarget "Framework2_macOS" */ = {
+		3F3C272D2EA61F6B88B80D440755448B /* Build configuration list for PBXNativeTarget "App_watchOS Extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_656BA4FF26F3FB2ECFA5F81D7E133C94 /* Production Debug */,
-				BC_5D7B920759B10537602230A4B5520551 /* Production Release */,
-				BC_27A94FA771ABEE02868BCED0690C89E1 /* Staging Debug */,
-				BC_9081CEAEC2FCC555B0BFC28B4EEDF0D6 /* Staging Release */,
-				BC_B44CB3772859FEECDAFDCD4B2FFA2E26 /* Test Debug */,
-				BC_22D59B57A805B62A266F803CCDD49C26 /* Test Release */,
+				4EBCDEB4013FDB072034346710E33B2C /* Production Debug */,
+				4BCE080A33E3A2F26D1DBEEB6ECC1D95 /* Production Release */,
+				1539437BBB98703535876E359712A22F /* Staging Debug */,
+				F75CC02D1BB9B39C329A9B433B047005 /* Staging Release */,
+				5FAA92426D53E239CDB39102D61ADD93 /* Test Debug */,
+				0C66F8A2D0CB0D802A327EB47C62BFCF /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_2E30D27084B352548CCAA3500158519B /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_watchOS" */ = {
+		4A036BD16A0E9D22AE065AC9D8232B5B /* Build configuration list for PBXNativeTarget "StaticLibrary_Swift" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_0E104167F96EA087A23DFBE2430D5612 /* Production Debug */,
-				BC_6EDDF7399F4EE2E8226F9D006C31ACB1 /* Production Release */,
-				BC_56B4C0BD8630088AECC29D1D7064530F /* Staging Debug */,
-				BC_F7D27DC0894036434C159F86616307EF /* Staging Release */,
-				BC_E90B182AC1AF70BB78598DADECF9254B /* Test Debug */,
-				BC_ACF9A90E6BEFB16076EE5B78A3711D41 /* Test Release */,
+				9FCB2F3977FC0F94393F86FEC15F50E2 /* Production Debug */,
+				3764AEC1D64BC7805DC7390019AF6C3A /* Production Release */,
+				66DBF782276810342031776DAAEB6C6D /* Staging Debug */,
+				FE46BDDF158F46B264958EA53707827B /* Staging Release */,
+				A0AA826373CDC7E0A8797430E86FA0AA /* Test Debug */,
+				1D61DC7F5309F4C8B7692D8522B99481 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_333C6C3162FB671343E806257FB2A411 /* Build configuration list for PBXNativeTarget "App_watchOS Extension" */ = {
+		4A8774E3B4F5C9B98E0D0CF9EC17CF91 /* Build configuration list for PBXNativeTarget "Framework_watchOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_B2819DF0E90F3F3341B2B3A828778827 /* Production Debug */,
-				BC_4AC83F754F5BB02C3019E8AE2303E966 /* Production Release */,
-				BC_6396C78E99C21A774B9819DC09D88BD7 /* Staging Debug */,
-				BC_9EA5ADC667D6445EB2976A3CA508E70D /* Staging Release */,
-				BC_0198386D4EF48A4C053820EEEE1936CB /* Test Debug */,
-				BC_E9A1D87B4DB80BCC61D6B5F59D81865D /* Test Release */,
+				E514F031B181A327296DB27BD4008504 /* Production Debug */,
+				9666BFAAA42CE2DC7E368E7DEFAA6225 /* Production Release */,
+				B928E061A126AC8D17D81D1E4DC11629 /* Staging Debug */,
+				015D35ADD269DCBEA53B52A34A4CB440 /* Staging Release */,
+				C96EA1AD4B3ABB8A49B98BC25E24E03A /* Test Debug */,
+				D9A0609EE6F341CD4E8758C1841CC3EF /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_3ABBEC1A6EFC98F40894F5E4769650EF /* Build configuration list for PBXNativeTarget "iMessageExtension" */ = {
+		50DA67E9A951C40D9536609DD12FA6CC /* Build configuration list for PBXNativeTarget "Framework_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_3D9C1A83637AB10D5FFC5D4F8331091E /* Production Debug */,
-				BC_679AB0D3CA0237CCB4B711609C0CB16A /* Production Release */,
-				BC_9CAC5683B65F9EA32F4A78810EAE488B /* Staging Debug */,
-				BC_2F352436A75D33C6D3337012367BE90C /* Staging Release */,
-				BC_7527094FD7492E6A964EC95E7378EF22 /* Test Debug */,
-				BC_7477F8344D6D7313C39D897C1864F1B7 /* Test Release */,
+				81AE120E23F0108E77BBCE228EB54DC0 /* Production Debug */,
+				580039D71F71A98572051157B9CEFDCA /* Production Release */,
+				55DA94C85E0E63D3AD593A08A2A8DAC7 /* Staging Debug */,
+				62F50207E03F6D9813514977AFA9314E /* Staging Release */,
+				8C9F67C7AA56DBE79F0F2640CE7FAC51 /* Test Debug */,
+				A861DE7670417FA256F4E459462B198D /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_3BB54CFB2F2EFE7302C0B0709BD0AE04 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_macOS" */ = {
+		56BF985F253DD84AD7C3753800E07F6D /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_5CBE4F01DBB084436375039EFEDDE6E4 /* Production Debug */,
-				BC_FF1009503385A37130A5A131E70F0B18 /* Production Release */,
-				BC_53BBB90244275C55B50604E0DC26809E /* Staging Debug */,
-				BC_F81BA31D0E5421AC0DDFB2D799C84E2E /* Staging Release */,
-				BC_63E4D52E21696EFA858D20EA01500612 /* Test Debug */,
-				BC_8433EE3901A89DD2CDDE9F61906433E5 /* Test Release */,
+				13FF53C2B3637EA82E3DF577DD665399 /* Production Debug */,
+				D24E68EE5DE052219B036D6333C8A07C /* Production Release */,
+				6A11812952F34525D14A410446BDD796 /* Staging Debug */,
+				AA4F4236D960D3ACE683A8158218D2FC /* Staging Release */,
+				EC9867399E6694681F8903B1A69AF80A /* Test Debug */,
+				CA08CB7E7DBBC99CDC7F2C2E282437DF /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_674C71F7D7B679C67A944F0110840758 /* Build configuration list for PBXNativeTarget "Framework_watchOS" */ = {
+		62D7BB889799B73F7E8B798FE670D384 /* Build configuration list for PBXNativeTarget "App_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_FAA6D28DC24848759E58A2552BD37359 /* Production Debug */,
-				BC_5BC104FB79C437B79CC9D676B3B964D2 /* Production Release */,
-				BC_9F1E5E527BE355504381023DED9562C9 /* Staging Debug */,
-				BC_C60CBFC5B28D2B8906EAF4D4D3C81597 /* Staging Release */,
-				BC_BBA77AE6DA089F82907B6DFC338A6F37 /* Test Debug */,
-				BC_0271561C28AF4A74C6924A2187BC8487 /* Test Release */,
+				AE37A01B34B4B956E784082C03DEB579 /* Production Debug */,
+				545342CFDF7810F2EBFFFC5EEE5B87A6 /* Production Release */,
+				B008685BA25BB8FD771F0AE3B59FA06C /* Staging Debug */,
+				06E4383A2687EAD5877836CD308F610F /* Staging Release */,
+				7931F229200F89B8CDC8A5E3B755C52E /* Test Debug */,
+				DC80DC0AF0B4F2B51DAB0A5276F79F05 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_6993244897DFCCF1F61A6136FDBE3C01 /* Build configuration list for PBXNativeTarget "XPC Service" */ = {
+		658628E35283172E17BFC6A35BE18143 /* Build configuration list for PBXNativeTarget "Framework_tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_9F549905032A4927CF6B843899EF5775 /* Production Debug */,
-				BC_C9DCD449062A9160795D3701B9D2286E /* Production Release */,
-				BC_4F7A9BAD8AB16D47ECA510689FB5F899 /* Staging Debug */,
-				BC_11CBEB05340DE3C8F396B359A9144039 /* Staging Release */,
-				BC_D4F031939A239C28219748EFD83D30AA /* Test Debug */,
-				BC_80FA279C7B3455A79612ECAB12C9E8F6 /* Test Release */,
+				589D05992FDC35F6BE05695828D404AE /* Production Debug */,
+				5822FCD48FCC177980F672D4783A1A0E /* Production Release */,
+				9E38571B33C3CE5CA10C8452AE897DF8 /* Staging Debug */,
+				4089B74CA10172B8ED2D004B8B4F5ECC /* Staging Release */,
+				2569D399CA3C4828EF87AD78F013FF7C /* Test Debug */,
+				E24703CFCCBD727B3FE08F51C14A0CC8 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_7A3206BF9A92D4552AE40D148897BB3E /* Build configuration list for PBXNativeTarget "Framework_macOS" */ = {
+		68CC35789B0DB020E2CFC517D39151D2 /* Build configuration list for PBXNativeTarget "App_iOS_UITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_5D33E2C3F29594425D03B339108871CF /* Production Debug */,
-				BC_58D5B708B08789E2DFD4D60A906AAA6E /* Production Release */,
-				BC_120D6C5C7E4D1D6566CBD71E11C3DF37 /* Staging Debug */,
-				BC_0D96F61E117D6A8D2353B0E7CB445AEA /* Staging Release */,
-				BC_5A05C344BCA2E54DFF945E68ECC21064 /* Test Debug */,
-				BC_6D1ED651D660692438EF3196506DC5AD /* Test Release */,
+				082A10B9E5EAC6E783EAB9B05B200B33 /* Production Debug */,
+				184E4078B13FE1CC6A11BD529C15AA7E /* Production Release */,
+				E3FC19CE2B78DA85314CB6A53F65577F /* Staging Debug */,
+				04172E0BDC7C512A23A51C76B325F8D0 /* Staging Release */,
+				0AB9030B7E8A8BBA74CCB1A946488B9A /* Test Debug */,
+				BBA736CF3FB466E323EA84621521053D /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_85167C2DED9F1F2F7D5162C1DD252426 /* Build configuration list for PBXProject "Project" */ = {
+		6B5C5F08C0EF06457756E379776B4C6F /* Build configuration list for PBXNativeTarget "App_watchOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_209579D4C144FB697FDD46843485CC6A /* Production Debug */,
-				BC_6851DF4113AFF271AA5DD6D587181A03 /* Production Release */,
-				BC_96931434222054E6D7469B6B4EC67E87 /* Staging Debug */,
-				BC_A61B5D8B6C38C2B4C738A48343FB4CDA /* Staging Release */,
-				BC_FBF3614A1E9EDDE43929E81FDBD8B4B8 /* Test Debug */,
-				BC_19E3B21D0DA59BAF1B99899A35858D52 /* Test Release */,
+				20803EC42C26E4EA13474E5A694068D1 /* Production Debug */,
+				AABC1E325EADF86C5137D659051CC749 /* Production Release */,
+				C4397CDA0D458BAD55C911B0A4DC7868 /* Staging Debug */,
+				7B2A1BE6CA654E9903A4C6802DBCE440 /* Staging Release */,
+				00FD318C7418F3351FC0074451FC8AF5 /* Test Debug */,
+				F3AC6A112F81D0958A316D820549143D /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		752BB3C1A601770BDD9AC01ECB78E01C /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				92602C025633FBA848F91812F4CD6D45 /* Production Debug */,
+				EC3A16C2887B72837F84904A8E8C21ED /* Production Release */,
+				02EB0C0230E6616EC8057F1CB1EEAD3D /* Staging Debug */,
+				01BF8C6D1C21955BA7E803E8E76EAE33 /* Staging Release */,
+				1341099486D8FE68A99CB5FE4AB85779 /* Test Debug */,
+				0CE2F7B8A955BE108A66FF68A60E7F63 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		77CE5B5E5DEAC820254D484CB8646E93 /* Build configuration list for PBXNativeTarget "App_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				943D402E936EC5BD391F9FD0C7D926EA /* Production Debug */,
+				4621C6C8A78FBB1CF4078178688742F9 /* Production Release */,
+				97009625463EC8B19F53007A9D102A56 /* Staging Debug */,
+				CBE9D80AD0719511A13A889E867077CC /* Staging Release */,
+				196FEEE6C4B0DDE53AD16BD6E5645F0E /* Test Debug */,
+				3FFEE1ED324166B88F5F9A451E59A29C /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		7CBF487CACC0BBFB530D79633BC124AA /* Build configuration list for PBXAggregateTarget "SuperTarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				40A3301910021B57051D1BD5CDE2006B /* Production Debug */,
+				A79632AF4FFC93B0940CE8E3FB93B600 /* Production Release */,
+				F9AA169AF7F8FB31037CB416C26412DE /* Staging Debug */,
+				A696B22A9734326DBFD20EC8065B6ACF /* Staging Release */,
+				26BACA32C62C38FAB45F532D54C340EE /* Test Debug */,
+				D37EB6FE8C8C4040A394F1E9E247EC63 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		7E4887637B4FA5B8E2F349CA4B36BDBE /* Build configuration list for PBXNativeTarget "Framework2_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				079E494F34C3CAFB8F9E44B3D43EEB31 /* Production Debug */,
+				B18D58177F363DF071A9AF955A1FE5AC /* Production Release */,
+				236247F0F85C9D342FAEE803854E5159 /* Staging Debug */,
+				AF25BBA6E0AD56CA13A3F6C6FC1BBCF1 /* Staging Release */,
+				5180F6C101C0335213FB28E58799AF2A /* Test Debug */,
+				AE8DA78BA7A7194BD625DD45A1AFC4BA /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		906B8E5233EE4169E84ABAF37433F2A2 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				96B8ADD171694B9A9E3ABC7EFB5F4D1B /* Production Debug */,
+				278E3C762E54ADDA52F9E68793ED6AFB /* Production Release */,
+				E5854B94A71A091D61E6ACD30A11414F /* Staging Debug */,
+				E4257B4F823EE947AADAD19594355998 /* Staging Release */,
+				817AFA080A41D783F5801C5A63BFEF87 /* Test Debug */,
+				36C4B3A6EACCB88098CE13D7E597918E /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		9A0EF0B71AD44055E8749C42210FBBE8 /* Build configuration list for PBXNativeTarget "Framework2_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E683F74557A3FC7BD78CAB2B693320B5 /* Production Debug */,
+				EDAF427566F715F739A4A1E1775508DD /* Production Release */,
+				4B389C6B6140EE7DE69A248A8047A3DA /* Staging Debug */,
+				FE029D76C57D0661E4B8F13B132169CA /* Staging Release */,
+				10E250D1DC79E11058B933F905968160 /* Test Debug */,
+				5A9C67C1F423247AE1541F63C53C88B5 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		BE0FF81B67730F081F45BC783F30F309 /* Build configuration list for PBXLegacyTarget "Legacy" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				53C3CC585BF0EAB4CA31AD3EEA8FE4D9 /* Production Debug */,
+				A91B13C5688E9BCC925C702A6740B026 /* Production Release */,
+				72EDF2E14A4CE916F4E2B01B5CB7984B /* Staging Debug */,
+				E599549D1B1432302031A9047D6BBA43 /* Staging Release */,
+				9A891313A139893990989BDDFA989F3A /* Test Debug */,
+				3DEEA480EDDC83405CFB9BBA0EBCA9BF /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		D379D1BBEF24ED05EB6ADEB3E5322641 /* Build configuration list for PBXNativeTarget "XPC Service" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A2EBD902E6DE2B2BD12C4484D36B6B76 /* Production Debug */,
+				64BEC335CD4016B9BC59F3C9EACDA68E /* Production Release */,
+				6B5A31340B8CF5849805CA3D0DF48215 /* Staging Debug */,
+				7E101F97604A0990174A46CD53FEEAF5 /* Staging Release */,
+				2630B88F53876A9AD7B61A4E3B8671F4 /* Test Debug */,
+				AC8E8FEA35961580D23185B296BA137F /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		D60A551D881B4B91F4535B78058154DF /* Build configuration list for PBXNativeTarget "Framework_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				982EA5A9273899567804B40D5E98CF39 /* Production Debug */,
+				25E62244CD9C539F614224DFDFBFB78D /* Production Release */,
+				65A21512F2B980615DF51D77519DBAE0 /* Staging Debug */,
+				D8267FD376089FF4497ED3F13C467F10 /* Staging Release */,
+				522E20DF286BE38B925CC57EA276B771 /* Test Debug */,
+				E3E69C722D5BBAF4C8EF4D29EFE9C6CB /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		D91E14E36EC0B415578456F264E0161E /* Build configuration list for PBXProject "Project" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B3B2FEA08FA4ACD18FDF9BC26A6F9613 /* Production Debug */,
+				C0D5765142C68AF68B954B3F748538C2 /* Production Release */,
+				E29961CFB084F6C1BF2CCCAE414F9D55 /* Staging Debug */,
+				FBC34FE61DA25D0516C15B601475D94C /* Staging Release */,
+				E95B2CE470959F04BE6AACA9D985D3A6 /* Test Debug */,
+				C59E649CEDC0E973B28B57A4F0841506 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
 		};
-		CL_89763567DCA601C83E4C78A9917D81AD /* Build configuration list for PBXNativeTarget "App_iOS_Tests" */ = {
+		ED1A174BA92C6E5172B519B7B6716A24 /* Build configuration list for PBXNativeTarget "iMessageExtension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_5901F7B4A1799821B3061B5EA7C4A033 /* Production Debug */,
-				BC_E52BEBA72F64BEC8F09733B49F7BA392 /* Production Release */,
-				BC_E6F51B0AAB0A7B33D902BD20A14E355C /* Staging Debug */,
-				BC_689C05D134F6C4AB2A86666C7C2D1E8F /* Staging Release */,
-				BC_A46551B496D75A9F6D5FF83C2308DC79 /* Test Debug */,
-				BC_833320F190FC427049CDF16E1B1AF316 /* Test Release */,
+				862658ACA3BF7AE7FA22870C96CCF7FE /* Production Debug */,
+				79FA19BACBA7B6C15E0399C0438D0133 /* Production Release */,
+				366C92A637FDA940E6BCB591EC2E6D5E /* Staging Debug */,
+				4662A9062E19E6BC30C9E0A1BFA83798 /* Staging Release */,
+				15F79278F4ABD33584FC69E4392176FF /* Test Debug */,
+				6645E6A343F71C3E91656BE99B8DC559 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_91682ADED17A2C81A700A67F5D70BA1F /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_tvOS" */ = {
+		EF0A56586AB1ED900B70D5BC3C15FDFD /* Build configuration list for PBXNativeTarget "Framework2_tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_C38327E8FC090ADC83AA700666F26B0E /* Production Debug */,
-				BC_0D53E4051E21792867D5FA4A11B751AB /* Production Release */,
-				BC_69E8021CB05224B9CAC27F6AFA1763CA /* Staging Debug */,
-				BC_9360F45D8F5B06962ACEBF423299C71B /* Staging Release */,
-				BC_791A2E3F88BE34E647BEE192E06BBA74 /* Test Debug */,
-				BC_46EDEC047C02E1E271BADF861EFB2F8D /* Test Release */,
+				77B8B41EBA5D778EB3AF89DCA0AD65E8 /* Production Debug */,
+				00AF278082A5D7C2A655586749873CE8 /* Production Release */,
+				4A0624A4FC88A7E232411C956533E4BA /* Staging Debug */,
+				7C473021DB2A2D88B535FBD60A5D1A0A /* Staging Release */,
+				401097AC487BBA8C7B2B4938968C263A /* Test Debug */,
+				F9F2DA45FBEAF1528EC026FBD97BD11E /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_9FEF3E411E281B1820B2B067FC1C1B85 /* Build configuration list for PBXNativeTarget "Framework_iOS" */ = {
+		F888428CB91ACDDAAE8C8F217D586ACD /* Build configuration list for PBXNativeTarget "App_iOS_Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_724E9BA97FC0605F596460587FFD4C61 /* Production Debug */,
-				BC_D02EB4360B13F2E445DB48AD85FDFCE6 /* Production Release */,
-				BC_874C935D654D12F1F106CBEFBC4D2074 /* Staging Debug */,
-				BC_6A4D0B334934E5E4901A4164AD2DF70A /* Staging Release */,
-				BC_71D19FC08A12CCAB1A85C7A5320A451A /* Test Debug */,
-				BC_917ABD477C99455FF6BE1A89107FDEC9 /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_A55E6C4018D2631D41C660DBF2113765 /* Build configuration list for PBXNativeTarget "Framework2_tvOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_BFFBE0C278E007152F06241181A3457E /* Production Debug */,
-				BC_24042033AF9D3DEDAD53ACAF1C2BB0B2 /* Production Release */,
-				BC_88D810589CFF611B0D20C0CB47822274 /* Staging Debug */,
-				BC_DF27A9642DF4C47995FB0B0F4F6C2A98 /* Staging Release */,
-				BC_313481FFED1411A2B5969B70EBA94383 /* Test Debug */,
-				BC_8624FCCF5B865B80E0B21BA20FA0FAC5 /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_AA475AE6741D5744A91627E7FAF4C986 /* Build configuration list for PBXNativeTarget "iMessageApp" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_50C3D866E3B57D83181A8F04E553F557 /* Production Debug */,
-				BC_CD673788A57DF4BFEB50B4F1581C742E /* Production Release */,
-				BC_5951C33138E508D3E6CA672980D5F2B6 /* Staging Debug */,
-				BC_93685F04BC9D8657E5D7B62B22E043AF /* Staging Release */,
-				BC_B19AA9EDCE45F13CA00B669DADF86395 /* Test Debug */,
-				BC_7A2C8B05671807E16D816BD7F0436418 /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_B523BC91AF70F483BF998E2BA8DD6669 /* Build configuration list for PBXAggregateTarget "SuperTarget" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_1841B61F3F85EC24C4AACBC5C025BD08 /* Production Debug */,
-				BC_904676A8DD86F548E50090FAA97FD9E1 /* Production Release */,
-				BC_0E087681CE92CC2069F9E562ECC9FD23 /* Staging Debug */,
-				BC_C07EA83764F4BDE5F0059DC49805D92B /* Staging Release */,
-				BC_B2EA5B6CE006C3C8DB5A6AC3A2C78E59 /* Test Debug */,
-				BC_57D3973CA01D421550D834AFA79D2B4B /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_C50D7BB75115E8561A0975DE1B65E088 /* Build configuration list for PBXNativeTarget "App_watchOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_853248A59437336C149C6DD8E6E4A208 /* Production Debug */,
-				BC_42C4FEAD23C2FE1A906F4D37F43182AB /* Production Release */,
-				BC_3CCE54849732E01493DDDB7D86E033D4 /* Staging Debug */,
-				BC_919006DE8A7D104D16D1D4C0AB2CC241 /* Staging Release */,
-				BC_F1A1A29B491BDE527B8095C7420311D9 /* Test Debug */,
-				BC_16E1FCDA9DB6E70091B54603E4E6F58B /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_C7673A8886407721BA5BFA1B18F184D4 /* Build configuration list for PBXNativeTarget "App_iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_C7D3757F2E3D9743FDC0CA97F807919C /* Production Debug */,
-				BC_1CF7F7BC6E19981DCBBFE6FE2D9FCB62 /* Production Release */,
-				BC_161B10E65E0BE143A17EADFA5EE88B3D /* Staging Debug */,
-				BC_DA5027F5182F7A40FB94FD282B57BC3E /* Staging Release */,
-				BC_AE11EA7D0985D3AD750BDB7F362B6726 /* Test Debug */,
-				BC_CECBF50DBAC4771C31C83814C20D07B2 /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_D72660834ED9ED4EB0E973ABC256E014 /* Build configuration list for PBXNativeTarget "App_macOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_80331E927C4BB7E48B375DB00FD90281 /* Production Debug */,
-				BC_C5288877BBCE2FA6BA4D3FACBFF3BA7F /* Production Release */,
-				BC_F947CECE4A424652DB631A640F423950 /* Staging Debug */,
-				BC_079D311B8C64F17C816583A1A4D84F42 /* Staging Release */,
-				BC_B52BB5E51BF8953D7DA1F42BA3803D2E /* Test Debug */,
-				BC_C507150F28216FCF1029C0C97677DBE5 /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_DB66C428B606518C825ECFF73A5EF059 /* Build configuration list for PBXNativeTarget "App_iOS_UITests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_9CDD286FAE4CE2FC296246C95A178023 /* Production Debug */,
-				BC_291E5C210DD53C3B3A4C6057C2B9652A /* Production Release */,
-				BC_E8AE376BBD8C86CFB51C9D5A490FDDBE /* Staging Debug */,
-				BC_19CBA184C0BDC24CE3657C025A8FC279 /* Staging Release */,
-				BC_B290BF236EBF078304DB54D0CE99B85A /* Test Debug */,
-				BC_E254C909463A5ADF59BD226772066ADA /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_E92E1636D45B284E44D38EB3EF7C98C9 /* Build configuration list for PBXNativeTarget "Framework2_watchOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_B3B360DE1D00D5D3DE54D0467886EEDD /* Production Debug */,
-				BC_FF3600FA7FDB235869A6CB7BBDBD8C86 /* Production Release */,
-				BC_85A9D050B594B6F44602E90470E75818 /* Staging Debug */,
-				BC_865AB65A39A201C7BF448737D287EF85 /* Staging Release */,
-				BC_D4FC53C776F8F2638D1D294F70517658 /* Test Debug */,
-				BC_83922E2AEA387FB9ABF402C3F401DBA1 /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_F6ECF2D45799DBBB48DE9AE80AC280AA /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_B3CC7B17DDF2C081536FC92CF25981BD /* Production Debug */,
-				BC_7D0687E6BFF4B05D03341A00447B5070 /* Production Release */,
-				BC_B6F81B24E04D91DFE5F36AAF99FCFA5D /* Staging Debug */,
-				BC_BC88A6EBF48BB9B821C5B8001678AC2E /* Staging Release */,
-				BC_1D9A30F2A4E9057FD8A7101D4AA4F47D /* Test Debug */,
-				BC_DA0BB134B708A4D257F250D3FA757711 /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_F8A83116F913B5DD0538C3680E08BDDB /* Build configuration list for PBXLegacyTarget "Legacy" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_057931652E9069AFF23BA573B6564BE5 /* Production Debug */,
-				BC_5B12F047BB0206FED25C955314A29B18 /* Production Release */,
-				BC_8895B9B729A8000331A682AF912CA229 /* Staging Debug */,
-				BC_2DB4D72679A12506C6A8B4728F130B7D /* Staging Release */,
-				BC_2D532F03F57D7D107FDAC3EF23DBFBFE /* Test Debug */,
-				BC_7BA9BA11D163D5F132FE6FFBA4DA1AB8 /* Test Release */,
+				C7EF8D96FA7893ADD61CF4C0432F4C36 /* Production Debug */,
+				B9BEDF424FEFB1047765C3C6B718FC6A /* Production Release */,
+				2F1CDD64CD0684A2B09D6ED398F2640B /* Staging Debug */,
+				0EFE33A4C09DCF9FE1519D3703549835 /* Staging Release */,
+				2F88193D8069519CD36F649B2E68FD74 /* Test Debug */,
+				7B4F942EA48FC1FED21AA2EE8C1F44C9 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
@@ -5081,19 +5081,19 @@
 /* End XCConfigurationList section */
 
 /* Begin XCVersionGroup section */
-		VG_EB676136B9F946373D4796800CC00AD4 /* Model.xcdatamodeld */ = {
+		306796628DD52FA55E833B65DD4F2A22 /* Model.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				FR_347062562C9C212A082B1326BBCDC71B /* Model 2.xcdatamodel */,
-				FR_6643E0FE8DD9AAC71691A739070C6833 /* Model 3.xcdatamodel */,
-				FR_58A974F0E117C1384FD1B5147E524659 /* Model.xcdatamodel */,
+				D70BE0C05E5779A077793BE613BE34E3 /* Model 2.xcdatamodel */,
+				4BF4D16042A80576D259160C97AD2C2E /* Model 3.xcdatamodel */,
+				7DE38C10AB71A47B786D5BF205BA002F /* Model.xcdatamodel */,
 			);
-			currentVersion = FR_347062562C9C212A082B1326BBCDC71B /* Model 2.xcdatamodel */;
+			currentVersion = D70BE0C05E5779A077793BE613BE34E3 /* Model 2.xcdatamodel */;
 			path = Model.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};
 /* End XCVersionGroup section */
 	};
-	rootObject = P_88EC38DC1E39C9039D2FA49EDC2FA124 /* Project object */;
+	rootObject = 0FBAE303E3CFC2ABAC876A7719B30922 /* Project object */;
 }

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+               BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
                BuildableName = "App_iOS.app"
                BlueprintName = "App_iOS"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -33,7 +33,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_D4BAEEEC88124103C8DFF41FCE206DCE"
+               BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA9A22DB35"
                BuildableName = "App_iOS_UITests.xctest"
                BlueprintName = "App_iOS_UITests"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -45,7 +45,7 @@
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_193BAF154270D1C21E269EDF2A1BD3F6"
+               BlueprintIdentifier = "DC2F16BAA6E13B44AB62F8887D4CE3FA"
                BuildableName = "App_iOS_Tests.xctest"
                BlueprintName = "App_iOS_Tests"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -55,7 +55,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -80,7 +80,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -99,7 +99,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+               BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
                BuildableName = "App_iOS.app"
                BlueprintName = "App_iOS"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -33,7 +33,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_193BAF154270D1C21E269EDF2A1BD3F6"
+               BlueprintIdentifier = "DC2F16BAA6E13B44AB62F8887D4CE3FA"
                BuildableName = "App_iOS_Tests.xctest"
                BlueprintName = "App_iOS_Tests"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -43,7 +43,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_D4BAEEEC88124103C8DFF41FCE206DCE"
+               BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA9A22DB35"
                BuildableName = "App_iOS_UITests.xctest"
                BlueprintName = "App_iOS_UITests"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -53,7 +53,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -86,7 +86,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -115,7 +115,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+               BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
                BuildableName = "App_iOS.app"
                BlueprintName = "App_iOS"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -33,7 +33,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_193BAF154270D1C21E269EDF2A1BD3F6"
+               BlueprintIdentifier = "DC2F16BAA6E13B44AB62F8887D4CE3FA"
                BuildableName = "App_iOS_Tests.xctest"
                BlueprintName = "App_iOS_Tests"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -43,7 +43,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_D4BAEEEC88124103C8DFF41FCE206DCE"
+               BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA9A22DB35"
                BuildableName = "App_iOS_UITests.xctest"
                BlueprintName = "App_iOS_UITests"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -53,7 +53,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -86,7 +86,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -115,7 +115,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+               BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
                BuildableName = "App_iOS.app"
                BlueprintName = "App_iOS"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -33,7 +33,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_193BAF154270D1C21E269EDF2A1BD3F6"
+               BlueprintIdentifier = "DC2F16BAA6E13B44AB62F8887D4CE3FA"
                BuildableName = "App_iOS_Tests.xctest"
                BlueprintName = "App_iOS_Tests"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -43,7 +43,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_D4BAEEEC88124103C8DFF41FCE206DCE"
+               BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA9A22DB35"
                BuildableName = "App_iOS_UITests.xctest"
                BlueprintName = "App_iOS_UITests"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -53,7 +53,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -86,7 +86,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -115,7 +115,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_BEB0891E36797FE2214A0A9D516D408D"
+            BlueprintIdentifier = "0867B0DACEF28C11442DE8F70C48D1AC"
             BuildableName = "App_iOS.app"
             BlueprintName = "App_iOS"
             ReferencedContainer = "container:Project.xcodeproj">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_watchOS.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_watchOS.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_38A9FE87056942A2746E0FF025B52A91"
+               BlueprintIdentifier = "208179651927D1138D19B5AD54E29D2B"
                BuildableName = "App_watchOS.app"
                BlueprintName = "App_watchOS"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -32,7 +32,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_38A9FE87056942A2746E0FF025B52A91"
+            BlueprintIdentifier = "208179651927D1138D19B5AD54E29D2B"
             BuildableName = "App_watchOS.app"
             BlueprintName = "App_watchOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -57,7 +57,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_38A9FE87056942A2746E0FF025B52A91"
+            BlueprintIdentifier = "208179651927D1138D19B5AD54E29D2B"
             BuildableName = "App_watchOS.app"
             BlueprintName = "App_watchOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -78,7 +78,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_38A9FE87056942A2746E0FF025B52A91"
+            BlueprintIdentifier = "208179651927D1138D19B5AD54E29D2B"
             BuildableName = "App_watchOS.app"
             BlueprintName = "App_watchOS"
             ReferencedContainer = "container:Project.xcodeproj">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
@@ -14,7 +14,7 @@
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "NT_7D108AE86BED8C9CCF52C2646FA4C5DE"
+                     BlueprintIdentifier = "AE3F93DB94E7208F2F1D9A78B91C1BC8"
                      BuildableName = "Framework.framework"
                      BlueprintName = "Framework_iOS"
                      ReferencedContainer = "container:Project.xcodeproj">
@@ -32,7 +32,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_7D108AE86BED8C9CCF52C2646FA4C5DE"
+               BlueprintIdentifier = "AE3F93DB94E7208F2F1D9A78B91C1BC8"
                BuildableName = "Framework.framework"
                BlueprintName = "Framework_iOS"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -51,7 +51,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_7D108AE86BED8C9CCF52C2646FA4C5DE"
+            BlueprintIdentifier = "AE3F93DB94E7208F2F1D9A78B91C1BC8"
             BuildableName = "Framework.framework"
             BlueprintName = "Framework_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -75,7 +75,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_7D108AE86BED8C9CCF52C2646FA4C5DE"
+            BlueprintIdentifier = "AE3F93DB94E7208F2F1D9A78B91C1BC8"
             BuildableName = "Framework.framework"
             BlueprintName = "Framework_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -104,7 +104,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_7D108AE86BED8C9CCF52C2646FA4C5DE"
+            BlueprintIdentifier = "AE3F93DB94E7208F2F1D9A78B91C1BC8"
             BuildableName = "Framework.framework"
             BlueprintName = "Framework_iOS"
             ReferencedContainer = "container:Project.xcodeproj">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/iMessageApp.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/iMessageApp.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_6BD068FAAC6AA35C090C48147B94EC6E"
+               BlueprintIdentifier = "834F55973F05AC8A18144DB04FF6F2C7"
                BuildableName = "iMessageApp.app"
                BlueprintName = "iMessageApp"
                ReferencedContainer = "container:Project.xcodeproj">
@@ -32,7 +32,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_6BD068FAAC6AA35C090C48147B94EC6E"
+            BlueprintIdentifier = "834F55973F05AC8A18144DB04FF6F2C7"
             BuildableName = "iMessageApp.app"
             BlueprintName = "iMessageApp"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -57,7 +57,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_6BD068FAAC6AA35C090C48147B94EC6E"
+            BlueprintIdentifier = "834F55973F05AC8A18144DB04FF6F2C7"
             BuildableName = "iMessageApp.app"
             BlueprintName = "iMessageApp"
             ReferencedContainer = "container:Project.xcodeproj">
@@ -78,7 +78,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_6BD068FAAC6AA35C090C48147B94EC6E"
+            BlueprintIdentifier = "834F55973F05AC8A18144DB04FF6F2C7"
             BuildableName = "iMessageApp.app"
             BlueprintName = "iMessageApp"
             ReferencedContainer = "container:Project.xcodeproj">


### PR DESCRIPTION
This resolves #481.

Changes:
- Update `Package.resolved` to ensure the latest version of `xcodeproj` is being used.
- Handle the newly-added `.instrumentsPackage` case of `PBXProductType`

I didn't make the change in this PR, but it might be worth pinning the version of `xcodeproj` in the `Package.swift` file to prevent additional changes to that library from affecting this project.