### PR TITLE
Add missingFiles option to skip checking for config file existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Master
 
+#### Added
+- Added `missingConfigFiles` to `options.disabledValidations` to optionally skip checking for the existence of config files.
+
 ## 2.2.0
 
 #### Added

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -103,7 +103,7 @@ Note that target names can also be changed by adding a `name` property to a targ
 - [ ] **deploymentTarget**: **[[Platform](#platform): String]** - A project wide deployment target can be specified for each platform otherwise the default SDK version in Xcode will be used. This will be overridden by any custom build settings that set the deployment target eg `IPHONEOS_DEPLOYMENT_TARGET`. Target specific deployment targets can also be set with [Target](#target).deploymentTarget.
 - [ ] **disabledValidations**: **[String]** - A list of validations that can be disabled if they're too strict for your use case. By default this is set to an empty array. Currently these are the available options:
   - `missingConfigs`: Disable errors for configurations in yaml files that don't exist in the project itself. This can be useful if you include the same yaml file in different projects
-  - `missingFiles`: Disable validation checks for the existence of files. This can be useful for generating a project in a context where config files are not available.
+  - `missingConfigFiles`: Disable checking for the existence of configuration files. This can be useful for generating a project in a context where config files are not available.
 - [ ] **defaultConfig**: **String** - The default configuration for command line builds from Xcode. If the configuration provided here doesn't match one in your [configs](#configs) key, XcodeGen will fail. If you don't set this, the first configuration alphabetically will be chosen.
 - [ ] **groupSortPosition**: **String** - Where groups are sorted in relation to other files. Either:
   - `none` - sorted alphabetically with all the other files

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -103,6 +103,7 @@ Note that target names can also be changed by adding a `name` property to a targ
 - [ ] **deploymentTarget**: **[[Platform](#platform): String]** - A project wide deployment target can be specified for each platform otherwise the default SDK version in Xcode will be used. This will be overridden by any custom build settings that set the deployment target eg `IPHONEOS_DEPLOYMENT_TARGET`. Target specific deployment targets can also be set with [Target](#target).deploymentTarget.
 - [ ] **disabledValidations**: **[String]** - A list of validations that can be disabled if they're too strict for your use case. By default this is set to an empty array. Currently these are the available options:
   - `missingConfigs`: Disable errors for configurations in yaml files that don't exist in the project itself. This can be useful if you include the same yaml file in different projects
+  - `missingFiles`: Disable validation checks for the existence of files. This can be useful for generating a project in a context where config files are not available.
 - [ ] **defaultConfig**: **String** - The default configuration for command line builds from Xcode. If the configuration provided here doesn't match one in your [configs](#configs) key, XcodeGen will fail. If you don't set this, the first configuration alphabetically will be chosen.
 - [ ] **groupSortPosition**: **String** - Where groups are sorted in relation to other files. Either:
   - `none` - sorted alphabetically with all the other files

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -23,7 +23,7 @@ public struct SpecOptions: Equatable {
 
     public enum ValidationType: String {
         case missingConfigs
-        case missingFiles
+        case missingConfigFiles
     }
 
     public enum SettingPresets: String {

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -23,6 +23,7 @@ public struct SpecOptions: Equatable {
 
     public enum ValidationType: String {
         case missingConfigs
+        case missingFiles
     }
 
     public enum SettingPresets: String {

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -52,7 +52,7 @@ extension Project {
         }
 
         for (config, configFile) in configFiles {
-            if !options.disabledValidations.contains(.missingFiles) && !(basePath + configFile).exists {
+            if !options.disabledValidations.contains(.missingConfigFiles) && !(basePath + configFile).exists {
                 errors.append(.invalidConfigFile(configFile: configFile, config: config))
             }
             if !options.disabledValidations.contains(.missingConfigs) && getConfig(config) == nil {
@@ -73,7 +73,7 @@ extension Project {
         for target in projectTargets {
 
             for (config, configFile) in target.configFiles {
-                if !options.disabledValidations.contains(.missingFiles) && !(basePath + configFile).exists {
+                if !options.disabledValidations.contains(.missingConfigFiles) && !(basePath + configFile).exists {
                     errors.append(.invalidTargetConfigFile(target: target.name, configFile: configFile, config: config))
                 }
                 if !options.disabledValidations.contains(.missingConfigs) && getConfig(config) == nil {

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -52,7 +52,7 @@ extension Project {
         }
 
         for (config, configFile) in configFiles {
-            if !(basePath + configFile).exists {
+            if !options.disabledValidations.contains(.missingFiles) && !(basePath + configFile).exists {
                 errors.append(.invalidConfigFile(configFile: configFile, config: config))
             }
             if !options.disabledValidations.contains(.missingConfigs) && getConfig(config) == nil {
@@ -73,7 +73,7 @@ extension Project {
         for target in projectTargets {
 
             for (config, configFile) in target.configFiles {
-                if !(basePath + configFile).exists {
+                if !options.disabledValidations.contains(.missingFiles) && !(basePath + configFile).exists {
                     errors.append(.invalidTargetConfigFile(target: target.name, configFile: configFile, config: config))
                 }
                 if !options.disabledValidations.contains(.missingConfigs) && getConfig(config) == nil {

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -117,6 +117,13 @@ class ProjectSpecTests: XCTestCase {
                 project.configFiles = ["missingConfiguration": configPath.string]
                 try project.validate()
             }
+            
+            $0.it("allows non-existent config files") {
+                var project = baseProject
+                project.options = SpecOptions(disabledValidations: [.missingFiles, .missingConfigs])
+                project.configFiles = ["invalidConfig": "invalidConfigFile"]
+                try project.validate()
+            }
 
             $0.it("fails with invalid target") {
                 var project = baseProject

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -120,7 +120,7 @@ class ProjectSpecTests: XCTestCase {
             
             $0.it("allows non-existent config files") {
                 var project = baseProject
-                project.options = SpecOptions(disabledValidations: [.missingFiles, .missingConfigs])
+                project.options = SpecOptions(disabledValidations: [.missingConfigFiles, .missingConfigs])
                 project.configFiles = ["invalidConfig": "invalidConfigFile"]
                 try project.validate()
             }

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -120,8 +120,8 @@ class ProjectSpecTests: XCTestCase {
             
             $0.it("allows non-existent config files") {
                 var project = baseProject
-                project.options = SpecOptions(disabledValidations: [.missingConfigFiles, .missingConfigs])
-                project.configFiles = ["invalidConfig": "invalidConfigFile"]
+                project.options = SpecOptions(disabledValidations: [.missingConfigFiles])
+                project.configFiles = ["invalid": "doesntexist.xcconfig"]
                 try project.validate()
             }
 


### PR DESCRIPTION
In https://github.com/yonaskolb/XcodeGen/pull/220#pullrequestreview-86853813, @yonaskolb suggested that XcodeGen could have a validation setting to disable checking for the existence of config files:

> We could create a followup PR that disables `missingFiles`

I'm playing with using XcodeGen from a context where I don't have config files available, so I went ahead and added a `missingFiles` option to handle this use case.

One question I have is whether `missingFiles` should imply `missingConfigs`, or whether you think it makes sense for those two options to remain distinct. Let me know what you think!