### PR TITLE
Fix Carthage dependencies for watchOS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 #### Fixed
 - Fixed `optional` file sources not being added to the project [#557](https://github.com/yonaskolb/XcodeGen/pull/557) @yonaskolb
 - Fixed order of file generation. Plists are now generated before the project is generated so that the project includes the generated plists [#544](https://github.com/yonaskolb/XcodeGen/issues/544) @tomquist
+- Addressed an issue that causes Carthage depencencies incorrectly embedded in WatchKit app bundle instead of WatchKit app extension [#558](https://github.com/yonaskolb/XcodeGen/pull/558) @KhaosT
 
 ## 2.4.0
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -421,7 +421,7 @@ public class PBXProjGenerator {
             getAllDependenciesPlusTransitiveNeedingEmbedding(target: target) : target.dependencies
 
         let targetSupportsDirectEmbed = !(target.platform.requiresSimulatorStripping &&
-            ((target.type.isApp && target.platform != .watchOS) || target.type == .watch2Extension ))
+            (target.type.isApp || target.type == .watch2Extension))
         let directlyEmbedCarthage = target.directlyEmbedCarthageDependencies ?? targetSupportsDirectEmbed
 
         func getEmbedSettings(dependency: Dependency, codeSign: Bool) -> [String: Any] {

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -1125,7 +1125,6 @@
 			buildPhases = (
 				91C895DE8170C96A75D29426BA2BC597 /* Sources */,
 				B7B71FA7D279029BF7A7FC7C08E41BB0 /* Resources */,
-				261B4BE58AA60B68A81874E3318793F3 /* Carthage */,
 				C765431E5FF4B02F59DE79B068D2CB68 /* Embed App Extensions */,
 			);
 			buildRules = (
@@ -1144,6 +1143,7 @@
 			buildPhases = (
 				AE7971E1CA54D23C264E6541EA9BAE1B /* Sources */,
 				4A6E8F3A477AA5F67A8EB733DFAD8387 /* Resources */,
+				8F8EE32AFABD8FEF976253259FA39ABC /* Carthage */,
 			);
 			buildRules = (
 			);
@@ -1580,22 +1580,6 @@
 			shellPath = /bin/sh;
 			shellScript = "ditto \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 		};
-		261B4BE58AA60B68A81874E3318793F3 /* Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/watchOS/Result.framework",
-			);
-			name = Carthage;
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "carthage copy-frameworks\n";
-		};
 		37182EC208DBF03DB1BAF452E1D2C836 /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1683,6 +1667,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "echo \"You ran a script\"\n";
+		};
+		8F8EE32AFABD8FEF976253259FA39ABC /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/watchOS/Result.framework",
+			);
+			name = Carthage;
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "carthage copy-frameworks\n";
 		};
 		BA454AAC926EDFCDA9226CBCACCBEDB1 /* MyScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
It appears that App Store does not allow embedding additional frameworks directly inside WatchKit app's framework directory (ITMS-90539). Instead, all embedded frameworks should live inside the app extension.

This PR updated the behavior to embed Carthage dependencies to watch extension, instead of the WatchKit app. Should address #511.

https://forums.developer.apple.com/thread/76615