### PR TITLE
Add example code for build rules

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -495,6 +495,11 @@ targets:
         script: generate_assets.py
       - fileType: sourcecode.swift
         script: pre_process_swift.py
+      - filePattern: "*.txt"
+        name: My Build Rule
+        compilerSpec: com.apple.xcode.tools.swift.compiler
+	outputFiles:
+	  - $(SRCROOT)/Generated.swift
 ```
 
 ###  Target Scheme

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -487,6 +487,15 @@ targets:
 - [ ] **outputFiles**: **[String]** - The list of output files
 - [ ] **outputFilesCompilerFlags**: **[String]** - The list of compiler flags to apply to the output files
 
+```yaml
+targets:
+  MyTarget:
+    buildRules:
+      - filePattern: "*.xcassets"
+        script: generate_assets.py
+      - fileType: sourcecode.swift
+        script: pre_process_swift.py
+```
 
 ###  Target Scheme
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -498,8 +498,8 @@ targets:
       - filePattern: "*.txt"
         name: My Build Rule
         compilerSpec: com.apple.xcode.tools.swift.compiler
-	outputFiles:
-	  - $(SRCROOT)/Generated.swift
+        outputFiles:
+          - $(SRCROOT)/Generated.swift
 ```
 
 ###  Target Scheme


### PR DESCRIPTION
I added a simple example about how to configure build rules. It took me a while to figure out that it was expecting a dictionary and XcodeGen doesn't throw any error if the syntax is wrong, just fails silently. This should help in removing some confusion to newcomers to the project 👍 

Let me know if you prefer another type of example, I tried to keep it as simple as possible.