### PR TITLE
use link property in framework deps

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -518,11 +518,15 @@ public class PBXProjGenerator {
                     )
                 }
 
-                let buildFile = addObject(
-                    PBXBuildFile(file: fileReference, settings: getDependencyFrameworkSettings(dependency: dependency))
-                )
-
-                targetFrameworkBuildFiles.append(buildFile)
+                
+                if dependency.link ?? true {
+                    let buildFile = addObject(
+                        PBXBuildFile(file: fileReference, settings: getDependencyFrameworkSettings(dependency: dependency))
+                    )
+                    
+                    targetFrameworkBuildFiles.append(buildFile)
+                }
+                
                 if !frameworkFiles.contains(fileReference) {
                     frameworkFiles.append(fileReference)
                 }


### PR DESCRIPTION
Allows using link property in framework dependencies. This is needed
if you use firebase as a framework dependency.