### PR TITLE
Spec file relative directory expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Added support for the `instrumentsPackage` product type [#482](https://github.com/yonaskolb/XcodeGen/pull/482) @ksulliva
 - Added support for `inputFileLists` and `outputFileLists` within project build scripts [#500](https://github.com/yonaskolb/XcodeGen/pull/500) @lukewakeford
 
+#### Changed
+- **BREAKING** All the paths within included files are now relative to that file and not the root spec. This can be disabled with a `relativePaths: false` on the include. See [docs](https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#include) for more details [#489](https://github.com/yonaskolb/XcodeGen/pull/489) @ellneal
+
 #### Fixed
 - Fixed `--project` argument not taking effect [#487](https://github.com/yonaskolb/XcodeGen/pull/487) @monowerker
 - Fixed Sticker Packs from generating an empty Source file phase which caused in error in the new build system [#492](https://github.com/yonaskolb/XcodeGen/pull/492) @rpassis

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -45,7 +45,22 @@ Required properties are marked with checkbox. Some of the YAML examples don't sh
 
 One or more specs can be included in the project spec. This can be used to split your project spec into multiple files, for easier structuring or sharing between multiple specs. Included specs can also include other specs and so on.
 
-Include can either be a list of string paths or a single string path. They will be merged in order and then the current spec will be merged on top.
+Include can either be a list of includes or a single include. They will be merged in order and then the current spec will be merged on top.
+
+An include can be provided via a string (the path) or an object of the form:
+
+**Include Object**
+
+- [x] **path**: **String** - The path to the included file.
+- [ ] **useRelativePaths**: **Bool** - Dictates whether the included spec specifies paths relative to itself (the default) or the root spec file.
+
+```yaml
+include:
+  - includedFile.yml
+  - path: path/to/includedFile.yml
+    useRelativePaths: false
+```
+
 By default specs are merged additively. That is for every value:
 
 - if existing value and new value are both dictionaries merge them and continue down the hierachy

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -52,13 +52,13 @@ An include can be provided via a string (the path) or an object of the form:
 **Include Object**
 
 - [x] **path**: **String** - The path to the included file.
-- [ ] **useRelativePaths**: **Bool** - Dictates whether the included spec specifies paths relative to itself (the default) or the root spec file.
+- [ ] **relativePaths**: **Bool** - Dictates whether the included spec specifies paths relative to itself (the default) or the root spec file.
 
 ```yaml
 include:
   - includedFile.yml
   - path: path/to/includedFile.yml
-    useRelativePaths: false
+    relativePaths: false
 ```
 
 By default specs are merged additively. That is for every value:

--- a/Sources/ProjectSpec/AggregateTarget.swift
+++ b/Sources/ProjectSpec/AggregateTarget.swift
@@ -1,6 +1,6 @@
 import Foundation
 import JSONUtilities
-import struct PathKit.Path
+import PathKit
 
 public struct AggregateTarget: ProjectTarget {
     public var name: String

--- a/Sources/ProjectSpec/AggregateTarget.swift
+++ b/Sources/ProjectSpec/AggregateTarget.swift
@@ -1,5 +1,6 @@
 import Foundation
 import JSONUtilities
+import struct PathKit.Path
 
 public struct AggregateTarget: ProjectTarget {
     public var name: String
@@ -59,5 +60,19 @@ extension AggregateTarget: NamedJSONDictionaryConvertible {
         buildScripts = jsonDictionary.json(atKeyPath: "buildScripts") ?? []
         scheme = jsonDictionary.json(atKeyPath: "scheme")
         attributes = jsonDictionary.json(atKeyPath: "attributes") ?? [:]
+    }
+}
+
+extension AggregateTarget: PathContaining {
+
+    static func expandPaths(for source: [String: JSONDictionary], relativeTo path: Path) -> [String: JSONDictionary] {
+        var result = source
+
+        for (targetName, var target) in result {
+            target = expandStringPaths(from: target, forKey: "configFiles", relativeTo: path)
+            target = expandChildPaths(from: target, forKey: "buildScripts", relativeTo: path, type: BuildScript.self)
+            result[targetName] = target
+        }
+        return result
     }
 }

--- a/Sources/ProjectSpec/AggregateTarget.swift
+++ b/Sources/ProjectSpec/AggregateTarget.swift
@@ -1,6 +1,5 @@
 import Foundation
 import JSONUtilities
-import PathKit
 
 public struct AggregateTarget: ProjectTarget {
     public var name: String

--- a/Sources/ProjectSpec/AggregateTarget.swift
+++ b/Sources/ProjectSpec/AggregateTarget.swift
@@ -63,7 +63,7 @@ extension AggregateTarget: NamedJSONDictionaryConvertible {
     }
 }
 
-extension AggregateTarget: PathContaining {
+extension AggregateTarget: PathContainer {
 
     static func expandPaths(for source: [String: JSONDictionary], relativeTo path: Path) -> [String: JSONDictionary] {
         var result = source

--- a/Sources/ProjectSpec/AggregateTarget.swift
+++ b/Sources/ProjectSpec/AggregateTarget.swift
@@ -65,14 +65,12 @@ extension AggregateTarget: NamedJSONDictionaryConvertible {
 
 extension AggregateTarget: PathContainer {
 
-    static func expandPaths(for source: [String: JSONDictionary], relativeTo path: Path) -> [String: JSONDictionary] {
-        var result = source
-
-        for (targetName, var target) in result {
-            target = expandStringPaths(from: target, forKey: "configFiles", relativeTo: path)
-            target = expandChildPaths(from: target, forKey: "buildScripts", relativeTo: path, type: BuildScript.self)
-            result[targetName] = target
-        }
-        return result
+    static var pathProperties: [PathProperty] {
+        return [
+            .dictionary([
+                .string("configFiles"),
+                .object("buildScripts", BuildScript.pathProperties),
+            ]),
+        ]
     }
 }

--- a/Sources/ProjectSpec/BuildScript.swift
+++ b/Sources/ProjectSpec/BuildScript.swift
@@ -57,7 +57,9 @@ extension BuildScript: JSONObjectConvertible {
 
 extension BuildScript: PathContainer {
 
-    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
-        return expandStringPaths(from: source, forKey: "path", relativeTo: path)
+    static var pathProperties: [PathProperty] {
+        return [
+            .string("path"),
+        ]
     }
 }

--- a/Sources/ProjectSpec/BuildScript.swift
+++ b/Sources/ProjectSpec/BuildScript.swift
@@ -55,7 +55,7 @@ extension BuildScript: JSONObjectConvertible {
     }
 }
 
-extension BuildScript: PathContaining {
+extension BuildScript: PathContainer {
 
     static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
         return expandStringPaths(from: source, forKey: "path", relativeTo: path)

--- a/Sources/ProjectSpec/BuildScript.swift
+++ b/Sources/ProjectSpec/BuildScript.swift
@@ -1,5 +1,6 @@
 import Foundation
 import JSONUtilities
+import struct PathKit.Path
 
 public struct BuildScript: Equatable {
 
@@ -51,5 +52,12 @@ extension BuildScript: JSONObjectConvertible {
         shell = jsonDictionary.json(atKeyPath: "shell")
         runOnlyWhenInstalling = jsonDictionary.json(atKeyPath: "runOnlyWhenInstalling") ?? false
         showEnvVars = jsonDictionary.json(atKeyPath: "showEnvVars") ?? true
+    }
+}
+
+extension BuildScript: PathContaining {
+
+    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
+        return expandStringPaths(from: source, forKey: "path", relativeTo: path)
     }
 }

--- a/Sources/ProjectSpec/BuildScript.swift
+++ b/Sources/ProjectSpec/BuildScript.swift
@@ -1,6 +1,6 @@
 import Foundation
 import JSONUtilities
-import struct PathKit.Path
+import PathKit
 
 public struct BuildScript: Equatable {
 

--- a/Sources/ProjectSpec/BuildScript.swift
+++ b/Sources/ProjectSpec/BuildScript.swift
@@ -1,6 +1,5 @@
 import Foundation
 import JSONUtilities
-import PathKit
 
 public struct BuildScript: Equatable {
 

--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -74,7 +74,7 @@ extension Dependency: JSONObjectConvertible {
     }
 }
 
-extension Dependency: PathContaining {
+extension Dependency: PathContainer {
     
     static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
         return expandStringPaths(from: source, forKey: "framework", relativeTo: path)

--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -1,6 +1,5 @@
 import Foundation
 import JSONUtilities
-import PathKit
 
 public struct Dependency: Equatable {
 

--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -1,5 +1,6 @@
 import Foundation
 import JSONUtilities
+import struct PathKit.Path
 
 public struct Dependency: Equatable {
 
@@ -70,5 +71,12 @@ extension Dependency: JSONObjectConvertible {
         if let bool: Bool = jsonDictionary.json(atKeyPath: "weak") {
             weakLink = bool
         }
+    }
+}
+
+extension Dependency: PathContaining {
+    
+    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
+        return expandStringPaths(from: source, forKey: "framework", relativeTo: path)
     }
 }

--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -75,8 +75,10 @@ extension Dependency: JSONObjectConvertible {
 }
 
 extension Dependency: PathContainer {
-    
-    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
-        return expandStringPaths(from: source, forKey: "framework", relativeTo: path)
+
+    static var pathProperties: [PathProperty] {
+        return [
+            .string("framework"),
+        ]
     }
 }

--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -1,6 +1,6 @@
 import Foundation
 import JSONUtilities
-import struct PathKit.Path
+import PathKit
 
 public struct Dependency: Equatable {
 

--- a/Sources/ProjectSpec/PathContainer.swift
+++ b/Sources/ProjectSpec/PathContainer.swift
@@ -14,6 +14,7 @@ enum PathProperty {
 }
 
 extension Array where Element == PathProperty {
+    
     func resolvingPaths(in jsonDictionary: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
         var result = jsonDictionary
 

--- a/Sources/ProjectSpec/PathContainer.swift
+++ b/Sources/ProjectSpec/PathContainer.swift
@@ -1,0 +1,49 @@
+import Foundation
+import JSONUtilities
+import PathKit
+
+protocol PathContainer {
+
+    static var pathProperties: [PathProperty] { get }
+}
+
+enum PathProperty {
+    case string(String)
+    case dictionary([PathProperty])
+    case object(String, [PathProperty])
+}
+
+extension Array where Element == PathProperty {
+    func resolvingPaths(in jsonDictionary: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
+        var result = jsonDictionary
+
+        for pathProperty in self {
+            switch pathProperty {
+            case .string(let key):
+                if let source = result[key] as? String {
+                    result[key] = (path + source).string
+                } else if let source = result[key] as? [String] {
+                    result[key] = source.map { (path + $0).string }
+                } else if let source = result[key] as? [String: String] {
+                    result[key] = source.mapValues { (path + $0).string }
+                }
+            case .dictionary(let pathProperties):
+                for (key, dictionary) in result {
+                    if let source = dictionary as? JSONDictionary {
+                        result[key] = pathProperties.resolvingPaths(in: source, relativeTo: path)
+                    }
+                }
+            case .object(let key, let pathProperties):
+                if let source = result[key] as? JSONDictionary {
+                    result[key] = pathProperties.resolvingPaths(in: source, relativeTo: path)
+                } else if let source = result[key] as? [JSONDictionary] {
+                    result[key] = source.map { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
+                } else if let source = result[key] as? [String: JSONDictionary] {
+                    result[key] = source.mapValues { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
+                }
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/ProjectSpec/Plist.swift
+++ b/Sources/ProjectSpec/Plist.swift
@@ -26,7 +26,7 @@ extension Plist: JSONObjectConvertible {
     }
 }
 
-extension Plist: PathContaining {
+extension Plist: PathContainer {
     static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
         return expandStringPaths(from: source, forKey: "path", relativeTo: path)
     }

--- a/Sources/ProjectSpec/Plist.swift
+++ b/Sources/ProjectSpec/Plist.swift
@@ -1,6 +1,5 @@
 import Foundation
 import JSONUtilities
-import PathKit
 
 public struct Plist: Equatable {
 

--- a/Sources/ProjectSpec/Plist.swift
+++ b/Sources/ProjectSpec/Plist.swift
@@ -1,6 +1,6 @@
 import Foundation
 import JSONUtilities
-import struct PathKit.Path
+import PathKit
 
 public struct Plist: Equatable {
 

--- a/Sources/ProjectSpec/Plist.swift
+++ b/Sources/ProjectSpec/Plist.swift
@@ -1,5 +1,6 @@
 import Foundation
 import JSONUtilities
+import struct PathKit.Path
 
 public struct Plist: Equatable {
 
@@ -22,5 +23,11 @@ extension Plist: JSONObjectConvertible {
     public init(jsonDictionary: JSONDictionary) throws {
         path = try jsonDictionary.json(atKeyPath: "path")
         properties = jsonDictionary.json(atKeyPath: "properties") ?? [:]
+    }
+}
+
+extension Plist: PathContaining {
+    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
+        return expandStringPaths(from: source, forKey: "path", relativeTo: path)
     }
 }

--- a/Sources/ProjectSpec/Plist.swift
+++ b/Sources/ProjectSpec/Plist.swift
@@ -27,7 +27,10 @@ extension Plist: JSONObjectConvertible {
 }
 
 extension Plist: PathContainer {
-    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
-        return expandStringPaths(from: source, forKey: "path", relativeTo: path)
+
+    static var pathProperties: [PathProperty] {
+        return [
+            .string("path"),
+        ]
     }
 }

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -132,6 +132,12 @@ extension Project: Equatable {
 
 extension Project {
 
+    @available(*, deprecated, message: "Use `Project.Spec` and `init(spec:basePath:)`.")
+    public init(basePath: Path, jsonDictionary: JSONDictionary) throws {
+        let spec = Project.Spec(relativePath: Path(), jsonDictionary: jsonDictionary)
+        try self.init(spec: spec, basePath: basePath)
+    }
+
     public init(spec: Spec, basePath: Path) throws {
         self.basePath = basePath
 

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -175,7 +175,7 @@ extension Project {
     }
 }
 
-extension Project: PathContaining {
+extension Project: PathContainer {
 
     static func expandPaths(for spec: Spec, relativeTo basePath: Path = Path()) -> Spec {
         let relativePath = (basePath + spec.relativePath).normalize()

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -135,6 +135,7 @@ extension Project {
     public init(spec: Spec, basePath: Path) throws {
         self.basePath = basePath
 
+        let spec = Project.expandPaths(for: spec)
         let jsonDictionary = try Project.resolveProject(jsonDictionary: spec.resolvedDictionary())
 
         name = try jsonDictionary.json(atKeyPath: "name")

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -177,7 +177,7 @@ extension Project {
 
 extension Project: PathContaining {
 
-    static func expandPaths(for spec: Spec, relativeTo basePath: Path = "") -> Spec {
+    static func expandPaths(for spec: Spec, relativeTo basePath: Path = Path()) -> Spec {
         let relativePath = (basePath + spec.relativePath).normalize()
         guard relativePath != Path() else {
             return spec

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -133,7 +133,7 @@ extension Project: Equatable {
 extension Project {
 
     public init(basePath: Path, jsonDictionary: JSONDictionary) throws {
-        let spec = Project.Spec(relativePath: Path(), jsonDictionary: jsonDictionary)
+        let spec = Spec(relativePath: Path(), jsonDictionary: jsonDictionary)
         try self.init(spec: spec, basePath: basePath)
     }
 

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -140,7 +140,7 @@ extension Project {
     public init(spec: Spec, basePath: Path) throws {
         self.basePath = basePath
 
-        let spec = Project.expandPaths(for: spec)
+        let spec = spec.resolvingPaths()
         let jsonDictionary = try Project.resolveProject(jsonDictionary: spec.resolvedDictionary())
 
         name = try jsonDictionary.json(atKeyPath: "name")
@@ -183,59 +183,6 @@ extension Project: PathContainer {
             .object("targets", Target.pathProperties),
             .object("aggregateTargets", AggregateTarget.pathProperties),
         ]
-    }
-}
-
-extension Project {
-
-    static func expandPaths(for spec: Spec, relativeTo basePath: Path = Path()) -> Spec {
-        let relativePath = (basePath + spec.relativePath).normalize()
-        guard relativePath != Path() else {
-            return spec
-        }
-
-        let jsonDictionary = expandPaths(Project.pathProperties, in: spec.jsonDictionary, relativeTo: relativePath)
-
-        return Spec(
-            relativePath: spec.relativePath,
-            jsonDictionary: jsonDictionary,
-            subSpecs: spec.subSpecs.map { template in
-                return Project.expandPaths(for: template, relativeTo: relativePath)
-            }
-        )
-    }
-
-    private static func expandPaths(_ pathProperties: [PathProperty], in jsonDictionary: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
-        var result = jsonDictionary
-
-        for pathProperty in pathProperties {
-            switch pathProperty {
-            case .string(let key):
-                if let source = result[key] as? String {
-                    result[key] = (path + source).string
-                } else if let source = result[key] as? [String] {
-                    result[key] = source.map { (path + $0).string }
-                } else if let source = result[key] as? [String: String] {
-                    result[key] = source.mapValues { (path + $0).string }
-                }
-            case .dictionary(let pathProperties):
-                for (key, dictionary) in result {
-                    if let source = dictionary as? JSONDictionary {
-                        result[key] = expandPaths(pathProperties, in: source, relativeTo: path)
-                    }
-                }
-            case .object(let key, let pathProperties):
-                if let source = result[key] as? JSONDictionary {
-                    result[key] = expandPaths(pathProperties, in: source, relativeTo: path)
-                } else if let source = result[key] as? [JSONDictionary] {
-                    result[key] = source.map { expandPaths(pathProperties, in: $0, relativeTo: path) }
-                } else if let source = result[key] as? [String: JSONDictionary] {
-                    result[key] = source.mapValues { expandPaths(pathProperties, in: $0, relativeTo: path) }
-                }
-            }
-        }
-
-        return result
     }
 }
 

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -132,7 +132,6 @@ extension Project: Equatable {
 
 extension Project {
 
-    @available(*, deprecated, message: "Use `Project.Spec` and `init(spec:basePath:)`.")
     public init(basePath: Path, jsonDictionary: JSONDictionary) throws {
         let spec = Project.Spec(relativePath: Path(), jsonDictionary: jsonDictionary)
         try self.init(spec: spec, basePath: basePath)

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -132,9 +132,11 @@ extension Project: Equatable {
 
 extension Project {
 
-    public init(basePath: Path, jsonDictionary: JSONDictionary) throws {
+    public init(spec: Spec, basePath: Path) throws {
         self.basePath = basePath
-        let jsonDictionary = try Project.resolveProject(jsonDictionary: jsonDictionary)
+
+        let jsonDictionary = try Project.resolveProject(jsonDictionary: spec.resolvedDictionary())
+
         name = try jsonDictionary.json(atKeyPath: "name")
         settings = jsonDictionary.json(atKeyPath: "settings") ?? .empty
         settingGroups = jsonDictionary.json(atKeyPath: "settingGroups")

--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -35,7 +35,7 @@ extension Project {
                 if let option = option as? String {
                     return (option, true)
                 } else if let option = option as? JSONDictionary, let path = option["path"] as? String {
-                    return (path, (option["useRelativePaths"] as? Bool) ?? true)
+                    return (path, (option["relativePaths"] as? Bool) ?? true)
                 }
                 return nil
             }

--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -1,0 +1,90 @@
+import Foundation
+import typealias JSONUtilities.JSONDictionary
+import PathKit
+
+extension Project {
+
+    public struct Spec {
+        public let relativePath: Path
+        public let jsonDictionary: JSONDictionary
+        public let subSpecs: [Spec]
+
+        public init(relativePath: Path, jsonDictionary: JSONDictionary, subSpecs: [Spec] = []) {
+            self.relativePath = relativePath
+            self.jsonDictionary = jsonDictionary
+            self.subSpecs = subSpecs
+        }
+
+        public init(filename: String, basePath: Path, relativePath: Path = "") throws {
+            let path = basePath + relativePath + filename
+
+            // Depending on the extension we will either load the file as YAML or JSON
+            var json: [String: Any]
+            if path.extension?.lowercased() == "json" {
+                let data: Data = try path.read()
+                let jsonData = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+                guard let jsonDictionary = jsonData as? [String: Any] else {
+                    fatalError("Invalid JSON at path \(path)")
+                }
+                json = jsonDictionary
+            } else {
+                json = try loadYamlDictionary(path: path)
+            }
+
+            var includeStrings: [String]
+            if let includeString = json["include"] as? String {
+                includeStrings = [includeString]
+            } else if let includeArray = json["include"] as? [String] {
+                includeStrings = includeArray
+            } else {
+                includeStrings = []
+            }
+
+            let includes = try includeStrings.map { include -> Spec in
+                let path = Path(include)
+                return try Spec(filename: path.lastComponent, basePath: basePath + relativePath, relativePath: path.parent())
+            }
+
+            self.relativePath = relativePath
+            self.jsonDictionary = json
+            self.subSpecs = includes
+        }
+
+        public func resolvedDictionary() -> JSONDictionary {
+            return jsonDictionary.merged(onto:
+                subSpecs
+                    .map { $0.resolvedDictionary() }
+                    .reduce([:]) { $1.merged(onto: $0) }
+            )
+        }
+    }
+}
+
+internal protocol SubSequenceConvertible: Sequence {
+
+    init(_ subsequence: SubSequence)
+}
+
+extension String: SubSequenceConvertible { }
+extension Substring: SubSequenceConvertible { }
+
+extension Dictionary where Key: StringProtocol, Key: SubSequenceConvertible, Value: Any {
+
+    func merged(onto other: Dictionary<Key, Value>) -> Dictionary<Key, Value> {
+        var merged = other
+
+        for (key, value) in self {
+            if key.hasSuffix(":REPLACE") {
+                let newKey = key[key.startIndex ..< key.index(key.endIndex, offsetBy: -8)]
+                merged[Key(newKey)] = value
+            } else if let dictionary = value as? Dictionary<Key, Value>, let base = merged[key] as? Dictionary<Key, Value> {
+                merged[key] = dictionary.merged(onto: base) as? Value
+            } else if let array = value as? [Any], let base = merged[key] as? [Any] {
+                merged[key] = (base + array) as? Value
+            } else {
+                merged[key] = value
+            }
+        }
+        return merged
+    }
+}

--- a/Sources/ProjectSpec/ProjectSpec.swift
+++ b/Sources/ProjectSpec/ProjectSpec.swift
@@ -72,15 +72,7 @@ extension Project {
     }
 }
 
-internal protocol SubSequenceConvertible: Sequence {
-
-    init(_ subsequence: SubSequence)
-}
-
-extension String: SubSequenceConvertible { }
-extension Substring: SubSequenceConvertible { }
-
-extension Dictionary where Key: StringProtocol, Key: SubSequenceConvertible, Value: Any {
+extension Dictionary where Key == String, Value: Any {
 
     func merged(onto other: Dictionary<Key, Value>) -> Dictionary<Key, Value> {
         var merged = other

--- a/Sources/ProjectSpec/Settings.swift
+++ b/Sources/ProjectSpec/Settings.swift
@@ -101,24 +101,6 @@ extension Dictionary where Key == String, Value: Any {
     }
 }
 
-func merge(dictionary: JSONDictionary, onto base: JSONDictionary) -> JSONDictionary {
-    var merged = base
-
-    for (key, value) in dictionary {
-        if key.hasSuffix(":REPLACE") {
-            let newKey = key.replacingOccurrences(of: ":REPLACE", with: "")
-            merged[newKey] = value
-        } else if let dictionary = value as? JSONDictionary, let base = merged[key] as? JSONDictionary {
-            merged[key] = merge(dictionary: dictionary, onto: base)
-        } else if let array = value as? [Any], let base = merged[key] as? [Any] {
-            merged[key] = base + array
-        } else {
-            merged[key] = value
-        }
-    }
-    return merged
-}
-
 public func += (lhs: inout BuildSettings, rhs: BuildSettings?) {
     guard let rhs = rhs else { return }
     lhs.merge(rhs)

--- a/Sources/ProjectSpec/Spec.swift
+++ b/Sources/ProjectSpec/Spec.swift
@@ -70,6 +70,7 @@ public struct Spec {
 }
 
 extension Spec {
+    
     func resolvingPaths(relativeTo basePath: Path = Path()) -> Spec {
         let relativePath = (basePath + self.relativePath).normalize()
         guard relativePath != Path() else {

--- a/Sources/ProjectSpec/Spec.swift
+++ b/Sources/ProjectSpec/Spec.swift
@@ -88,41 +88,6 @@ extension Spec {
     }
 }
 
-extension Array where Element == PathProperty {
-    func resolvingPaths(in jsonDictionary: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
-        var result = jsonDictionary
-
-        for pathProperty in self {
-            switch pathProperty {
-            case .string(let key):
-                if let source = result[key] as? String {
-                    result[key] = (path + source).string
-                } else if let source = result[key] as? [String] {
-                    result[key] = source.map { (path + $0).string }
-                } else if let source = result[key] as? [String: String] {
-                    result[key] = source.mapValues { (path + $0).string }
-                }
-            case .dictionary(let pathProperties):
-                for (key, dictionary) in result {
-                    if let source = dictionary as? JSONDictionary {
-                        result[key] = pathProperties.resolvingPaths(in: source, relativeTo: path)
-                    }
-                }
-            case .object(let key, let pathProperties):
-                if let source = result[key] as? JSONDictionary {
-                    result[key] = pathProperties.resolvingPaths(in: source, relativeTo: path)
-                } else if let source = result[key] as? [JSONDictionary] {
-                    result[key] = source.map { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
-                } else if let source = result[key] as? [String: JSONDictionary] {
-                    result[key] = source.mapValues { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
-                }
-            }
-        }
-
-        return result
-    }
-}
-
 extension Dictionary where Key == String, Value: Any {
 
     func merged(onto other: Dictionary<Key, Value>) -> Dictionary<Key, Value> {

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -11,3 +11,47 @@ extension Project {
         try self.init(spec: template, basePath: basePath)
     }
 }
+
+protocol PathContaining {
+
+    associatedtype JSONSourceType
+    static func expandPaths(for source: JSONSourceType, relativeTo path: Path) -> JSONSourceType
+}
+
+extension PathContaining {
+
+    static func expandStringPaths(from source: JSONDictionary, forKey key: String, relativeTo path: Path) -> JSONDictionary {
+        var result = source
+
+        if let source = result[key] as? String {
+            result[key] = (path + source).string
+        } else if let source = result[key] as? [String] {
+            result[key] = source.map { (path + $0).string }
+        } else if let source = result[key] as? [String: String] {
+            result[key] = source.mapValues { (path + $0).string }
+        }
+        return result
+    }
+    
+    static func expandChildPaths<T: PathContaining>(from source: JSONDictionary, forKey key: String, relativeTo path: Path, type: T.Type) -> JSONDictionary {
+        var result = source
+
+        if let source = result[key] as? T.JSONSourceType {
+            result[key] = T.expandPaths(for: source, relativeTo: path)
+        } else if let source = result[key] as? [T.JSONSourceType] {
+            result[key] = source.map { T.expandPaths(for: $0, relativeTo: path) }
+        } else if let source = result[key] as? [String: T.JSONSourceType] {
+            result[key] = source.mapValues { T.expandPaths(for: $0, relativeTo: path) }
+        }
+        return result
+    }
+
+    static func expandChildPaths<T: PathContaining>(from source: JSONDictionary, forPotentialKeys keys: [String], relativeTo path: Path, type: T.Type) -> JSONDictionary {
+        var result = source
+
+        for key in keys {
+            result = expandChildPaths(from: result, forKey: key, relativeTo: path, type: type)
+        }
+        return result
+    }
+}

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -10,6 +10,11 @@ extension Project {
         let template = try Spec(filename: path.lastComponent, basePath: basePath)
         try self.init(spec: template, basePath: basePath)
     }
+
+    @available(*, deprecated, message: "Use `Project.Spec` for loading files from disk.")
+    public static func loadDictionary(path: Path) throws -> JSONDictionary {
+        return try Project.Spec(filename: path.lastComponent, basePath: path.parent()).jsonDictionary
+    }
 }
 
 protocol PathContaining {

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -6,46 +6,8 @@ import Yams
 extension Project {
     
     public init(path: Path) throws {
-        let dictionary = try Project.loadDictionary(path: path)
-        try self.init(basePath: path.parent(), jsonDictionary: dictionary)
-    }
-
-    public static func loadDictionary(path: Path) throws -> JSONDictionary {
-
-        // Depending on the extension we will either load the file as YAML or JSON
-        var json: [String: Any]
-        if path.extension?.lowercased() == "json" {
-            let data: Data = try path.read()
-            let jsonData = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-            guard let jsonDictionary = jsonData as? [String: Any] else {
-                fatalError("Invalid JSON at path \(path)")
-            }
-            json = jsonDictionary
-        } else {
-            json = try loadYamlDictionary(path: path)
-        }
-
-        var includes: [String]
-        if let includeString = json["include"] as? String {
-            includes = [includeString]
-        } else if let includeArray = json["include"] as? [String] {
-            includes = includeArray
-        } else {
-            includes = []
-        }
-
-        if !includes.isEmpty {
-            var includeDictionary: JSONDictionary = [:]
-            for include in includes {
-                let includePath = path.parent() + include
-                let dictionary = try loadDictionary(path: includePath)
-                includeDictionary = merge(dictionary: dictionary, onto: includeDictionary)
-            }
-            json = merge(dictionary: json, onto: includeDictionary)
-        }
-
-        return json
-    }
-
+        let basePath = path.parent()
+        let template = try Spec(filename: path.lastComponent, basePath: basePath)
+        try self.init(spec: template, basePath: basePath)
     }
 }

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -19,44 +19,11 @@ extension Project {
 
 protocol PathContainer {
 
-    associatedtype JSONSourceType
-    static func expandPaths(for source: JSONSourceType, relativeTo path: Path) -> JSONSourceType
+    static var pathProperties: [PathProperty] { get }
 }
 
-extension PathContainer {
-
-    static func expandStringPaths(from source: JSONDictionary, forKey key: String, relativeTo path: Path) -> JSONDictionary {
-        var result = source
-
-        if let source = result[key] as? String {
-            result[key] = (path + source).string
-        } else if let source = result[key] as? [String] {
-            result[key] = source.map { (path + $0).string }
-        } else if let source = result[key] as? [String: String] {
-            result[key] = source.mapValues { (path + $0).string }
-        }
-        return result
-    }
-    
-    static func expandChildPaths<T: PathContainer>(from source: JSONDictionary, forKey key: String, relativeTo path: Path, type: T.Type) -> JSONDictionary {
-        var result = source
-
-        if let source = result[key] as? T.JSONSourceType {
-            result[key] = T.expandPaths(for: source, relativeTo: path)
-        } else if let source = result[key] as? [T.JSONSourceType] {
-            result[key] = source.map { T.expandPaths(for: $0, relativeTo: path) }
-        } else if let source = result[key] as? [String: T.JSONSourceType] {
-            result[key] = source.mapValues { T.expandPaths(for: $0, relativeTo: path) }
-        }
-        return result
-    }
-
-    static func expandChildPaths<T: PathContainer>(from source: JSONDictionary, forPotentialKeys keys: [String], relativeTo path: Path, type: T.Type) -> JSONDictionary {
-        var result = source
-
-        for key in keys {
-            result = expandChildPaths(from: result, forKey: key, relativeTo: path, type: type)
-        }
-        return result
-    }
+enum PathProperty {
+    case string(String)
+    case dictionary([PathProperty])
+    case object(String, [PathProperty])
 }

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -4,7 +4,7 @@ import PathKit
 import Yams
 
 extension Project {
-
+    
     public init(path: Path) throws {
         let dictionary = try Project.loadDictionary(path: path)
         try self.init(basePath: path.parent(), jsonDictionary: dictionary)
@@ -44,41 +44,8 @@ extension Project {
             json = merge(dictionary: json, onto: includeDictionary)
         }
 
-        let basePath = path.parent()
-        json = expandPaths(in: json, basePath: basePath)
-
         return json
     }
 
-    private static func expandPaths(in source: Dictionary<String, Any>, basePath: Path) -> Dictionary<String, Any> {
-        var result = source
-
-        for (key, value) in source {
-            if let value = value as? String {
-                result[key] = value.replacingOccurrences(of: "$(CURDIR)", with: basePath.string)
-            } else if let value = value as? Array<Any> {
-                result[key] = expandPaths(in: value, basePath: basePath)
-            } else if let value = value as? Dictionary<String, Any> {
-                result[key] = expandPaths(in: value, basePath: basePath)
-            }
-        }
-
-        return result
-    }
-
-    private static func expandPaths(in source: Array<Any>, basePath: Path) -> Array<Any> {
-        var result = source
-
-        for (index, value) in source.enumerated() {
-            if let value = value as? String {
-                result[index] = value.replacingOccurrences(of: "$(CURDIR)", with: basePath.string)
-            } else if let value = value as? Array<Any> {
-                result[index] = expandPaths(in: value, basePath: basePath)
-            } else if let value = value as? Dictionary<String, Any> {
-                result[index] = expandPaths(in: value, basePath: basePath)
-            }
-        }
-
-        return result
     }
 }

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -1,7 +1,6 @@
 import Foundation
 import JSONUtilities
 import PathKit
-import Yams
 
 extension Project {
 
@@ -13,51 +12,5 @@ extension Project {
 
     public static func loadDictionary(path: Path) throws -> JSONDictionary {
         return try Spec(filename: path.lastComponent, basePath: path.parent()).jsonDictionary
-    }
-}
-
-protocol PathContainer {
-
-    static var pathProperties: [PathProperty] { get }
-}
-
-enum PathProperty {
-    case string(String)
-    case dictionary([PathProperty])
-    case object(String, [PathProperty])
-}
-
-extension Array where Element == PathProperty {
-    func resolvingPaths(in jsonDictionary: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
-        var result = jsonDictionary
-
-        for pathProperty in self {
-            switch pathProperty {
-            case .string(let key):
-                if let source = result[key] as? String {
-                    result[key] = (path + source).string
-                } else if let source = result[key] as? [String] {
-                    result[key] = source.map { (path + $0).string }
-                } else if let source = result[key] as? [String: String] {
-                    result[key] = source.mapValues { (path + $0).string }
-                }
-            case .dictionary(let pathProperties):
-                for (key, dictionary) in result {
-                    if let source = dictionary as? JSONDictionary {
-                        result[key] = pathProperties.resolvingPaths(in: source, relativeTo: path)
-                    }
-                }
-            case .object(let key, let pathProperties):
-                if let source = result[key] as? JSONDictionary {
-                    result[key] = pathProperties.resolvingPaths(in: source, relativeTo: path)
-                } else if let source = result[key] as? [JSONDictionary] {
-                    result[key] = source.map { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
-                } else if let source = result[key] as? [String: JSONDictionary] {
-                    result[key] = source.mapValues { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
-                }
-            }
-        }
-
-        return result
     }
 }

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -12,7 +12,7 @@ extension Project {
     }
 
     public static func loadDictionary(path: Path) throws -> JSONDictionary {
-        return try Project.Spec(filename: path.lastComponent, basePath: path.parent()).jsonDictionary
+        return try Spec(filename: path.lastComponent, basePath: path.parent()).jsonDictionary
     }
 }
 

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -43,6 +43,42 @@ extension Project {
             }
             json = merge(dictionary: json, onto: includeDictionary)
         }
+
+        let basePath = path.parent()
+        json = expandPaths(in: json, basePath: basePath)
+
         return json
+    }
+
+    private static func expandPaths(in source: Dictionary<String, Any>, basePath: Path) -> Dictionary<String, Any> {
+        var result = source
+
+        for (key, value) in source {
+            if let value = value as? String {
+                result[key] = value.replacingOccurrences(of: "$(CURDIR)", with: basePath.string)
+            } else if let value = value as? Array<Any> {
+                result[key] = expandPaths(in: value, basePath: basePath)
+            } else if let value = value as? Dictionary<String, Any> {
+                result[key] = expandPaths(in: value, basePath: basePath)
+            }
+        }
+
+        return result
+    }
+
+    private static func expandPaths(in source: Array<Any>, basePath: Path) -> Array<Any> {
+        var result = source
+
+        for (index, value) in source.enumerated() {
+            if let value = value as? String {
+                result[index] = value.replacingOccurrences(of: "$(CURDIR)", with: basePath.string)
+            } else if let value = value as? Array<Any> {
+                result[index] = expandPaths(in: value, basePath: basePath)
+            } else if let value = value as? Dictionary<String, Any> {
+                result[index] = expandPaths(in: value, basePath: basePath)
+            }
+        }
+
+        return result
     }
 }

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -17,13 +17,13 @@ extension Project {
     }
 }
 
-protocol PathContaining {
+protocol PathContainer {
 
     associatedtype JSONSourceType
     static func expandPaths(for source: JSONSourceType, relativeTo path: Path) -> JSONSourceType
 }
 
-extension PathContaining {
+extension PathContainer {
 
     static func expandStringPaths(from source: JSONDictionary, forKey key: String, relativeTo path: Path) -> JSONDictionary {
         var result = source
@@ -38,7 +38,7 @@ extension PathContaining {
         return result
     }
     
-    static func expandChildPaths<T: PathContaining>(from source: JSONDictionary, forKey key: String, relativeTo path: Path, type: T.Type) -> JSONDictionary {
+    static func expandChildPaths<T: PathContainer>(from source: JSONDictionary, forKey key: String, relativeTo path: Path, type: T.Type) -> JSONDictionary {
         var result = source
 
         if let source = result[key] as? T.JSONSourceType {
@@ -51,7 +51,7 @@ extension PathContaining {
         return result
     }
 
-    static func expandChildPaths<T: PathContaining>(from source: JSONDictionary, forPotentialKeys keys: [String], relativeTo path: Path, type: T.Type) -> JSONDictionary {
+    static func expandChildPaths<T: PathContainer>(from source: JSONDictionary, forPotentialKeys keys: [String], relativeTo path: Path, type: T.Type) -> JSONDictionary {
         var result = source
 
         for key in keys {

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -26,3 +26,38 @@ enum PathProperty {
     case dictionary([PathProperty])
     case object(String, [PathProperty])
 }
+
+extension Array where Element == PathProperty {
+    func resolvingPaths(in jsonDictionary: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
+        var result = jsonDictionary
+
+        for pathProperty in self {
+            switch pathProperty {
+            case .string(let key):
+                if let source = result[key] as? String {
+                    result[key] = (path + source).string
+                } else if let source = result[key] as? [String] {
+                    result[key] = source.map { (path + $0).string }
+                } else if let source = result[key] as? [String: String] {
+                    result[key] = source.mapValues { (path + $0).string }
+                }
+            case .dictionary(let pathProperties):
+                for (key, dictionary) in result {
+                    if let source = dictionary as? JSONDictionary {
+                        result[key] = pathProperties.resolvingPaths(in: source, relativeTo: path)
+                    }
+                }
+            case .object(let key, let pathProperties):
+                if let source = result[key] as? JSONDictionary {
+                    result[key] = pathProperties.resolvingPaths(in: source, relativeTo: path)
+                } else if let source = result[key] as? [JSONDictionary] {
+                    result[key] = source.map { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
+                } else if let source = result[key] as? [String: JSONDictionary] {
+                    result[key] = source.mapValues { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
+                }
+            }
+        }
+
+        return result
+    }
+}

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -4,7 +4,7 @@ import PathKit
 import Yams
 
 extension Project {
-    
+
     public init(path: Path) throws {
         let basePath = path.parent()
         let template = try Spec(filename: path.lastComponent, basePath: basePath)

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -11,7 +11,6 @@ extension Project {
         try self.init(spec: template, basePath: basePath)
     }
 
-    @available(*, deprecated, message: "Use `Project.Spec` for loading files from disk.")
     public static func loadDictionary(path: Path) throws -> JSONDictionary {
         return try Project.Spec(filename: path.lastComponent, basePath: path.parent()).jsonDictionary
     }

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -122,7 +122,7 @@ extension SpecOptions: JSONObjectConvertible {
     }
 }
 
-extension SpecOptions: PathContaining {
+extension SpecOptions: PathContainer {
     
     static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
         var result = source

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -1,6 +1,5 @@
 import Foundation
 import JSONUtilities
-import PathKit
 
 public struct SpecOptions: Equatable {
 

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -1,6 +1,6 @@
 import Foundation
 import JSONUtilities
-import struct PathKit.Path
+import PathKit
 
 public struct SpecOptions: Equatable {
 

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -1,5 +1,6 @@
 import Foundation
 import JSONUtilities
+import struct PathKit.Path
 
 public struct SpecOptions: Equatable {
 
@@ -118,5 +119,17 @@ extension SpecOptions: JSONObjectConvertible {
         transitivelyLinkDependencies = jsonDictionary.json(atKeyPath: "transitivelyLinkDependencies") ?? false
         groupSortPosition = jsonDictionary.json(atKeyPath: "groupSortPosition") ?? .bottom
         generateEmptyDirectories = jsonDictionary.json(atKeyPath: "generateEmptyDirectories") ?? false
+    }
+}
+
+extension SpecOptions: PathContaining {
+    
+    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
+        var result = source
+
+        result = expandStringPaths(from: result, forKey: "carthageBuildPath", relativeTo: path)
+        result = expandStringPaths(from: result, forKey: "carthageExecutablePath", relativeTo: path)
+        result = expandStringPaths(from: result, forKey: "defaultConfig", relativeTo: path)
+        return result
     }
 }

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -123,13 +123,12 @@ extension SpecOptions: JSONObjectConvertible {
 }
 
 extension SpecOptions: PathContainer {
-    
-    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
-        var result = source
 
-        result = expandStringPaths(from: result, forKey: "carthageBuildPath", relativeTo: path)
-        result = expandStringPaths(from: result, forKey: "carthageExecutablePath", relativeTo: path)
-        result = expandStringPaths(from: result, forKey: "defaultConfig", relativeTo: path)
-        return result
+    static var pathProperties: [PathProperty] {
+        return [
+            .string("carthageBuildPath"),
+            .string("carthageExecutablePath"),
+            .string("defaultConfig"),
+        ]
     }
 }

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -1,6 +1,6 @@
 import Foundation
 import JSONUtilities
-import struct PathKit.Path
+import PathKit
 import xcodeproj
 
 public struct LegacyTarget: Equatable {

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -1,6 +1,5 @@
 import Foundation
 import JSONUtilities
-import PathKit
 import xcodeproj
 
 public struct LegacyTarget: Equatable {

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -113,25 +113,21 @@ extension Target: CustomStringConvertible {
 
 extension Target: PathContainer {
 
-    static func expandPaths(for source: [String: JSONDictionary], relativeTo path: Path) -> [String: JSONDictionary] {
-        var result = source
-        for (targetName, var target) in result {
-
-            // sources can either be an array of strings or an array of objects, so attempt to expand both
-            target = expandStringPaths(from: target, forKey: "sources", relativeTo: path)
-            target = expandChildPaths(from: target, forKey: "sources", relativeTo: path, type: TargetSource.self)
-
-            target = expandStringPaths(from: target, forKey: "configFiles", relativeTo: path)
-            target = expandChildPaths(from: target, forKey: "dependencies", relativeTo: path, type: Dependency.self)
-            target = expandChildPaths(from: target, forKey: "info", relativeTo: path, type: Plist.self)
-            target = expandChildPaths(from: target, forKey: "entitlements", relativeTo: path, type: Plist.self)
-            target = expandChildPaths(from: target, forPotentialKeys: ["preBuildScripts", "prebuildScripts"], relativeTo: path, type: BuildScript.self)
-            target = expandChildPaths(from: target, forKey: "postCompileScripts", relativeTo: path, type: BuildScript.self)
-            target = expandChildPaths(from: target, forKey: "postBuildScripts", relativeTo: path, type: BuildScript.self)
-
-            result[targetName] = target
-        }
-        return result
+    static var pathProperties: [PathProperty] {
+        return [
+            .dictionary([
+                .string("sources"),
+                .object("sources", TargetSource.pathProperties),
+                .string("configFiles"),
+                .object("dependencies", Dependency.pathProperties),
+                .object("info", Plist.pathProperties),
+                .object("entitlements", Plist.pathProperties),
+                .object("preBuildScripts", BuildScript.pathProperties),
+                .object("prebuildScripts", BuildScript.pathProperties),
+                .object("postCompileScripts", BuildScript.pathProperties),
+                .object("postBuildScripts", BuildScript.pathProperties),
+            ]),
+        ]
     }
 }
 

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -125,10 +125,10 @@ extension Target {
                 var mergedDictionary: JSONDictionary = [:]
                 for template in templates {
                     if let templateDictionary = targetTemplatesDictionary[template] {
-                        mergedDictionary = merge(dictionary: templateDictionary, onto: mergedDictionary)
+                        mergedDictionary = templateDictionary.merged(onto: mergedDictionary)
                     }
                 }
-                target = merge(dictionary: target, onto: mergedDictionary)
+                target = target.merged(onto: mergedDictionary)
             }
             targetsDictionary[targetName] = target
         }

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -111,7 +111,7 @@ extension Target: CustomStringConvertible {
     }
 }
 
-extension Target: PathContaining {
+extension Target: PathContainer {
 
     static func expandPaths(for source: [String: JSONDictionary], relativeTo path: Path) -> [String: JSONDictionary] {
         var result = source

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -1,6 +1,6 @@
 import Foundation
 import JSONUtilities
-import struct PathKit.Path
+import PathKit
 import xcodeproj
 
 public struct TargetSource: Equatable {

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -210,11 +210,10 @@ extension TargetSource.BuildPhase.CopyFilesSettings: JSONObjectConvertible {
 
 extension TargetSource: PathContainer {
 
-    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
-        var result = source
-
-        result = expandStringPaths(from: result, forKey: "path", relativeTo: path)
-        result = expandStringPaths(from: result, forKey: "excludes", relativeTo: path)
-        return result
+    static var pathProperties: [PathProperty] {
+        return [
+            .string("path"),
+            .string("excludes"),
+        ]
     }
 }

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -1,6 +1,6 @@
 import Foundation
 import JSONUtilities
-import PathKit
+import struct PathKit.Path
 import xcodeproj
 
 public struct TargetSource: Equatable {
@@ -205,5 +205,16 @@ extension TargetSource.BuildPhase.CopyFilesSettings: JSONObjectConvertible {
         destination = try jsonDictionary.json(atKeyPath: "destination")
         subpath = jsonDictionary.json(atKeyPath: "subpath") ?? ""
         phaseOrder = .postCompile
+    }
+}
+
+extension TargetSource: PathContaining {
+
+    static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
+        var result = source
+
+        result = expandStringPaths(from: result, forKey: "path", relativeTo: path)
+        result = expandStringPaths(from: result, forKey: "excludes", relativeTo: path)
+        return result
     }
 }

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -208,7 +208,7 @@ extension TargetSource.BuildPhase.CopyFilesSettings: JSONObjectConvertible {
     }
 }
 
-extension TargetSource: PathContaining {
+extension TargetSource: PathContainer {
 
     static func expandPaths(for source: JSONDictionary, relativeTo path: Path) -> JSONDictionary {
         var result = source

--- a/Sources/XcodeGenKit/SpecLoader.swift
+++ b/Sources/XcodeGenKit/SpecLoader.swift
@@ -16,7 +16,7 @@ public class SpecLoader {
     }
 
     public func loadProject(path: Path) throws -> Project {
-        let template = try Project.Spec(filename: path.lastComponent, basePath: path.parent())
+        let template = try Spec(filename: path.lastComponent, basePath: path.parent())
         let project = try Project(spec: template, basePath: path.parent())
 
         self.project = project

--- a/Sources/XcodeGenKit/SpecLoader.swift
+++ b/Sources/XcodeGenKit/SpecLoader.swift
@@ -16,11 +16,11 @@ public class SpecLoader {
     }
 
     public func loadProject(path: Path) throws -> Project {
-        let dictionary = try Project.loadDictionary(path: path)
-        let project = try Project(basePath: path.parent(), jsonDictionary: dictionary)
+        let template = try Project.Spec(filename: path.lastComponent, basePath: path.parent())
+        let project = try Project(spec: template, basePath: path.parent())
 
         self.project = project
-        projectDictionary = dictionary
+        projectDictionary = template.jsonDictionary
 
         return project
     }

--- a/Tests/Fixtures/legacy_paths_test.yml
+++ b/Tests/Fixtures/legacy_paths_test.yml
@@ -1,4 +1,4 @@
 include:
   path: legacy_paths_test/legacy_included_paths_test.yml
-  useRelativePaths: false
+  relativePaths: false
 name: NewName

--- a/Tests/Fixtures/legacy_paths_test.yml
+++ b/Tests/Fixtures/legacy_paths_test.yml
@@ -1,0 +1,4 @@
+include:
+  path: legacy_paths_test/legacy_included_paths_test.yml
+  useRelativePaths: false
+name: NewName

--- a/Tests/Fixtures/legacy_paths_test/legacy_included_paths_test.yml
+++ b/Tests/Fixtures/legacy_paths_test/legacy_included_paths_test.yml
@@ -1,0 +1,33 @@
+configFiles:
+  IncludedConfig: config
+options:
+  carthageBuildPath: carthage_build
+  carthageExecutablePath: carthage_executable
+targets:
+  IncludedTarget:
+    type: application
+    platform: tvOS
+    configFiles:
+      Config: config
+    sources:
+      - source
+    dependencies:
+      - framework: Framework
+    info:
+      path: info
+    entitlements:
+      path: entitlements
+    preBuildScripts:
+    - path: preBuildScript
+    postCompileScripts:
+    - path: postCompileScript
+    postBuildScripts:
+    - path: postBuildScript
+aggregateTargets:
+  IncludedAggregateTarget:
+    targets:
+      - IncludedTarget
+    configFiles:
+      Config: config
+    buildScripts:
+    - path: buildScript

--- a/Tests/Fixtures/paths_test.yml
+++ b/Tests/Fixtures/paths_test.yml
@@ -1,0 +1,8 @@
+include: paths_test/included_paths_test.yml
+name: NewName
+targets:
+  NewTarget:
+    type: application
+    platform: iOS
+    sources:
+      - $(CURDIR)/source

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -1,6 +1,31 @@
+include: recursive_test/recursive_test.yml
+configFiles:
+  IncludedConfig: config
 targets:
   IncludedTarget:
     type: application
-    platform: iOS
+    platform: tvOS
+    configFiles:
+      Config: config
     sources:
-      - $(CURDIR)/source
+      - source
+    dependencies:
+      - framework: Framework
+    info:
+      path: info
+    entitlements:
+      path: entitlements
+    preBuildScripts:
+    - path: preBuildScript
+    postCompileScripts:
+    - path: postCompileScript
+    postBuildScripts:
+    - path: postBuildScript
+aggregateTargets:
+  IncludedAggregateTarget:
+    targets:
+      - IncludedTarget
+    configFiles:
+      Config: config
+    buildScripts:
+    - path: buildScript

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -1,0 +1,6 @@
+targets:
+  IncludedTarget:
+    type: application
+    platform: iOS
+    sources:
+      - $(CURDIR)/source

--- a/Tests/Fixtures/paths_test/recursive_test/recursive_test.yml
+++ b/Tests/Fixtures/paths_test/recursive_test/recursive_test.yml
@@ -1,11 +1,12 @@
-include: paths_test/included_paths_test.yml
-name: NewName
+options:
+  carthageBuildPath: carthage_build
+  carthageExecutablePath: carthage_executable
 configFiles:
-  NewConfig: config
+  RecursiveConfig: config
 targets:
-  NewTarget:
+  RecursiveTarget:
     type: application
-    platform: iOS
+    platform: macOS
     configFiles:
       Config: config
     sources:
@@ -16,16 +17,16 @@ targets:
       path: info
     entitlements:
       path: entitlements
-    preBuildScripts:
-    - path: preBuildScript
+    prebuildScripts:
+    - path: prebuildScript
     postCompileScripts:
     - path: postCompileScript
     postBuildScripts:
     - path: postBuildScript
 aggregateTargets:
-  NewAggregateTarget:
+  RecursiveAggregateTarget:
     targets:
-      - NewTarget
+      - RecursiveTarget
     configFiles:
       Config: config
     buildScripts:

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -10,6 +10,14 @@ class SpecLoadingTests: XCTestCase {
 
     func testSpecLoader() {
         describe {
+            $0.it("expands directories") {
+                let path = fixturePath + "paths_test.yml"
+                let project = try Project(path: path)
+
+                try expect(project.targets.first!.sources.first!.path) == (fixturePath + "paths_test" + "source").string
+                try expect(project.targets.last!.sources.first!.path) == (fixturePath + "source").string
+            }
+
             $0.it("merges includes") {
                 let path = fixturePath + "include_test.yml"
                 let project = try Project(path: path)

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -655,7 +655,7 @@ fileprivate func getProjectSpec(_ project: [String: Any], file: String = #file, 
         projectDictionary[key] = value
     }
     do {
-        let template = Project.Spec(relativePath: "", jsonDictionary: projectDictionary)
+        let template = Spec(relativePath: "", jsonDictionary: projectDictionary)
         return try Project(spec: template, basePath: "")
     } catch {
         throw failure("\(error)", file: file, line: line)

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -105,6 +105,45 @@ class SpecLoadingTests: XCTestCase {
                 ]
             }
 
+            $0.it("respects directory expansion preference") {
+                let path = fixturePath + "legacy_paths_test.yml"
+                let project = try Project(path: path)
+
+                try expect(project.configFiles) == [
+                    "IncludedConfig": "config",
+                ]
+
+                try expect(project.options) == SpecOptions(
+                    carthageBuildPath: "carthage_build",
+                    carthageExecutablePath: "carthage_executable"
+                )
+
+                try expect(project.aggregateTargets) == [
+                    AggregateTarget(
+                        name: "IncludedAggregateTarget",
+                        targets: ["IncludedTarget"],
+                        configFiles: ["Config": "config"],
+                        buildScripts: [BuildScript(script: .path("buildScript"))]
+                    ),
+                ]
+
+                try expect(project.targets) == [
+                    Target(
+                        name: "IncludedTarget",
+                        type: .application,
+                        platform: .tvOS,
+                        configFiles: ["Config": "config"],
+                        sources: ["source"],
+                        dependencies: [Dependency(type: .framework, reference: "Framework")],
+                        info: Plist(path: "info"),
+                        entitlements: Plist(path: "entitlements"),
+                        preBuildScripts: [BuildScript(script: .path("preBuildScript"))],
+                        postCompileScripts: [BuildScript(script: .path("postCompileScript"))],
+                        postBuildScripts: [BuildScript(script: .path("postBuildScript"))]
+                    ),
+                ]
+            }
+
             $0.it("parses yaml types") {
                 let path = fixturePath + "yaml.yml"
                 let dictionary = try loadYamlDictionary(path: path)

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -10,14 +10,6 @@ class SpecLoadingTests: XCTestCase {
 
     func testSpecLoader() {
         describe {
-            $0.it("expands directories") {
-                let path = fixturePath + "paths_test.yml"
-                let project = try Project(path: path)
-
-                try expect(project.targets.first!.sources.first!.path) == (fixturePath + "paths_test" + "source").string
-                try expect(project.targets.last!.sources.first!.path) == (fixturePath + "source").string
-            }
-
             $0.it("merges includes") {
                 let path = fixturePath + "include_test.yml"
                 let project = try Project(path: path)
@@ -31,6 +23,85 @@ class SpecLoadingTests: XCTestCase {
                 try expect(project.targets) == [
                     Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"]),
                     Target(name: "NewTarget", type: .application, platform: .iOS, sources: ["template", "target"]),
+                ]
+            }
+
+            $0.it("expands directories") {
+                let path = fixturePath + "paths_test.yml"
+                let project = try Project(path: path)
+
+                try expect(project.configFiles) == [
+                    "IncludedConfig": "paths_test/config",
+                    "NewConfig": "config",
+                    "RecursiveConfig": "paths_test/recursive_test/config",
+                ]
+
+                try expect(project.options) == SpecOptions(
+                    carthageBuildPath: "paths_test/recursive_test/carthage_build",
+                    carthageExecutablePath: "paths_test/recursive_test/carthage_executable"
+                )
+
+                try expect(project.aggregateTargets) == [
+                    AggregateTarget(
+                        name: "IncludedAggregateTarget",
+                        targets: ["IncludedTarget"],
+                        configFiles: ["Config": "paths_test/config"],
+                        buildScripts: [BuildScript(script: .path("paths_test/buildScript"))]
+                    ),
+                    AggregateTarget(
+                        name: "NewAggregateTarget",
+                        targets: ["NewTarget"],
+                        configFiles: ["Config": "config"],
+                        buildScripts: [BuildScript(script: .path("buildScript"))]
+                    ),
+                    AggregateTarget(
+                        name: "RecursiveAggregateTarget",
+                        targets: ["RecursiveTarget"],
+                        configFiles: ["Config": "paths_test/recursive_test/config"],
+                        buildScripts: [BuildScript(script: .path("paths_test/recursive_test/buildScript"))]
+                    ),
+                ]
+
+                try expect(project.targets) == [
+                    Target(
+                        name: "IncludedTarget",
+                        type: .application,
+                        platform: .tvOS,
+                        configFiles: ["Config": "paths_test/config"],
+                        sources: ["paths_test/source"],
+                        dependencies: [Dependency(type: .framework, reference: "paths_test/Framework")],
+                        info: Plist(path: "paths_test/info"),
+                        entitlements: Plist(path: "paths_test/entitlements"),
+                        preBuildScripts: [BuildScript(script: .path("paths_test/preBuildScript"))],
+                        postCompileScripts: [BuildScript(script: .path("paths_test/postCompileScript"))],
+                        postBuildScripts: [BuildScript(script: .path("paths_test/postBuildScript"))]
+                    ),
+                    Target(
+                        name: "NewTarget",
+                        type: .application,
+                        platform: .iOS,
+                        configFiles: ["Config": "config"],
+                        sources: ["source"],
+                        dependencies: [Dependency(type: .framework, reference: "Framework")],
+                        info: Plist(path: "info"),
+                        entitlements: Plist(path: "entitlements"),
+                        preBuildScripts: [BuildScript(script: .path("preBuildScript"))],
+                        postCompileScripts: [BuildScript(script: .path("postCompileScript"))],
+                        postBuildScripts: [BuildScript(script: .path("postBuildScript"))]
+                    ),
+                    Target(
+                        name: "RecursiveTarget",
+                        type: .application,
+                        platform: .macOS,
+                        configFiles: ["Config": "paths_test/recursive_test/config"],
+                        sources: ["paths_test/recursive_test/source"],
+                        dependencies: [Dependency(type: .framework, reference: "paths_test/recursive_test/Framework")],
+                        info: Plist(path: "paths_test/recursive_test/info"),
+                        entitlements: Plist(path: "paths_test/recursive_test/entitlements"),
+                        preBuildScripts: [BuildScript(script: .path("paths_test/recursive_test/prebuildScript"))],
+                        postCompileScripts: [BuildScript(script: .path("paths_test/recursive_test/postCompileScript"))],
+                        postBuildScripts: [BuildScript(script: .path("paths_test/recursive_test/postBuildScript"))]
+                    ),
                 ]
             }
 
@@ -541,7 +612,8 @@ fileprivate func getProjectSpec(_ project: [String: Any], file: String = #file, 
         projectDictionary[key] = value
     }
     do {
-        return try Project(basePath: "", jsonDictionary: projectDictionary)
+        let template = Project.Spec(relativePath: "", jsonDictionary: projectDictionary)
+        return try Project(spec: template, basePath: "")
     } catch {
         throw failure("\(error)", file: file, line: line)
     }


### PR DESCRIPTION
Closes #385.

This PR started as a bug fix but ended up including quite a bit refactoring; so I welcome any feedback (I've tried to stay as true to the style of the existing code as I could).

### The Problem

`Included` spec files still used the root spec file's directory as their base directory.

```
Root/
    project.yml
    Sources/
        ...
    Embedded/
        project.yml
        Sources/
            ...
```

In this structure, a target declared in `Embedded/project.yml` would have to use the path `Embedded/Sources` to reference the `Sources` directory adjacent to it.

### The Fix

The first major change is that I've introduced a `Spec` struct that references the directory containing the spec file, the `JSONDictionary` content of the spec file, and any _included_ spec files.

```swift
public struct Spec {
    public let relativePath: Path
    public let jsonDictionary: JSONDictionary
    public let subSpecs: [Spec]
}
```

This struct replaces the `Project.loadDictionary(path:)` function used before, and the `Spec` struct itself is used in the initialization of a `Project`, where previously a raw `JSONDictionary` was used.

The second major change is the introduction of a `PathContainer` protocol to abstract away the process of changing a path in an embedded file.

```swift
protocol PathContainer {
    static var pathProperties: [PathProperty] { get }
}

enum PathProperty {
    case string(String)
    case dictionary([PathProperty])
    case object(String, [PathProperty])
}
```

This is implemented by the model types (e.g. `Target`) to convert any dictionary keys that reference paths relative to the spec file. It is then used during initialization of a `Project` before collapsing the tree of `Spec` objects into a single `JSONDictionary`.