### PR TITLE
Add ability to define `templateAttributes` within a target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added ability to automatically include Carthage related dependencies via `includeRelated: true` [#506](https://github.com/yonaskolb/XcodeGen/pull/506) @rpassis
 - Added ability to define a per-platform `deploymentTarget` for Multi-Platform targets. [#510](https://github.com/yonaskolb/XcodeGen/pull/510) @ainopara
 - Added support for nested target templates [#534](https://github.com/yonaskolb/XcodeGen/pull/534) @tomquist
+- Added ability to define `templateAttributes` within a target to be able to parameterize templates. [#533](https://github.com/yonaskolb/XcodeGen/pull/533) @tomquist
+
+#### Changed
+- **DEPRECATION**: Placeholders `$target_name` and `$platform` have been deprecated in favour of `${target_name}` and `${platform}`. Support for the old placeholders will be removed in a future version [#533](https://github.com/yonaskolb/XcodeGen/pull/533) @tomquist
 
 #### Fixed
 - Sources outside a project spec's directory will be correctly referenced as relative paths in the project file. [#524](https://github.com/yonaskolb/XcodeGen/pull/524)

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -203,7 +203,8 @@ Settings are merged in the following order: groups, base, configs.
   - `CFBundleVersion`
   - `CFBundlePackageType`
 - [ ] **entitlements**: **[Plist](#plist)** - If defined this will generate and write a `.entitlements` file, and use it by setting `CODE_SIGN_ENTITLEMENTS` build setting for every configuration. All properties must be provided
-- [ ] **templates**: **[String]** - A list of [Target Templates](#target-template) referenced by name that will be merged with the target in order. Any instances of `$target_name` within these templates will be replaced with the target name.
+- [ ] **templates**: **[String]** - A list of [Target Templates](#target-template) referenced by name that will be merged with the target in order. Any instances of `${target_name}` within these templates will be replaced with the target name.
+- [ ] **templateAttributes**: **[String: String]** - A list of attributes where each instance of `${attributeName}` within the templates listed in `templates` will be replaced with the value specified.
 - [ ] **transitivelyLinkDependencies**: **Bool** - If this is not specified the value from the project set in [Options](#options)`.transitivelyLinkDependencies` will be used.
 - [ ] **directlyEmbedCarthageDependencies**: **Bool** - If this is `true` Carthage dependencies will be embedded using an `Embed Frameworks` build phase instead of the `copy-frameworks` script. Defaults to `true` for all targets except iOS/tvOS/watchOS Applications.
 - [ ] **requiresObjCLinking**: **Bool** - If this is `true` any targets that link to this target will have `-ObjC` added to their `OTHER_LDFLAGS`. This is required if a static library has any catagories or extensions on Objective-C code. See [this guide](https://pewpewthespells.com/blog/objc_linker_flags.html#objc) for more details. Defaults to `true` if `type` is `library.static`. If you are 100% sure you don't have catagories or extensions on Objective-C code (pure Swift with no use of Foundation/UIKit) you can set this to `false`, otherwise it's best to leave it alone.
@@ -257,9 +258,9 @@ This will provide default build settings for a certain platform. It can be any o
 
 You can also specify an array of platforms. This will generate a target for each platform.
 If `deploymenTarget` is specified for a multi platform target, it can have different values per platform similar to how it's defined in [Options](#options). See below for an example.
-If you reference the string `$platform` anywhere within the target spec, that will be replaced with the platform.
+If you reference the string `${platform}` anywhere within the target spec, that will be replaced with the platform.
 
-The generated targets by default will have a suffix of `_$platform` applied, you can change this by specifying a `platformSuffix` or `platformPrefix`.
+The generated targets by default will have a suffix of `_${platform}` applied, you can change this by specifying a `platformSuffix` or `platformPrefix`.
 
 If no `PRODUCT_NAME` build setting is specified for a target, this will be set to the target name, so that this target can be imported under a single name.
 
@@ -276,9 +277,9 @@ targets:
       base:
         INFOPLIST_FILE: MyApp/Info.plist
         PRODUCT_BUNDLE_IDENTIFIER: com.myapp
-        MY_SETTING: platform $platform
+        MY_SETTING: platform ${platform}
       groups:
-        - $platform
+        - ${platform}
 ```
 
 The above will generate 2 targets named `MyFramework_iOS` and `MyFramework_tvOS`, with all the relevant platform build settings. They will both have a `PRODUCT_NAME` of `MyFramework`
@@ -583,7 +584,8 @@ This is used to override settings or run build scripts in specific targets
 ## Target Template
 
 This is a template that can be referenced from a normal target using the `templates` property. The properties of this template are the same as a [Target](#target)].
-Any instances of `$target_name` within each template will be replaced by the final target name which references the template.
+Any instances of `${target_name}` within each template will be replaced by the final target name which references the template.
+Any attributes defined within a targets `templateAttributes` will be used to replace any attribute references in the template using the syntax `${attribute_name}`.
 
 
 ```yaml
@@ -591,6 +593,8 @@ targets:
   MyFramework:
     templates: 
       - Framework
+    templateAttributes:
+      frameworkName: AwesomeFramework
     sources:
       - SomeSources
 targetTemplates:
@@ -598,7 +602,7 @@ targetTemplates:
     platform: iOS
     type: framework
     sources:
-      - $target_name/Sources
+      - ${frameworkName}/${target_name}
 ```
 
 ## Scheme

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JSONUtilities
 import PathKit
 
 extension Project {

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -4,6 +4,10 @@ public struct SpecValidationError: Error, CustomStringConvertible {
 
     public var errors: [ValidationError]
 
+    public init(errors: [ValidationError]) {
+        self.errors = errors
+    }
+
     public enum ValidationError: Error, CustomStringConvertible {
         case invalidXcodeGenVersion(minimumVersion: Version, version: Version)
         case invalidSDKDependency(target: String, dependency: String)
@@ -23,6 +27,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case missingConfigForTargetScheme(target: String, configType: ConfigType)
         case missingDefaultConfig(configName: String)
         case invalidPerConfigSettings
+        case deprecatedUsageOfPlaceholder(placeholderName: String)
 
         public var description: String {
             switch self {
@@ -62,6 +67,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Default configuration \(name) doesn't exist"
             case .invalidPerConfigSettings:
                 return "Settings that are for a specific config must go in \"configs\". \"base\" can be used for common settings"
+            case let .deprecatedUsageOfPlaceholder(placeholderName: placeholderName):
+                return "Usage of $\(placeholderName) is deprecated and will stop working in an upcoming version. Use ${\(placeholderName)} instead."
             }
         }
     }

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -168,7 +168,13 @@ extension Target {
                     }
                 }
                 target = target.merged(onto: mergedDictionary)
-                target = target.replaceString("$target_name", with: targetName)
+                target = target.replaceString("$target_name", with: targetName) // Will be removed in upcoming version
+                target = target.replaceString("${target_name}", with: targetName)
+                if let templateAttributes = target["templateAttributes"] as? [String: String] {
+                    for (templateAttribute, value) in templateAttributes {
+                        target = target.replaceString("${\(templateAttribute)}", with: value)
+                    }
+                }
             }
             targetsDictionary[targetName] = target
         }
@@ -192,7 +198,8 @@ extension Target {
                 for platform in platforms {
                     var platformTarget = target
 
-                    platformTarget = platformTarget.replaceString("$platform", with: platform)
+                    platformTarget = platformTarget.replaceString("$platform", with: platform) // Will be removed in upcoming version
+                    platformTarget = platformTarget.replaceString("${platform}", with: platform)
 
                     platformTarget["platform"] = platform
                     let platformSuffix = platformTarget["platformSuffix"] as? String ?? "_\(platform)"

--- a/Sources/XcodeGenCLI/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/GenerateCommand.swift
@@ -64,6 +64,13 @@ class GenerateCommand: Command {
             throw GenerationError.projectSpecParsingError(error)
         }
 
+        // validate project dictionary
+        do {
+            try specLoader.validateProjectDictionaryWarnings()
+        } catch {
+            warning("\(error)")
+        }
+
         let projectPath = projectDirectory + "\(project.name).xcodeproj"
 
         let cacheFilePath = self.cacheFilePath.value ??
@@ -140,6 +147,12 @@ class GenerateCommand: Command {
     func info(_ string: String) {
         if !quiet.value {
             stdout.print(string)
+        }
+    }
+
+    func warning(_ string: String) {
+        if !quiet.value {
+            stdout.print(string.yellow)
         }
     }
 


### PR DESCRIPTION
This allows parameterizing templates. One specific problem I wanted to solve with this issue is that I have a multi-framework project where framework-targets are specified by a target template. Each framework consists of the framework itself and a corresponding test target. The framework template is specified like this:
```yaml
targetTemplates:
  Module:
    platform: iOS
    type: framework
    sources: [modules/$target_name/Sources]
```

Now I'd like to create a template for the test target where the test-files are placed in `modules/<ModuleName>/Tests`. I have no way of defining a common template for this.

When this PR is merged, I'm able to define the following template:
```yaml
targetTemplates:
  ModuleTests:
    platform: iOS
    type: bundle.unit-test
    sources: [modules/$targetUnderTest/Tests]
    dependencies:
      target: $targetUnderTest
```
and use it like this:
```yaml
targets:
  MyFramework:
    templates: [Module]
  MyFrameworkTests:
    templates: [ModuleTests]
    templateAttributes:
      targetUnderTest: MyFramework
```