### PR TITLE
Add support for nested templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `missingConfigFiles` to `options.disabledValidations` to optionally skip checking for the existence of config files.
 - Added ability to automatically include Carthage related dependencies via `includeRelated: true` [#506](https://github.com/yonaskolb/XcodeGen/pull/506) @rpassis
 - Added ability to define a per-platform `deploymentTarget` for Multi-Platform targets. [#510](https://github.com/yonaskolb/XcodeGen/pull/510) @ainopara
+- Added support for nested target templates [#534](https://github.com/yonaskolb/XcodeGen/pull/534) @tomquist
 
 #### Fixed
 - Sources outside a project spec's directory will be correctly referenced as relative paths in the project file. [#524](https://github.com/yonaskolb/XcodeGen/pull/524)


### PR DESCRIPTION
It would be convenient if templates could be nested, which means
a template can be based on another template.

This change implements support for nested templates. It avoids
cycles by just ignoring templates that have already been visited
when collecting the set of templates to use.