### PR TITLE
Allow skipping tests in test targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Added
 
 - Added ability to encode ProjectSpec to JSON [#545](https://github.com/yonaskolb/XcodeGen/pull/545) @ryohey
+- Added ability to skip tests [#582](https://github.com/yonaskolb/XcodeGen/pull/582) @kadarandras
 
 ## 2.5.0
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -691,6 +691,7 @@ A multiline script can be written using the various YAML multiline methods, for 
 - [x] **name**: **String** - The name of the target
 - [ ] **parallelizable**: **Bool** - Whether to run tests in parallel. Defaults to false
 - [ ] **randomExecutionOrder**: **Bool** - Whether to run tests in a random order. Defaults to false
+- [ ] **skippedTests**: **[String]** - List of tests in the test target to skip. Defaults to empty.
 
 ### Archive Action
 
@@ -719,7 +720,12 @@ schemes:
       config: prod-debug
       commandLineArguments: "--option testValue"
       gatherCoverageData: true
-      targets: [Tester1, Tester2]
+      targets: 
+        - Tester1 
+        - name: Tester2
+          parallelizable: true
+          randomExecutionOrder: true
+          skippedTests: [Test/testExample()]
       environmentVariables:
         - variable: TEST_ENV_VAR
           value: VALUE

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -102,25 +102,30 @@ public struct Scheme: Equatable {
         public struct TestTarget: Equatable, ExpressibleByStringLiteral {
             public static let randomExecutionOrderDefault = false
             public static let parallelizableDefault = false
+            public static let skippedTestsDefault: [String] = []
 
             public let name: String
             public var randomExecutionOrder: Bool
             public var parallelizable: Bool
+            public var skippedTests: [String]
 
             public init(
                 name: String,
                 randomExecutionOrder: Bool = randomExecutionOrderDefault,
-                parallelizable: Bool = parallelizableDefault
+                parallelizable: Bool = parallelizableDefault,
+                skippedTests: [String] = skippedTestsDefault
             ) {
                 self.name = name
                 self.randomExecutionOrder = randomExecutionOrder
                 self.parallelizable = parallelizable
+                self.skippedTests = skippedTests
             }
 
             public init(stringLiteral value: String) {
                 name = value
                 randomExecutionOrder = false
                 parallelizable = false
+                skippedTests = []
             }
         }
 
@@ -306,6 +311,7 @@ extension Scheme.Test.TestTarget: JSONObjectConvertible {
         name = try jsonDictionary.json(atKeyPath: "name")
         randomExecutionOrder = jsonDictionary.json(atKeyPath: "randomExecutionOrder") ?? Scheme.Test.TestTarget.randomExecutionOrderDefault
         parallelizable = jsonDictionary.json(atKeyPath: "parallelizable") ?? Scheme.Test.TestTarget.parallelizableDefault
+        skippedTests = jsonDictionary.json(atKeyPath: "skippedTests") ?? Scheme.Test.TestTarget.skippedTestsDefault
     }
 }
 

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -102,7 +102,6 @@ public struct Scheme: Equatable {
         public struct TestTarget: Equatable, ExpressibleByStringLiteral {
             public static let randomExecutionOrderDefault = false
             public static let parallelizableDefault = false
-            public static let skippedTestsDefault: [String] = []
 
             public let name: String
             public var randomExecutionOrder: Bool
@@ -113,7 +112,7 @@ public struct Scheme: Equatable {
                 name: String,
                 randomExecutionOrder: Bool = randomExecutionOrderDefault,
                 parallelizable: Bool = parallelizableDefault,
-                skippedTests: [String] = skippedTestsDefault
+                skippedTests: [String] = []
             ) {
                 self.name = name
                 self.randomExecutionOrder = randomExecutionOrder
@@ -311,7 +310,7 @@ extension Scheme.Test.TestTarget: JSONObjectConvertible {
         name = try jsonDictionary.json(atKeyPath: "name")
         randomExecutionOrder = jsonDictionary.json(atKeyPath: "randomExecutionOrder") ?? Scheme.Test.TestTarget.randomExecutionOrderDefault
         parallelizable = jsonDictionary.json(atKeyPath: "parallelizable") ?? Scheme.Test.TestTarget.parallelizableDefault
-        skippedTests = jsonDictionary.json(atKeyPath: "skippedTests") ?? Scheme.Test.TestTarget.skippedTestsDefault
+        skippedTests = jsonDictionary.json(atKeyPath: "skippedTests") ?? []
     }
 }
 

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -133,7 +133,8 @@ public class SchemeGenerator {
                 skipped: false,
                 parallelizable: testTarget.parallelizable,
                 randomExecutionOrdering: testTarget.randomExecutionOrder,
-                buildableReference: testBuilEntries.buildableReference
+                buildableReference: testBuilEntries.buildableReference,
+                skippedTests: testTarget.skippedTests.map(XCScheme.SkippedTest.init)
             )
         }
 

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -729,6 +729,7 @@ class SpecLoadingTests: XCTestCase {
                                 "name": "Target2",
                                 "parallelizable": true,
                                 "randomExecutionOrder": true,
+                                "skippedTests": ["Test/testExample()"]
                             ],
                         ],
                         "gatherCoverageData": true,
@@ -760,7 +761,8 @@ class SpecLoadingTests: XCTestCase {
                         Scheme.Test.TestTarget(
                             name: "Target2",
                             randomExecutionOrder: true,
-                            parallelizable: true
+                            parallelizable: true,
+                            skippedTests: ["Test/testExample()"]
                         ),
                     ]
                 )


### PR DESCRIPTION
Since the used xcodeproj project allows an extra `skippedTests` parameter inside the `TestableReference.init`, with a small change in the project I was able to implement the same functionality here.

https://github.com/tuist/xcodeproj/blob/master/Sources/xcodeproj/Scheme/XCScheme%2BTestableReference.swift#L20