### PR TITLE
Compute relative paths to support sources outside a spec's directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Added
 - Added `missingConfigFiles` to `options.disabledValidations` to optionally skip checking for the existence of config files.
 
+#### Fixed
+- Sources outside a project spec's directory will be correctly referenced as relative paths in the project file. [#524](https://github.com/yonaskolb/XcodeGen/pull/524)
+
 ## 2.2.0
 
 #### Added

--- a/Sources/XcodeGenKit/CacheFile.swift
+++ b/Sources/XcodeGenKit/CacheFile.swift
@@ -10,7 +10,7 @@ public class CacheFile {
         guard #available(OSX 10.13, *) else { return nil }
 
         let files = Array(Set(project.allFiles))
-            .map { $0.byRemovingBase(path: project.basePath).string }
+            .map { ((try? $0.relativePath(from: project.basePath)) ?? $0).string }
             .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
             .joined(separator: "\n")
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -811,7 +811,7 @@ public class PBXProjGenerator {
                     searchForPlist = false
                 }
                 if let plistPath = plistPath {
-                    buildSettings["INFOPLIST_FILE"] = plistPath.byRemovingBase(path: project.basePath)
+                    buildSettings["INFOPLIST_FILE"] = (try? plistPath.relativePath(from: project.basePath)) ?? plistPath
                 }
             }
 

--- a/Sources/XcodeGenKit/PathExtensions.swift
+++ b/Sources/XcodeGenKit/PathExtensions.swift
@@ -2,11 +2,6 @@ import Foundation
 import PathKit
 
 extension Path {
-
-    public func byRemovingBase(path: Path) -> Path {
-        return Path(normalize().string.replacingOccurrences(of: "\(path.normalize().string)/", with: ""))
-    }
-
     /// Returns a Path without any inner parent directory references.
     ///
     /// Similar to `NSString.standardizingPath`, but works with relative paths.

--- a/Sources/XcodeGenKit/PathExtensions.swift
+++ b/Sources/XcodeGenKit/PathExtensions.swift
@@ -6,4 +6,71 @@ extension Path {
     public func byRemovingBase(path: Path) -> Path {
         return Path(normalize().string.replacingOccurrences(of: "\(path.normalize().string)/", with: ""))
     }
+    
+    public func relativePath(from base: Path) throws -> Path {
+        enum PathArgumentError: Error {
+            /// Can't back out of an unknown parent directory
+            case unknownParentDirectory
+            /// It's impossible to determine the path between an absolute and a relative path
+            case unmatchedAbsolutePath
+        }
+        
+        func pathComponents(for path: ArraySlice<String>, relativeTo base: ArraySlice<String>, memo: [String]) throws -> [String] {
+            switch (base.first, path.first) {
+            // 1. Paths are equivalent
+            case (.none, .none):
+                return memo
+                
+            // 2. No path to backtrack from
+            case (.none, .some(let rhs)):
+                guard rhs != "." else {
+                    // Skip . instead of appending it
+                    return try pathComponents(for: path.dropFirst(), relativeTo: base, memo: memo)
+                }
+                return try pathComponents(for: path.dropFirst(), relativeTo: base, memo: memo + [rhs])
+                
+            // 3. Both sides have a common parent
+            case (.some(let lhs), .some(let rhs)) where lhs == rhs:
+                return try pathComponents(for: path.dropFirst(), relativeTo: base.dropFirst(), memo: memo)
+                
+            // 4. `base` has a path to back out of
+            case (.some(let lhs), _):
+                guard lhs != ".." else {
+                    throw PathArgumentError.unknownParentDirectory
+                }
+                guard lhs != "." else {
+                    // Skip . instead of resolving it to ..
+                    return try pathComponents(for: path, relativeTo: base.dropFirst(), memo: memo)
+                }
+                return try pathComponents(for: path, relativeTo: base.dropFirst(), memo: memo + [".."])
+            }
+        }
+        
+        guard isAbsolute && base.isAbsolute || !isAbsolute && !base.isAbsolute else {
+            throw PathArgumentError.unmatchedAbsolutePath
+        }
+        
+        return Path(components: try pathComponents(for: ArraySlice(normalize().components.strippingParentDirectoryReferences()),
+                                                   relativeTo: ArraySlice(base.normalize().components.strippingParentDirectoryReferences()),
+                                                   memo: []))
+    }
+}
+
+private extension Array where Element == String {
+    func strippingParentDirectoryReferences() -> [Element] {
+        var backtracks = 0
+        let components = reversed().filter { pathComponent in
+            if pathComponent == ".." {
+                backtracks += 1
+                return false
+            } else if backtracks > 0 {
+                backtracks -= 1
+                return false
+            } else {
+                return true
+            }
+        }
+        
+        return Array(repeating: "..", count: backtracks) + components.reversed()
+    }
 }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -119,7 +119,7 @@ class SourceGenerator {
         if let fileReference = fileReferencesByPath[fileReferenceKey] {
             return fileReference
         } else {
-            let fileReferencePath = path.byRemovingBase(path: inPath)
+            let fileReferencePath = (try? path.relativePath(from: inPath)) ?? path
             var fileReferenceName: String? = name ?? fileReferencePath.lastComponent
             if fileReferencePath.string == fileReferenceName {
                 fileReferenceName = nil
@@ -474,7 +474,7 @@ class SourceGenerator {
         var sourcePath = path
         switch type {
         case .folder:
-            let folderPath = Path(targetSource.path)
+            let folderPath = project.basePath + Path(targetSource.path)
             let fileReference = getFileReference(
                 path: folderPath,
                 inPath: project.basePath,

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -254,7 +254,7 @@ class SourceGenerator {
 
             let groupName = name ?? path.lastComponent
             let groupPath = isTopLevelGroup ?
-                path.byRemovingBase(path: project.basePath).string :
+                ((try? path.relativePath(from: project.basePath)) ?? path).string :
                 path.lastComponent
             let group = PBXGroup(
                 children: children,

--- a/Tests/XcodeGenKitTests/PathExtensionsTests.swift
+++ b/Tests/XcodeGenKitTests/PathExtensionsTests.swift
@@ -20,7 +20,8 @@ class PathExtensionsTests: XCTestCase {
                 try expect(relativePath(to: "/a", from: "/b")) == "../a"
                 try expect(relativePath(to: "/a", from: "/b/")) == "../a"
                 try expect(relativePath(to: "/a/", from: "/b")) == "../a"
-                try expect(relativePath(to: "/a/", from: "/b/")) == "../a"            }
+                try expect(relativePath(to: "/a/", from: "/b/")) == "../a"
+            }
             
             $0.it("resolves paths with a common parent") {
                 try expect(relativePath(to: "a/b", from: "a/c")) == "../b"

--- a/Tests/XcodeGenKitTests/PathExtensionsTests.swift
+++ b/Tests/XcodeGenKitTests/PathExtensionsTests.swift
@@ -1,0 +1,64 @@
+import Spectre
+import PathKit
+import XCTest
+
+class PathExtensionsTests: XCTestCase {
+    
+    func testPathRelativeToPath() {
+        func relativePath(to path: String, from base: String) throws -> String {
+            return try Path(path).relativePath(from: Path(base)).string
+        }
+        
+        // These are based on ruby's tests for Pathname#relative_path_from:
+        // https://github.com/ruby/ruby/blob/7c2bbd1c7d40a30583844d649045824161772e36/test/pathname/test_pathname.rb#L297
+        describe {
+            $0.it("resolves single-level paths") {
+                try expect(relativePath(to: "a", from: "b")) == "../a"
+                try expect(relativePath(to: "a", from: "b/")) == "../a"
+                try expect(relativePath(to: "a/", from: "b")) == "../a"
+                try expect(relativePath(to: "a/", from: "b/")) == "../a"
+                try expect(relativePath(to: "/a", from: "/b")) == "../a"
+                try expect(relativePath(to: "/a", from: "/b/")) == "../a"
+                try expect(relativePath(to: "/a/", from: "/b")) == "../a"
+                try expect(relativePath(to: "/a/", from: "/b/")) == "../a"            }
+            
+            $0.it("resolves paths with a common parent") {
+                try expect(relativePath(to: "a/b", from: "a/c")) == "../b"
+                try expect(relativePath(to: "../a", from: "../b")) == "../a"
+            }
+            
+            $0.it("resolves dot paths") {
+                try expect(relativePath(to: "a", from: ".")) == "a"
+                try expect(relativePath(to: ".", from: "a")) == ".."
+                try expect(relativePath(to: ".", from: ".")) == "."
+                try expect(relativePath(to: "..", from: "..")) == "."
+                try expect(relativePath(to: "..", from: ".")) == ".."
+            }
+            
+            $0.it("resolves multi-level paths") {
+                try expect(relativePath(to: "/a/b/c/d", from: "/a/b")) == "c/d"
+                try expect(relativePath(to: "/a/b", from: "/a/b/c/d")) == "../.."
+                try expect(relativePath(to: "/e", from: "/a/b/c/d")) == "../../../../e"
+                try expect(relativePath(to: "a/b/c", from: "a/d")) == "../b/c"
+                try expect(relativePath(to: "/../a", from: "/b")) == "../a"
+                try expect(relativePath(to: "../a", from: "b")) == "../../a"
+                try expect(relativePath(to: "/a/../../b", from: "/b")) == "."
+                try expect(relativePath(to: "a/..", from: "a")) == ".."
+                try expect(relativePath(to: "a/../b", from: "b")) == "."
+            }
+            
+            $0.it("backtracks on a non-normalized base path") {
+                try expect(relativePath(to: "a", from: "b/..")) == "a"
+                try expect(relativePath(to: "b/c", from: "b/..")) == "b/c"
+            }
+            
+            $0.it("throws when given unresolvable paths") {
+                try expect(relativePath(to: "/", from: ".")).toThrow()
+                try expect(relativePath(to: ".", from: "/")).toThrow()
+                try expect(relativePath(to: "a", from: "..")).toThrow()
+                try expect(relativePath(to: ".", from: "..")).toThrow()
+                try expect(relativePath(to: "a", from: "b/../..")).toThrow()
+            }
+        }
+    }
+}

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -387,7 +387,7 @@ class SourceGeneratorTests: XCTestCase {
                 let pbxProj = try project.generatePbxProj()
                 try pbxProj.expectFile(paths: ["Sources", "A", "b.swift"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["Sources", "F", "G", "h.swift"], buildPhase: .sources)
-                try pbxProj.expectFile(paths: [(outOfRootPath + "C/D").string, "e.swift"], names: ["D", "e.swift"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: ["../OtherDirectory/C/D", "e.swift"], names: ["D", "e.swift"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["Sources/B", "b.swift"], names: ["B", "b.swift"], buildPhase: .sources)
             }
 


### PR DESCRIPTION
Closes #318 

Previously, XcodeGen would determine the relative path to a source by removing the project's `basePath` from the source's path, but this doesn't work when the source's path is outside the base path. For example, given a base path `/a/b` and a path to a source `../c`, XcodeGen would unsuccessfully try to remove "/a/b" from "/a/c" and wind up creating a "relative" file reference to "/a/c".

This change adds a method to `Path` that computes the relative path between two paths, inspired by methods like [`Pathname#relative_path_from`][0] in Ruby, and uses it to determine the paths for top-level references in the project.

I'm trying to decide whether I should really be contributing this to PathKit, since this solves a generalizable path problem, but since it fixes a specific bug in XcodeGen I wanted to put it up here. I'm happy to open a PR on PathKit in addition to this one, so that you don't get stuck maintaining a pathing algorithm 🙂

[0]: http://ruby-doc.org/stdlib-2.6.1/libdoc/pathname/rdoc/Pathname.html#method-i-relative_path_from