### PR TITLE
Add support for custom groups in target sources

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -302,7 +302,8 @@ A source can be provided via a string (the path) or an object of the form:
 #### Target Source
 
 - [x] **path**: **String** - The path to the source file or directory.
-- [ ] **name**: **String** - Can be used to override the name of the source file or directory. By default the last component of the path is used for the name
+- [ ] **name**: **String** - Can be used to override the name of the source file or directory. By default the last component of the path is used for the name.
+- [ ] **group**: **String** - A path-like string representing the project group hierarchy in which the source file or directory should appear.
 - [ ] **compilerFlags**: **[String]** or **String** - A list of compilerFlags to add to files under this specific path provided as a list or a space delimitted string. Defaults to empty.
 - [ ] **excludes**: **[String]** - A list of [global patterns](https://en.wikipedia.org/wiki/Glob_(programming)) representing the files to exclude. These rules are relative to `path` and _not the directory where `project.yml` resides_.
 - [ ] **createIntermediateGroups**: **Bool** - This overrides the value in [Options](#options)
@@ -618,7 +619,7 @@ Any attributes defined within a targets `templateAttributes` will be used to rep
 ```yaml
 targets:
   MyFramework:
-    templates: 
+    templates:
       - Framework
     templateAttributes:
       frameworkName: AwesomeFramework
@@ -728,8 +729,8 @@ schemes:
       config: prod-debug
       commandLineArguments: "--option testValue"
       gatherCoverageData: true
-      targets: 
-        - Tester1 
+      targets:
+        - Tester1
         - name: Tester2
           parallelizable: true
           randomExecutionOrder: true

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -9,6 +9,7 @@ public struct TargetSource: Equatable {
 
     public var path: String
     public var name: String?
+    public var group: String?
     public var compilerFlags: [String]
     public var excludes: [String]
     public var type: SourceType?
@@ -123,6 +124,7 @@ public struct TargetSource: Equatable {
     public init(
         path: String,
         name: String? = nil,
+        group: String? = nil,
         compilerFlags: [String] = [],
         excludes: [String] = [],
         type: SourceType? = nil,
@@ -134,6 +136,7 @@ public struct TargetSource: Equatable {
     ) {
         self.path = path
         self.name = name
+        self.group = group
         self.compilerFlags = compilerFlags
         self.excludes = excludes
         self.type = type
@@ -165,6 +168,7 @@ extension TargetSource: JSONObjectConvertible {
     public init(jsonDictionary: JSONDictionary) throws {
         path = try jsonDictionary.json(atKeyPath: "path")
         name = jsonDictionary.json(atKeyPath: "name")
+        group = jsonDictionary.json(atKeyPath: "group")
 
         let maybeCompilerFlagsString: String? = jsonDictionary.json(atKeyPath: "compilerFlags")
         let maybeCompilerFlagsArray: [String]? = jsonDictionary.json(atKeyPath: "compilerFlags")
@@ -193,6 +197,7 @@ extension TargetSource: JSONEncodable {
             "compilerFlags": compilerFlags,
             "excludes": excludes,
             "name": name,
+            "group": group,
             "headerVisibility": headerVisibility?.rawValue,
             "type": type?.rawValue,
             "buildPhase": buildPhase?.toJSONValue(),

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 
 /* Begin PBXBuildFile section */
 		01BFA2C4D9C5BBC72C015AA8 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		01C2453A267140188E1B9B81 /* utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F0789275EF43FB229D71173 /* utility.swift */; };
 		02F9D686CBA6068A8EE58026 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D0C79A8C750EC0DE748C463 /* StaticLibrary_ObjC.m */; };
 		0786F9C725AD215C4F915BB5 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		078FAAF5C2B851C7D5EA714F /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE /* Result.framework */; };
@@ -440,6 +441,7 @@
 		38F1191E5B85DC882B8ABE85 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3D8A2D4363866877B9140156 /* XPC_ServiceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPC_ServiceProtocol.h; sourceTree = "<group>"; };
 		3EF21DF245F66BEF5446AAEF /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3F0789275EF43FB229D71173 /* utility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = utility.swift; path = CustomGroup/utility.swift; sourceTree = "<group>"; };
 		41FC82ED1C4C3B7B3D7B2FB7 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		42B95EB66A17FBA091F50601 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		4BF4D16042A80576D259160C /* Model 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 3.xcdatamodel"; sourceTree = "<group>"; };
@@ -467,6 +469,7 @@
 		7F1A2F579A6F79C62DDA0571 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7FDC16E1938AA114B67D87A9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
 		814822136AF3C64428D69DD6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		86D80193B705AA1A8563C164 /* CustomGroup.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = CustomGroup.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8A9274BE42A03DC5DA1FAD04 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8CAF6C55B555E3E1352645B6 /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
 		9390121B4ECBB1B796C7CBBD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -665,6 +668,7 @@
 				795B8D70B674C850B57DD39D /* App_watchOS Extension */,
 				6DBE0EE90642BB3F6E58AD43 /* Configs */,
 				3F2E22B7AB20FA42CD205C2A /* CopyFiles */,
+				FCC084D4F8992BBC49983A38 /* CustomGroup */,
 				5CBCE0E2A145046265FE99E2 /* FileGroup */,
 				1A57D1EE1FBC13598F6B5CB0 /* Framework */,
 				B370CE9C04C41EBC52D4E4EA /* iMessage */,
@@ -712,6 +716,14 @@
 				70A8E15C81E454DC950C59F0 /* SomeXPCService.xpc */,
 			);
 			path = Vendor;
+			sourceTree = "<group>";
+		};
+		46EE46AC9F0F52F6AB577474 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				3F0789275EF43FB229D71173 /* utility.swift */,
+			);
+			name = Utilities;
 			sourceTree = "<group>";
 		};
 		5CBCE0E2A145046265FE99E2 /* FileGroup */ = {
@@ -806,6 +818,7 @@
 				33F6DCDC37D2E66543D4965D /* App_macOS.app */,
 				0D09D243DBCF9D32E239F1E8 /* App_watchOS Extension.appex */,
 				A680BE9F68A255B0FB291AE6 /* App_watchOS.app */,
+				86D80193B705AA1A8563C164 /* CustomGroup.a */,
 				7D700FA699849D2F95216883 /* EntitledApp.app */,
 				8A9274BE42A03DC5DA1FAD04 /* Framework.framework */,
 				41FC82ED1C4C3B7B3D7B2FB7 /* Framework.framework */,
@@ -904,6 +917,14 @@
 			path = App_macOS;
 			sourceTree = "<group>";
 		};
+		F73BBD6C3321D71E5CE8B8D6 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				46EE46AC9F0F52F6AB577474 /* Utilities */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
 		FC1515684236259C50A7747F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -921,6 +942,14 @@
 				D132EA69984F32DA9DC727B6 /* TestProjectTests.swift */,
 			);
 			path = App_iOS_Tests;
+			sourceTree = "<group>";
+		};
+		FCC084D4F8992BBC49983A38 /* CustomGroup */ = {
+			isa = PBXGroup;
+			children = (
+				F73BBD6C3321D71E5CE8B8D6 /* Sources */,
+			);
+			name = CustomGroup;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1199,6 +1228,22 @@
 			productName = "App_watchOS Extension";
 			productReference = 0D09D243DBCF9D32E239F1E8 /* App_watchOS Extension.appex */;
 			productType = "com.apple.product-type.watchkit2-extension";
+		};
+		39740856C6070F02F1C6D08E /* CustomGroup */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FBFEA523165CF6A5FBBD11BC /* Build configuration list for PBXNativeTarget "CustomGroup" */;
+			buildPhases = (
+				77B89868D3B9B03EDB2CEA1D /* Sources */,
+				EF03AAD5282BBFD6B117B62B /* Copy Swift Objective-C Interface Header */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CustomGroup;
+			productName = CustomGroup;
+			productReference = 86D80193B705AA1A8563C164 /* CustomGroup.a */;
+			productType = "com.apple.product-type.library.static";
 		};
 		536ACF18E4603B59207D43CE /* Framework_tvOS */ = {
 			isa = PBXNativeTarget;
@@ -1515,6 +1560,7 @@
 				020A320BB3736FCDE6CC4E70 /* App_macOS */,
 				208179651927D1138D19B5AD /* App_watchOS */,
 				307AE3FA155FFD09B74AE351 /* App_watchOS Extension */,
+				39740856C6070F02F1C6D08E /* CustomGroup */,
 				B61ED4688789B071275E2B7A /* EntitledApp */,
 				CE7D183D3752B5B35D2D8E6D /* Framework2_iOS */,
 				FC26AF2506D3B2B40DE8A5F8 /* Framework2_macOS */,
@@ -1789,6 +1835,22 @@
 			shellPath = /bin/sh;
 			shellScript = "echo \"do the thing\"";
 		};
+		EF03AAD5282BBFD6B117B62B /* Copy Swift Objective-C Interface Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DERIVED_SOURCES_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			name = "Copy Swift Objective-C Interface Header";
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/include/$(PRODUCT_MODULE_NAME)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "ditto \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -1882,6 +1944,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				079B6E02AF21664AB08E621C /* TestProjectUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		77B89868D3B9B03EDB2CEA1D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				01C2453A267140188E1B9B81 /* utility.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2877,6 +2947,17 @@
 			};
 			name = "Production Debug";
 		};
+		45EE9B23C13427B5BB418E46 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.CustomGroup;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
 		4621C6C8A78FBB1CF4078178 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3320,6 +3401,17 @@
 			};
 			name = "Staging Release";
 		};
+		64197A225D32415A877B3496 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.CustomGroup;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
 		64BEC335CD4016B9BC59F3C9 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3378,6 +3470,17 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Staging Debug";
+		};
+		677C130781432460D684E917 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.CustomGroup;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
 		};
 		6A11812952F34525D14A4104 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
@@ -3487,6 +3590,17 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Production Release";
+		};
+		79FB285E32C47FEB97F93FD3 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.CustomGroup;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
 		};
 		7B2A1BE6CA654E9903A4C680 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
@@ -3670,6 +3784,17 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Test Debug";
+		};
+		911914C3D977DD8FF6231719 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.CustomGroup;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
 		};
 		921EC740167F616C38809275 /* Production Release */ = {
 			isa = XCBuildConfiguration;
@@ -4684,6 +4809,17 @@
 			};
 			name = "Production Debug";
 		};
+		DE0E97DEB1721328F41793B7 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.CustomGroup;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
 		DF558E25A4E143219DF4AA51 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5611,6 +5747,19 @@
 				0EFE33A4C09DCF9FE1519D37 /* Staging Release */,
 				2F88193D8069519CD36F649B /* Test Debug */,
 				7B4F942EA48FC1FED21AA2EE /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		FBFEA523165CF6A5FBBD11BC /* Build configuration list for PBXNativeTarget "CustomGroup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				911914C3D977DD8FF6231719 /* Production Debug */,
+				677C130781432460D684E917 /* Production Release */,
+				64197A225D32415A877B3496 /* Staging Debug */,
+				79FB285E32C47FEB97F93FD3 /* Staging Release */,
+				DE0E97DEB1721328F41793B7 /* Test Debug */,
+				45EE9B23C13427B5BB418E46 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -164,7 +164,7 @@ targets:
   iMessageStickersExtension:
     type: app-extension.messages-sticker-pack
     platform: iOS
-    sources:       
+    sources:
       - path: iMessage Stickers
 
   StaticLibrary_ObjC:
@@ -238,6 +238,13 @@ targets:
     platform: macOS
     sources: [Tool]
     scheme: {}
+
+  CustomGroup:
+    type: library.static
+    platform: iOS
+    sources:
+      - path: CustomGroup/utility.swift
+        group: CustomGroup/Sources/Utilities
 
 schemes:
   Framework:


### PR DESCRIPTION
Currently, the groups layout in the Xcode project is bound to the filesystem organisation of source files. This patch adds a new 'group' property for target sources which allows the customization of the group where said source should appear in.

Resolves #478