### PR TITLE
Fixed bug occurs during generating empty directories

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -318,12 +318,13 @@ class SourceGenerator {
         return try dirPath.children()
             .filter {
                 if $0.isDirectory {
-                    if project.options.generateEmptyDirectories {
-                        return true    
-                    } else {
-                        let children = try $0.children().filter(isIncludedPath)
-                        return !children.isEmpty
+                    let children = try $0.children()
+                    
+                    if children.isEmpty {
+                        return project.options.generateEmptyDirectories
                     }
+                    
+                    return !children.filter(isIncludedPath).isEmpty
                 } else if $0.isFile {
                     return isIncludedPath($0)
                 } else {

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -277,33 +277,39 @@ class SourceGeneratorTests: XCTestCase {
                 ]
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: [TargetSource(path: "Sources", excludes: excludes)])
-                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
-
-                let pbxProj = try project.generatePbxProj()
-                try pbxProj.expectFile(paths: ["Sources", "A", "a.swift"])
-                try pbxProj.expectFile(paths: ["Sources", "D", "d.h"])
-                try pbxProj.expectFile(paths: ["Sources", "D", "d.m"])
-                try pbxProj.expectFile(paths: ["Sources", "E", "e.jpg"])
-                try pbxProj.expectFile(paths: ["Sources", "E", "e.m"])
-                try pbxProj.expectFile(paths: ["Sources", "E", "e.h"])
-                try pbxProj.expectFile(paths: ["Sources", "types", "a.swift"])
-                try pbxProj.expectFile(paths: ["Sources", "numbers", "file1.a"])
-                try pbxProj.expectFile(paths: ["Sources", "numbers", "file4.a"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "B", "b.swift"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "E", "F", "f.swift"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "G", "H", "h.swift"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "types", "a.h"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "types", "a.x"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "numbers", "file2.a"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "numbers", "file3.a"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "partial", "file_part"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "a.ignored"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "ignore.file"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "project.xcodeproj"])
-                try pbxProj.expectFileMissing(paths: ["Sources", "a.playground"])
-                // not supported: "**/*.ignored"
-                // try pbxProj.expectFileMissing(paths: ["Sources", "A", "a.ignored"])
-                // try pbxProj.expectFileMissing(paths: ["Sources", "A", "B", "b.ignored"])
+                
+                func test(generateEmptyDirectories: Bool) throws {
+                    let options = SpecOptions(generateEmptyDirectories: true)
+                    let project = Project(basePath: directoryPath, name: "Test", targets: [target], options: options)
+                    let pbxProj = try project.generatePbxProj()
+                    try pbxProj.expectFile(paths: ["Sources", "A", "a.swift"])
+                    try pbxProj.expectFile(paths: ["Sources", "D", "d.h"])
+                    try pbxProj.expectFile(paths: ["Sources", "D", "d.m"])
+                    try pbxProj.expectFile(paths: ["Sources", "E", "e.jpg"])
+                    try pbxProj.expectFile(paths: ["Sources", "E", "e.m"])
+                    try pbxProj.expectFile(paths: ["Sources", "E", "e.h"])
+                    try pbxProj.expectFile(paths: ["Sources", "types", "a.swift"])
+                    try pbxProj.expectFile(paths: ["Sources", "numbers", "file1.a"])
+                    try pbxProj.expectFile(paths: ["Sources", "numbers", "file4.a"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "B", "b.swift"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "E", "F", "f.swift"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "G", "H", "h.swift"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "types", "a.h"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "types", "a.x"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "numbers", "file2.a"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "numbers", "file3.a"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "partial", "file_part"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "a.ignored"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "ignore.file"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "project.xcodeproj"])
+                    try pbxProj.expectFileMissing(paths: ["Sources", "a.playground"])
+                    // not supported: "**/*.ignored"
+                    // try pbxProj.expectFileMissing(paths: ["Sources", "A", "a.ignored"])
+                    // try pbxProj.expectFileMissing(paths: ["Sources", "A", "B", "b.ignored"])
+                }
+                
+                try test(generateEmptyDirectories: false)
+                try test(generateEmptyDirectories: true)
             }
 
             $0.it("generates file sources") {

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -279,7 +279,7 @@ class SourceGeneratorTests: XCTestCase {
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: [TargetSource(path: "Sources", excludes: excludes)])
                 
                 func test(generateEmptyDirectories: Bool) throws {
-                    let options = SpecOptions(generateEmptyDirectories: true)
+                    let options = SpecOptions(generateEmptyDirectories: generateEmptyDirectories)
                     let project = Project(basePath: directoryPath, name: "Test", targets: [target], options: options)
                     let pbxProj = try project.generatePbxProj()
                     try pbxProj.expectFile(paths: ["Sources", "A", "a.swift"])


### PR DESCRIPTION
I understood why the tests didn't pass in PR #480. I broke the feature of excluding sources, but now I fixed it, so you can review it.