### PR TITLE
Fix writing to a project path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Added
 - Added new ability to generate empty directories via `options.generateEmptyDirectories` [#480](https://github.com/yonaskolb/XcodeGen/pull/480) @Beniamiiin
 
+#### Fixed
+- Fixed writing project file to specified directory path [#487](https://github.com/yonaskolb/XcodeGen/pull/487) @monowerker
+
 ## 2.1.0
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Added new ability to generate empty directories via `options.generateEmptyDirectories` [#480](https://github.com/yonaskolb/XcodeGen/pull/480) @Beniamiiin
 
 #### Fixed
-- Fixed writing project file to specified directory path [#487](https://github.com/yonaskolb/XcodeGen/pull/487) @monowerker
+- Fixed `--project` argument not taking effect [#487](https://github.com/yonaskolb/XcodeGen/pull/487) @monowerker
 
 ## 2.1.0
 

--- a/Sources/XcodeGenKit/FileWriter.swift
+++ b/Sources/XcodeGenKit/FileWriter.swift
@@ -12,7 +12,7 @@ public class FileWriter {
     }
 
     public func writeXcodeProject(_ xcodeProject: XcodeProj, to projectPath: Path? = nil) throws {
-        let projectPath = project.defaultProjectPath
+        let projectPath = projectPath ?? project.defaultProjectPath
         let tempPath = try Path.processUniqueTemporary() + "XcodeGen"
         try? tempPath.delete()
         if projectPath.exists {


### PR DESCRIPTION
Looks like current `master` (and version 2.1.0) disregards the `projectPath` argument when writing the Xcode project, and always uses  `defaultProjectPath`. This PR make it so `defaultProjectPath` is only used if the `projectPath` argument is `nil`.