### PR TITLE
Fix watchOS Intents Extension support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Added ability to encode ProjectSpec to JSON [#545](https://github.com/yonaskolb/XcodeGen/pull/545) @ryohey
 
+#### Fixed
+- Fixed an issue that prevents watchOS Intents Extension from running correctly. [#TBD](https://github.com/yonaskolb/XcodeGen/pull/TDB) @KhaosT
+
 ## 2.5.0
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Added ability to encode ProjectSpec to JSON [#545](https://github.com/yonaskolb/XcodeGen/pull/545) @ryohey
 
 #### Fixed
-- Fixed an issue that prevents watchOS Intents Extension from running correctly. [#TBD](https://github.com/yonaskolb/XcodeGen/pull/TDB) @KhaosT
+- Fixed an issue that prevents watchOS Intents Extension from running correctly. [#571](https://github.com/yonaskolb/XcodeGen/pull/571) @KhaosT
 
 ## 2.5.0
 

--- a/SettingPresets/Products/app-extension.intents-service.yml
+++ b/SettingPresets/Products/app-extension.intents-service.yml
@@ -1,0 +1,1 @@
+LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks @executable_path/../../../../Frameworks"


### PR DESCRIPTION
watchOS Intents Extension is embedded in `Main.app/Watch/Watch.app/PlugIns/WatchExtension.appex/PlugIns/SiriExtension.appex` and embedded frameworks are located under `Main.app/Watch/Watch.app/PlugIns/WatchExtension.appex/Frameworks`.

Prior to this change, the generated project does not correctly populate `LD_RUNPATH_SEARCH_PATHS`, causing the Intents Extension failed to launch during lack of @rpath. This also prevented app embedding such extension from submitting to App Store as App Store Connect failed to validate the app bundle.
```
Invalid Bundle - One or more dynamic libraries that are referenced by your app are not present in the dylib search path.
```