### PR TITLE
Fix CocoaPods spelling

### DIFF
--- a/Docs/FAQ.md
+++ b/Docs/FAQ.md
@@ -1,6 +1,6 @@
 # Frequently asked questions
 - [Can I still check in my project](#can-i-still-check-in-my-project)
-- [Can I use Cocoapods](#can-i-use-cocoapods)
+- [Can I use CocoaPods](#can-i-use-cocoapods)
 - [How do I setup code signing](#how-do-i-setup-code-signing)
 
 ## Can I still check in my project
@@ -12,7 +12,7 @@ If files were added or removed in the new checkout you will most likely need to 
 
 For now you can always add xcodegen as a git `post-checkout` hook.
  
-## Can I use Cocoapods
+## Can I use CocoaPods
 Yes, simply generate your project and then run `pod install` which will integrate with your project and create a workspace.
 
 ## How do I setup code signing

--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -5,7 +5,7 @@
     - [Setting Groups](#setting-groups)
     - [xcconfig files](#xcconfig-files)
 - [Use dependencies](#use-dependencies)
-    - [Cocoapods](#cocoapods)
+    - [CocoaPods](#cocoapods)
     - [Carthage](#carthage)
     - [SDK](#sdk)
 
@@ -95,8 +95,8 @@ DEVELOPMENT_TEAM=XXXXXXXXX xcodebuild ...
 
 Each target can declare one or more dependencies. See [Dependency](ProjectSpec.md#dependency) in the ProjectSpec for more info about all the properties
 
-### Cocoapods
-Use your `podfile` as normal. The pods themselves don't need to be referenced in the project spec. After you generate your project simply run `pod install` which will integrate with your project and create a workspace.
+### CocoaPods
+Use your `Podfile` as normal. The pods themselves don't need to be referenced in the project spec. After you generate your project simply run `pod install` which will integrate with your project and create a workspace.
 
 ### Carthage
 XcodeGen makes integrating Carthage dependencies super easy!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,6 @@
 1. Update the version at the top of `Makefile`
 1. Run `make release`
 1. Push commit and tag to github
-1. Create release from tag on Github using the version number and relevant changelog contents
+1. Create release from tag on GitHub using the version number and relevant changelog contents
 1. Run `make archive` and upload `xcodegen.zip` to the github release
 1. Run `make bump_brew` which will open a PR on homebrew core


### PR DESCRIPTION
Just a couple of minor spelling corrections: `Cocoapods`->`CocoaPods`, `Github`->`GitHub`.