### PR TITLE
Fixed flattening of relative paths (#525)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Updated default generated settings for Xcode 10.2 [#555](https://github.com/yonaskolb/XcodeGen/pull/555) @yonaskolb
 
 #### Fixed
+- Groups from sources outside a project spec's directory will not be flattened. [#550](https://github.com/yonaskolb/XcodeGen/pull/550) @sroebert
 - Fixed `optional` file sources not being added to the project [#557](https://github.com/yonaskolb/XcodeGen/pull/557) @yonaskolb
 
 ## 2.4.0

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -247,7 +247,7 @@ class SourceGenerator {
             let isOutOfBasePath = !path.absolute().string.contains(project.basePath.absolute().string)
 
             // has no valid parent paths
-            let isRootPath = isOutOfBasePath || path.parent() == project.basePath
+            let isRootPath = (isBaseGroup && isOutOfBasePath) || path.parent() == project.basePath
 
             // is a top level group in the project
             let isTopLevelGroup = (isBaseGroup && !createIntermediateGroups) || isRootPath


### PR DESCRIPTION
Currently when adding relative paths as a source root, all folders are flattened as root groups in the Xcode project (#525). This fix makes sure the folder structure is kept without flattening.