### PR TITLE
Update Xcode compatibility version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Fixed `--project` argument not taking effect [#487](https://github.com/yonaskolb/XcodeGen/pull/487) @monowerker
 - Fixed Sticker Packs from generating an empty Source file phase which caused in error in the new build system [#492](https://github.com/yonaskolb/XcodeGen/pull/492) @rpassis
 
+#### Changed
+- Updated the Xcode compatability version from 3.2 to 9.3 [#497](https://github.com/yonaskolb/XcodeGen/pull/497) @yonaskolb
+
 ## 2.1.0
 
 #### Added

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -88,7 +88,7 @@ public class PBXProjGenerator {
             PBXProject(
                 name: project.name,
                 buildConfigurationList: buildConfigList,
-                compatibilityVersion: "Xcode 3.2",
+                compatibilityVersion: project.compatabilityVersion,
                 mainGroup: mainGroup,
                 developmentRegion: project.options.developmentLanguage ?? "en"
             )

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -27,7 +27,7 @@ public class PBXProjGenerator {
 
     public init(project: Project) {
         self.project = project
-        pbxProj = PBXProj(rootObject: nil, objectVersion: 46)
+        pbxProj = PBXProj(rootObject: nil, objectVersion: project.objectVersion)
         sourceGenerator = SourceGenerator(project: project, pbxProj: pbxProj)
     }
 

--- a/Sources/XcodeGenKit/Version.swift
+++ b/Sources/XcodeGenKit/Version.swift
@@ -11,6 +11,10 @@ extension Project {
         return "1.3"
     }
 
+    var compatabilityVersion: String {
+        return "Xcode 9.3"
+    }
+
     public func validateMinimumXcodeGenVersion(_ xcodeGenVersion: Version) throws {
         if let minimumXcodeGenVersion = options.minimumXcodeGenVersion, xcodeGenVersion < minimumXcodeGenVersion {
             throw SpecValidationError.ValidationError.invalidXcodeGenVersion(minimumVersion: minimumXcodeGenVersion, version: xcodeGenVersion)

--- a/Sources/XcodeGenKit/Version.swift
+++ b/Sources/XcodeGenKit/Version.swift
@@ -15,6 +15,10 @@ extension Project {
         return "Xcode 9.3"
     }
 
+    var objectVersion: UInt {
+        return 50
+    }
+
     public func validateMinimumXcodeGenVersion(_ xcodeGenVersion: Version) throws {
         if let minimumXcodeGenVersion = options.minimumXcodeGenVersion, xcodeGenVersion < minimumXcodeGenVersion {
             throw SpecValidationError.ValidationError.invalidXcodeGenVersion(minimumVersion: minimumXcodeGenVersion, version: xcodeGenVersion)

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXAggregateTarget section */

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -1407,7 +1407,7 @@
 				};
 			};
 			buildConfigurationList = D91E14E36EC0B415578456F264E0161E /* Build configuration list for PBXProject "Project" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (


### PR DESCRIPTION
Resolves #494
This updates the project `compatibilityVersion` from 3.2 to 9.3, and `objectVersion` from 46 to 50, which are the default values when creating a new project in Xcode 10.1