### PR TITLE
Fixes issue with sticker pack targets generating redundant compile sources phase

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -665,8 +665,13 @@ public class PBXProjGenerator {
         }
 
         let sourcesBuildPhaseFiles = getBuildFilesForPhase(.sources)
-        let sourcesBuildPhase = addObject(PBXSourcesBuildPhase(files: sourcesBuildPhaseFiles))
-        buildPhases.append(sourcesBuildPhase)
+        // Sticker packs should not include a compile sources build phase as they
+        // are purely based on a set of image files, and nothing else.
+        let shouldSkipSourcesBuildPhase = sourcesBuildPhaseFiles.isEmpty && target.type == .stickerPack
+        if !shouldSkipSourcesBuildPhase {
+            let sourcesBuildPhase = addObject(PBXSourcesBuildPhase(files: sourcesBuildPhaseFiles))
+            buildPhases.append(sourcesBuildPhase)
+        }
 
         buildPhases += try target.postCompileScripts.map { try generateBuildScript(targetName: target.name, buildScript: $0) }
 

--- a/Tests/Fixtures/TestProject/IMessage Stickers/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tests/Fixtures/TestProject/IMessage Stickers/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Tests/Fixtures/TestProject/IMessage Stickers/Assets.xcassets/Contents.json
+++ b/Tests/Fixtures/TestProject/IMessage Stickers/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/Tests/Fixtures/TestProject/IMessage Stickers/Info.plist
+++ b/Tests/Fixtures/TestProject/IMessage Stickers/Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		262B4F15CB0780B21C37D89F5EA9FE80 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		29A79F030DD325754FD2C82C4A6E0AE6 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B53F03FF0 /* Result.framework */; };
 		2DE309130A6F5A7E2E7E13169357C316 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE7EB96D92 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2DFBC735559B5AC7702C7DD1F54FBFFE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9390121B4ECBB1B796C7CBBDD32C4DD4 /* Assets.xcassets */; };
 		319B977623307E83E948E9E4CEBB432E /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359FD0114B0C /* StaticLibrary_ObjC.h */; };
 		3474A5D469F41494C4CB871D75C77106 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D185A35C1FB /* module.modulemap */; };
 		36152E299B36BCA0F25AD1FC9B002835 /* MoreUnder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8718C7CD3BE86D9B1F51203A548A51 /* MoreUnder.swift */; };
@@ -434,6 +435,7 @@
 		4BF4D16042A80576D259160C97AD2C2E /* Model 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 3.xcdatamodel"; sourceTree = "<group>"; };
 		4D0BF47DF71A6DBA33ED23FD22D023EF /* StaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = StaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5116B3B58070BCD09F1487BAFC210EE0 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		564E35E83C95F5591345B7722A59AA4E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		57FF8864B8EBAB5777DC12E62D66732F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		587B9E9A3533E965CA602B763210583F /* TestProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectUITests.swift; sourceTree = "<group>"; };
 		5A2B916A11DCC2565241359FD0114B0C /* StaticLibrary_ObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticLibrary_ObjC.h; sourceTree = "<group>"; };
@@ -456,6 +458,7 @@
 		814822136AF3C64428D69DD62246E8A2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		8A9274BE42A03DC5DA1FAD04992ED6E3 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8CAF6C55B555E3E1352645B630CCB23E /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
+		9390121B4ECBB1B796C7CBBDD32C4DD4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9A87A926D563773658FB87FEEE4DD132 /* iMessageApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = iMessageApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F27382DD66E26C059E26EFE8D6BEF4D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A0DC40025AB59B688E758829FB7EDB95 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -470,6 +473,7 @@
 		BA040F1F7D6CA08878323A551349F18D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BB178D03E75929F3F5B10C56838882EC /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
 		C2F3574CCEF023755DDB1A06C6FE315C /* Mintfile */ = {isa = PBXFileReference; path = Mintfile; sourceTree = "<group>"; };
+		C53ACB2962FED621389C36A2E1AE6E28 /* iMessageStickersExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = iMessageStickersExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		C5ABEA2284F13483EFDF7C0E050F0450 /* MessagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
 		C7809CE9FE9852C2AA87ACE57B5DEF9E /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.module; path = module.modulemap; sourceTree = "<group>"; };
 		C934C1F7A68CCD0AB6B384782470EE7B /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
@@ -641,6 +645,7 @@
 				1A57D1EE1FBC13598F6B5CB018E7D348 /* Framework */,
 				B370CE9C04C41EBC52D4E4EA1F3EB767 /* iMessage */,
 				0A989C35EEBD58B9B98C41A75CE9CE00 /* iMessage MessagesExtension */,
+				D1B8D50CE1D32597CD569AB52E84F9C2 /* iMessage Stickers */,
 				9EDF27BB8A57733E6639D36D66958B76 /* Resources */,
 				9DB22CB08CFAA455518700DBA5CAD7DE /* StandaloneFiles */,
 				BDA839814AF73F01F771051894A708E8 /* StaticLibrary_ObjC */,
@@ -778,6 +783,7 @@
 				AB055761199DF36DB0C629A608A4EF3A /* Framework2.framework */,
 				9A87A926D563773658FB87FEEE4DD132 /* iMessageApp.app */,
 				D629E142AB87C681D4EC90F7106F7299 /* iMessageExtension.appex */,
+				C53ACB2962FED621389C36A2E1AE6E28 /* iMessageStickersExtension.appex */,
 				4D0BF47DF71A6DBA33ED23FD22D023EF /* StaticLibrary_ObjC.a */,
 				056A43A09CE7E88D578696D83330E45F /* StaticLibrary_ObjC.a */,
 				1313F043F19B484A5046E0748579814C /* StaticLibrary_ObjC.a */,
@@ -823,6 +829,15 @@
 				6AC91042453E18DF74BA1C0F957D87DC /* StaticLibrary.swift */,
 			);
 			path = StaticLibrary_Swift;
+			sourceTree = "<group>";
+		};
+		D1B8D50CE1D32597CD569AB52E84F9C2 /* iMessage Stickers */ = {
+			isa = PBXGroup;
+			children = (
+				9390121B4ECBB1B796C7CBBDD32C4DD4 /* Assets.xcassets */,
+				564E35E83C95F5591345B7722A59AA4E /* Info.plist */,
+			);
+			path = "iMessage Stickers";
 			sourceTree = "<group>";
 		};
 		D557819B1EE5B42A0A3DD4D1F3D982C4 /* tvOS */ = {
@@ -1028,6 +1043,21 @@
 			productName = StaticLibrary_ObjC_iOS;
 			productReference = 4D0BF47DF71A6DBA33ED23FD22D023EF /* StaticLibrary_ObjC.a */;
 			productType = "com.apple.product-type.library.static";
+		};
+		192C574D74079A99AF1AD0B16DEF8F76 /* iMessageStickersExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B40D2F785317445D9A9C8C122B3BFFD3 /* Build configuration list for PBXNativeTarget "iMessageStickersExtension" */;
+			buildPhases = (
+				AA12B5909FEE45016F469C78D3F4941B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iMessageStickersExtension;
+			productName = iMessageStickersExtension;
+			productReference = C53ACB2962FED621389C36A2E1AE6E28 /* iMessageStickersExtension.appex */;
+			productType = "com.apple.product-type.app-extension.messages-sticker-pack";
 		};
 		19BFB84599B0AA1275A9662DCB5C0E50 /* StaticLibrary_Swift */ = {
 			isa = PBXNativeTarget;
@@ -1412,6 +1442,7 @@
 				E7815F2F0D9CDECF9185AAF3A6B474C1 /* XPC Service */,
 				834F55973F05AC8A18144DB04FF6F2C7 /* iMessageApp */,
 				1C26A6A0BC446191F311D470FDFF54F8 /* iMessageExtension */,
+				192C574D74079A99AF1AD0B16DEF8F76 /* iMessageStickersExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -1465,6 +1496,14 @@
 				8493DEA48BF40EFFAC6FBD459C0E9EE4 /* ResourceFolder in Resources */,
 				36F2B8CC97BD885A59E4FBA6EBC8EB22 /* StandaloneAssets.xcassets in Resources */,
 				EF285B90A968453FA1CB0CDE8C0AD440 /* iMessageApp.app in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AA12B5909FEE45016F469C78D3F4941B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2DFBC735559B5AC7702C7DD1F54FBFFE /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2993,6 +3032,17 @@
 			};
 			name = "Production Debug";
 		};
+		59416DBF97224D8A1B28D6102CE1A723 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "IMessage Stickers/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
 		5A9C67C1F423247AE1541F63C53C88B5 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3557,6 +3607,17 @@
 			};
 			name = "Production Release";
 		};
+		9E0CC963DE7E2ED71A4C16C1DC243AD9 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "IMessage Stickers/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
 		9E38571B33C3CE5CA10C8452AE897DF8 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3603,6 +3664,17 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Test Debug";
+		};
+		A0C50DBBF4AC5D30C92B19F78B9CC141 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "IMessage Stickers/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
 		};
 		A2EBD902E6DE2B2BD12C4484D36B6B76 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
@@ -3903,6 +3975,17 @@
 			};
 			name = "Production Debug";
 		};
+		B4297CD61108CE066C29984455AA0CE0 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "IMessage Stickers/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
 		B928E061A126AC8D17D81D1E4DC11629 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3961,6 +4044,17 @@
 				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Test Release";
+		};
+		BF2F04729CC0602591655B251D13DD47 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "IMessage Stickers/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
 		};
 		C0D5765142C68AF68B954B3F748538C2 /* Production Release */ = {
 			isa = XCBuildConfiguration;
@@ -4718,6 +4812,17 @@
 			};
 			name = "Staging Release";
 		};
+		FC4A8130B924FC04E9190AB603D97A24 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "IMessage Stickers/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
 		FE029D76C57D0661E4B8F13B132169CA /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4983,6 +5088,19 @@
 				FE029D76C57D0661E4B8F13B132169CA /* Staging Release */,
 				10E250D1DC79E11058B933F905968160 /* Test Debug */,
 				5A9C67C1F423247AE1541F63C53C88B5 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		B40D2F785317445D9A9C8C122B3BFFD3 /* Build configuration list for PBXNativeTarget "iMessageStickersExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BF2F04729CC0602591655B251D13DD47 /* Production Debug */,
+				59416DBF97224D8A1B28D6102CE1A723 /* Production Release */,
+				9E0CC963DE7E2ED71A4C16C1DC243AD9 /* Staging Debug */,
+				B4297CD61108CE066C29984455AA0CE0 /* Staging Release */,
+				FC4A8130B924FC04E9190AB603D97A24 /* Test Debug */,
+				A0C50DBBF4AC5D30C92B19F78B9CC141 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -151,6 +151,12 @@ targets:
     settings:
       PRODUCT_BUNDLE_IDENTIFIER: com.project.iMessageApp.extension
 
+  iMessageStickersExtension:
+    type: app-extension.messages-sticker-pack
+    platform: iOS
+    sources:       
+      - path: iMessage Stickers
+
   StaticLibrary_ObjC:
     type: library.static
     platform: [iOS, tvOS, watchOS, macOS]


### PR DESCRIPTION
This PR is intended to address the issue of Sticker Pack targets getting generated with a redundant compile sources build phase.

I am not entirely happy with the testing for this here but when I started looking at testing against `pbxProject.sourcesBuildPhases` a big can of worms ensued 😬

Note: The rest of this description is (semi)unrelated to the PR so feel free to ignore.

If you take a look at the `testTarget()` test, on line 578 the code iterates over targets.

Inside that for loop I tried to add code to the effect of the below

```
for target in targets { 
    let nativeTarget = ...
    let buildPhases = nativeTarget.buildPhases
    let sourcesPhases = pbxProject.sourcesBuildPhases.filter { buildPhases.contains($0) }
}
```

For example in one instance of the for loop where `buildPhases.count == 3` the `sourcePhases.count` was returning `8`. I assume the source of the problem is due to how `hashValue` is implemented in `PBXObject.swift` but I haven't had the change to fully investigate it.
