### PR TITLE
Fix multi-platform target templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed error when `optional` path is missing [#527](https://github.com/yonaskolb/XcodeGen/pull/527) @yonaskolb
 - Fixed excludes within included spec [#535](https://github.com/yonaskolb/XcodeGen/pull/535) @yonaskolb
 - Fixed paths in target templates within included files not being relative [#537](https://github.com/yonaskolb/XcodeGen/pull/537) @yonaskolb
+- Fix multi-platform target templates [#541](https://github.com/yonaskolb/XcodeGen/pull/541) @yonaskolb
 
 ## 2.2.0
 

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -171,8 +171,8 @@ extension Project {
 
     static func resolveProject(jsonDictionary: JSONDictionary) throws -> JSONDictionary {
         var jsonDictionary = jsonDictionary
-        jsonDictionary = try Target.resolveMultiplatformTargets(jsonDictionary: jsonDictionary)
         jsonDictionary = try Target.resolveTargetTemplates(jsonDictionary: jsonDictionary)
+        jsonDictionary = try Target.resolveMultiplatformTargets(jsonDictionary: jsonDictionary)
         return jsonDictionary
     }
 }

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -171,8 +171,13 @@ extension Project {
 
     static func resolveProject(jsonDictionary: JSONDictionary) throws -> JSONDictionary {
         var jsonDictionary = jsonDictionary
+
+        // resolve multiple times so that we support both multi-platform templates,
+        // as well as platform specific templates in multi-platform targets
+        jsonDictionary = try Target.resolveMultiplatformTargets(jsonDictionary: jsonDictionary)
         jsonDictionary = try Target.resolveTargetTemplates(jsonDictionary: jsonDictionary)
         jsonDictionary = try Target.resolveMultiplatformTargets(jsonDictionary: jsonDictionary)
+
         return jsonDictionary
     }
 }

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -613,6 +613,32 @@ class SpecLoadingTests: XCTestCase {
                 try expect(tvOSTarget?.type) == .framework
             }
 
+            $0.it("parses platform specific templates") {
+
+                let project = try getProjectSpec([
+                    "targets": [
+                        "Framework": [
+                            "type": "framework",
+                            "platform": ["iOS", "tvOS"],
+                            "templates": ["$platform"],
+                        ]
+                    ],
+                    "targetTemplates": [
+                        "iOS": [
+                            "sources": "A",
+                        ],
+                        "tvOS": [
+                            "sources": "B",
+                        ]
+                    ],
+                    ])
+
+                let iOSTarget = project.targets.first { $0.platform == .iOS }
+                let tvOSTarget = project.targets.first { $0.platform == .tvOS }
+                try expect(iOSTarget?.sources) == ["A"]
+                try expect(tvOSTarget?.sources) == ["B"]
+            }
+
             $0.it("parses aggregate targets") {
                 let dictionary: [String: Any] = [
                     "targets": ["target_1", "target_2"],

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -590,6 +590,28 @@ class SpecLoadingTests: XCTestCase {
                 try expect(target.sources) == ["nestedTemplateSource2", "nestedTemplateSource1", "templateSource", "targetSource"] // merges array in order
                 try expect(target.configFiles["debug"]) == "Configs/Framework/debug.xcconfig" // replaces $target_name
             }
+            
+            $0.it("parses cross platform target templates") {
+  
+                let project = try getProjectSpec([
+                    "targets": [
+                        "Framework": [
+                            "type": "framework",
+                            "templates": ["temp"],
+                        ]
+                    ],
+                    "targetTemplates": [
+                        "temp": [
+                            "platform": ["iOS", "tvOS"],
+                        ]
+                    ],
+                    ])
+                
+                let iOSTarget = project.targets.first { $0.platform == .iOS }
+                let tvOSTarget = project.targets.first { $0.platform == .tvOS }
+                try expect(iOSTarget?.type) == .framework
+                try expect(tvOSTarget?.type) == .framework
+            }
 
             $0.it("parses aggregate targets") {
                 let dictionary: [String: Any] = [


### PR DESCRIPTION
Fixes #523
This was due to multi-platform targets being resolved before templates. This order is now switched