### PR TITLE
Feature: Add path support to Scheme.ExecutionAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-g<p align="center">
+<p align="center">
 <a href="https://github.com/yonaskolb/XcodeGen">
 <img src="Assets/Logo_animated.gif" alt="XcodeGen" />
 </a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+g<p align="center">
 <a href="https://github.com/yonaskolb/XcodeGen">
 <img src="Assets/Logo_animated.gif" alt="XcodeGen" />
 </a>
@@ -136,7 +136,7 @@ git clone https://github.com/yonaskolb/XcodeGen.git
 cd XcodeGen
 swift package generate-xcodeproj
 ```
-This use Swift Project Manager to create an `xcodeproj` file that you can open, edit and run in Xcode, which makes editing any code easier.
+This uses Swift Project Manager to create an `xcodeproj` file that you can open, edit and run in Xcode, which makes editing any code easier.
 
 If you want to pass any required arguments when running in Xcode, you can edit the scheme to include launch arguments.
 

--- a/Sources/ProjectSpec/BuildScript.swift
+++ b/Sources/ProjectSpec/BuildScript.swift
@@ -1,6 +1,22 @@
 import Foundation
 import JSONUtilities
 
+public enum ScriptType: Equatable {
+    case path(String)
+    case script(String)
+}
+
+extension ScriptType: JSONObjectConvertible {
+    public init(jsonDictionary: JSONDictionary) throws {
+        if let string: String = jsonDictionary.json(atKeyPath: "script") {
+            self = .script(string)
+        } else {
+            let path: String = try jsonDictionary.json(atKeyPath: "path")
+            self = .path(path)
+        }
+    }
+}
+
 public struct BuildScript: Equatable {
 
     public var script: ScriptType
@@ -12,11 +28,6 @@ public struct BuildScript: Equatable {
     public var outputFileLists: [String]
     public var runOnlyWhenInstalling: Bool
     public let showEnvVars: Bool
-
-    public enum ScriptType: Equatable {
-        case path(String)
-        case script(String)
-    }
 
     public init(
         script: ScriptType,
@@ -49,13 +60,7 @@ extension BuildScript: JSONObjectConvertible {
         outputFiles = jsonDictionary.json(atKeyPath: "outputFiles") ?? []
         inputFileLists = jsonDictionary.json(atKeyPath: "inputFileLists") ?? []
         outputFileLists = jsonDictionary.json(atKeyPath: "outputFileLists") ?? []
-
-        if let string: String = jsonDictionary.json(atKeyPath: "script") {
-            script = .script(string)
-        } else {
-            let path: String = try jsonDictionary.json(atKeyPath: "path")
-            script = .path(path)
-        }
+        script = try ScriptType(jsonDictionary: jsonDictionary)
         shell = jsonDictionary.json(atKeyPath: "shell")
         runOnlyWhenInstalling = jsonDictionary.json(atKeyPath: "runOnlyWhenInstalling") ?? false
         showEnvVars = jsonDictionary.json(atKeyPath: "showEnvVars") ?? true

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -33,10 +33,10 @@ public struct Scheme: Equatable {
     }
 
     public struct ExecutionAction: Equatable {
-        public var script: String
+        public var script: ScriptType
         public var name: String
         public var settingsTarget: String?
-        public init(name: String, script: String, settingsTarget: String? = nil) {
+        public init(name: String, script: ScriptType, settingsTarget: String? = nil) {
             self.script = script
             self.name = name
             self.settingsTarget = settingsTarget
@@ -212,9 +212,17 @@ protocol BuildAction: Equatable {
 extension Scheme.ExecutionAction: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
-        script = try jsonDictionary.json(atKeyPath: "script")
+        script = try ScriptType(jsonDictionary: jsonDictionary)
         name = jsonDictionary.json(atKeyPath: "name") ?? "Run Script"
         settingsTarget = jsonDictionary.json(atKeyPath: "settingsTarget")
+    }
+}
+
+extension Scheme.ExecutionAction: PathContainer {
+    static var pathProperties: [PathProperty] {
+        return [
+            .string("path"),
+        ]
     }
 }
 

--- a/Tests/PerformanceTests/TestProject.swift
+++ b/Tests/PerformanceTests/TestProject.swift
@@ -26,8 +26,8 @@ extension Project {
                 XCScheme.EnvironmentVariable(variable: "ENV", value: "HELLO", enabled: true),
                 XCScheme.EnvironmentVariable(variable: "ENV2", value: "HELLO", enabled: false),
             ],
-            preActions: [Scheme.ExecutionAction(name: "run", script: "script")],
-            postActions: [Scheme.ExecutionAction(name: "run", script: "script")]
+            preActions: [Scheme.ExecutionAction(name: "run", script: .script("script"))],
+            postActions: [Scheme.ExecutionAction(name: "run", script: .script("script"))]
         )
         for platform in Platform.all {
             let appTarget = Target(

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -39,7 +39,7 @@ class SchemeGeneratorTests: XCTestCase {
 
             let buildTarget = Scheme.BuildTarget(target: app.name)
             $0.it("generates scheme") {
-                let preAction = Scheme.ExecutionAction(name: "Script", script: "echo Starting", settingsTarget: app.name)
+                let preAction = Scheme.ExecutionAction(name: "Script", script: .script("echo Starting"), settingsTarget: app.name)
                 let scheme = Scheme(
                     name: "MyScheme",
                     build: Scheme.Build(targets: [buildTarget], preActions: [preAction])
@@ -177,8 +177,8 @@ class SchemeGeneratorTests: XCTestCase {
             $0.it("generates pre and post actions for target schemes") {
                 var target = app
                 target.scheme = TargetScheme(
-                    preActions: [.init(name: "Run", script: "do")],
-                    postActions: [.init(name: "Run2", script: "post", settingsTarget: "MyApp")]
+                    preActions: [.init(name: "Run", script: .script("do"))],
+                    postActions: [.init(name: "Run2", script: .script("post"), settingsTarget: "MyApp")]
                 )
 
                 let project = Project(name: "test", targets: [target, framework])

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -406,8 +406,8 @@ class SpecLoadingTests: XCTestCase {
                     gatherCoverageData: true,
                     commandLineArguments: ["ENV1": true],
                     environmentVariables: [XCScheme.EnvironmentVariable(variable: "TEST_VAR", value: "TEST_VAL", enabled: true)],
-                    preActions: [.init(name: "Do Thing", script: "dothing", settingsTarget: "test")],
-                    postActions: [.init(name: "Run Script", script: "hello")]
+                    preActions: [.init(name: "Do Thing", script: .script("dothing"), settingsTarget: "test")],
+                    postActions: [.init(name: "Run Script", script: .script("hello"))]
                 )
 
                 try expect(target.scheme) == scheme
@@ -458,7 +458,7 @@ class SpecLoadingTests: XCTestCase {
                 ]
                 try expect(scheme.name) == "Scheme"
                 try expect(scheme.build.targets) == expectedTargets
-                try expect(scheme.build.preActions.first?.script) == "echo Before Build"
+                try expect(scheme.build.preActions.first?.script) == .script("echo Before Build")
                 try expect(scheme.build.preActions.first?.name) == "Before Build"
                 try expect(scheme.build.preActions.first?.settingsTarget) == "Target1"
 


### PR DESCRIPTION
## Background
I have a use-case to add a large shell script (50-100 lines) as a `postAction` for one of my schemes. I have made an initial attempt to add it using the existing `PathType` from `BuildScript`. 

Open to your feedback. Thanks!
