### PR TITLE
Fix included relative sources in mixed arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed excludes within included spec [#535](https://github.com/yonaskolb/XcodeGen/pull/535) @yonaskolb
 - Fixed paths in target templates within included files not being relative [#537](https://github.com/yonaskolb/XcodeGen/pull/537) @yonaskolb
 - Fix multi-platform target templates [#541](https://github.com/yonaskolb/XcodeGen/pull/541) @yonaskolb
+- Fixed sources in an included target not being relative when the sources are mix of string and dictionaries [#542](https://github.com/yonaskolb/XcodeGen/pull/542) @yonaskolb
 
 ## 2.2.0
 

--- a/Sources/ProjectSpec/PathContainer.swift
+++ b/Sources/ProjectSpec/PathContainer.swift
@@ -23,8 +23,14 @@ extension Array where Element == PathProperty {
             case .string(let key):
                 if let source = result[key] as? String {
                     result[key] = (path + source).string
-                } else if let source = result[key] as? [String] {
-                    result[key] = source.map { (path + $0).string }
+                } else if let source = result[key] as? [Any] {
+                    result[key] = source.map { any -> Any in
+                        if let string = any as? String {
+                            return (path + string).string
+                        } else {
+                            return any
+                        }
+                    }
                 } else if let source = result[key] as? [String: String] {
                     result[key] = source.mapValues { (path + $0).string }
                 }
@@ -37,8 +43,14 @@ extension Array where Element == PathProperty {
             case .object(let key, let pathProperties):
                 if let source = result[key] as? JSONDictionary {
                     result[key] = pathProperties.resolvingPaths(in: source, relativeTo: path)
-                } else if let source = result[key] as? [JSONDictionary] {
-                    result[key] = source.map { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
+                } else if let source = result[key] as? [Any] {
+                    result[key] = source.map { any -> Any in
+                        if let dictionary = any as? JSONDictionary {
+                            return pathProperties.resolvingPaths(in: dictionary, relativeTo: path)
+                        } else {
+                            return any
+                        }
+                    }
                 } else if let source = result[key] as? [String: JSONDictionary] {
                     result[key] = source.mapValues { pathProperties.resolvingPaths(in: $0, relativeTo: path) }
                 }

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -8,6 +8,7 @@ targets:
     configFiles:
       Config: config
     sources:
+      - simplesource
       - path: source
         excludes: [file]
     dependencies:

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -69,7 +69,10 @@ class SpecLoadingTests: XCTestCase {
                         type: .application,
                         platform: .tvOS,
                         configFiles: ["Config": "paths_test/config"],
-                        sources: [TargetSource(path: "paths_test/source", excludes: ["file"])],
+                        sources: [
+                            "paths_test/simplesource",
+                            TargetSource(path: "paths_test/source", excludes: ["file"]),
+                            ],
                         dependencies: [Dependency(type: .framework, reference: "paths_test/Framework")],
                         info: Plist(path: "paths_test/info"),
                         entitlements: Plist(path: "paths_test/entitlements"),


### PR DESCRIPTION
This fixes cases where targets that were in an `include` file didn't have their sources transformed to be relative if they had multiple sources that were a mix of simple string definitions and complex dictionaries:

```yml
targets:
  App:
    sources:
      - simplesource
      - path: sources
         name: Sources
```