### PR TITLE
Change compatibilityVersion to Xcode 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Added ability to encode ProjectSpec to JSON [#545](https://github.com/yonaskolb/XcodeGen/pull/545) @ryohey
 
+#### Changed
+- Follow up on the Xcode 10.2 updates done in [#555](https://github.com/yonaskolb/XcodeGen/pull/555): updated the `compatibilityVersion` project setting to `Xcode 10.0`. With the `compatibilityVersion` set to `Xcode 9.3`, Xcode automatically sets the `ObjectVersion` from `51` to `50` [#578](https://github.com/yonaskolb/XcodeGen/pull/578) @acecilia
+
 ## 2.5.0
 
 #### Added

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -87,7 +87,7 @@ public class PBXProjGenerator {
             PBXProject(
                 name: project.name,
                 buildConfigurationList: buildConfigList,
-                compatibilityVersion: project.compatabilityVersion,
+                compatibilityVersion: project.compatibilityVersion,
                 mainGroup: mainGroup,
                 developmentRegion: project.options.developmentLanguage ?? "en"
             )

--- a/Sources/XcodeGenKit/Version.swift
+++ b/Sources/XcodeGenKit/Version.swift
@@ -11,8 +11,8 @@ extension Project {
         return "1.3"
     }
 
-    var compatabilityVersion: String {
-        return "Xcode 9.3"
+    var compatibilityVersion: String {
+        return "Xcode 10.0"
     }
 
     var objectVersion: UInt {


### PR DESCRIPTION
I experienced that with the `compatibilityVersion` set to `Xcode 9.3`, Xcode automatically sets the `ObjectVersion` from `51` to `50`.