### PR TITLE
Fix excludes within included specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixed
 - Sources outside a project spec's directory will be correctly referenced as relative paths in the project file. [#524](https://github.com/yonaskolb/XcodeGen/pull/524)
 - Fixed error when `optional` path is missing [#527](https://github.com/yonaskolb/XcodeGen/pull/527) @yonaskolb
+- Fixed excludes within included spec [#535](https://github.com/yonaskolb/XcodeGen/pull/535) @yonaskolb
 
 ## 2.2.0
 

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -218,7 +218,6 @@ extension TargetSource: PathContainer {
     static var pathProperties: [PathProperty] {
         return [
             .string("path"),
-            .string("excludes"),
         ]
     }
 }

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -8,7 +8,8 @@ targets:
     configFiles:
       Config: config
     sources:
-      - source
+      - path: source
+        excludes: [file]
     dependencies:
       - framework: Framework
     info:

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -68,7 +68,7 @@ class SpecLoadingTests: XCTestCase {
                         type: .application,
                         platform: .tvOS,
                         configFiles: ["Config": "paths_test/config"],
-                        sources: ["paths_test/source"],
+                        sources: [TargetSource(path: "paths_test/source", excludes: ["file"])],
                         dependencies: [Dependency(type: .framework, reference: "paths_test/Framework")],
                         info: Plist(path: "paths_test/info"),
                         entitlements: Plist(path: "paths_test/entitlements"),


### PR DESCRIPTION
Resolves #526
Resolves #518

This fixes excluded within included specs from having that files relative path. This was a regression caused by https://github.com/yonaskolb/XcodeGen/pull/489