### PR TITLE
support sdks with dylib extension

### DIFF
--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -149,6 +149,7 @@ extension Project {
                     if !dependency.reference.contains("/") {
                         switch path.extension {
                         case "framework"?,
+                            "dylib"?,
                              "tbd"?:
                             break
                         default:


### PR DESCRIPTION
Attempting to build a project with a dependency like `- sdk: libz.dylib` causes an error: `Spec validation error: Target "TARGET_NAME" has invalid sdk dependency: "libz.dylib". It must be a full path or have the following extensions: .framework, .dylib, .tbd`