### PR TITLE
Added custom group support for target sources (#478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Added
+- Added custom group support for target sources [#611](https://github.com/yonaskolb/XcodeGen/pull/611) @sroebert
+
 ## 2.6.0
 
 #### Added

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -303,6 +303,7 @@ A source can be provided via a string (the path) or an object of the form:
 
 - [x] **path**: **String** - The path to the source file or directory.
 - [ ] **name**: **String** - Can be used to override the name of the source file or directory. By default the last component of the path is used for the name
+- [ ] **group**: **String** - Can be used to override the parent group of the source file or directory. By default a group is created at the root with the name of this source file or directory or intermediate groups are created if `createIntermediateGroups` is set to `true`. Multiple groups can be created by separating each one using a `/`. If multiple target sources share the same `group`, they will be put together in the same parent group.
 - [ ] **compilerFlags**: **[String]** or **String** - A list of compilerFlags to add to files under this specific path provided as a list or a space delimitted string. Defaults to empty.
 - [ ] **excludes**: **[String]** - A list of [global patterns](https://en.wikipedia.org/wiki/Glob_(programming)) representing the files to exclude. These rules are relative to `path` and _not the directory where `project.yml` resides_.
 - [ ] **createIntermediateGroups**: **Bool** - This overrides the value in [Options](#options)

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -9,6 +9,7 @@ public struct TargetSource: Equatable {
 
     public var path: String
     public var name: String?
+    public var group: String?
     public var compilerFlags: [String]
     public var excludes: [String]
     public var type: SourceType?
@@ -123,6 +124,7 @@ public struct TargetSource: Equatable {
     public init(
         path: String,
         name: String? = nil,
+        group: String? = nil,
         compilerFlags: [String] = [],
         excludes: [String] = [],
         type: SourceType? = nil,
@@ -134,6 +136,7 @@ public struct TargetSource: Equatable {
     ) {
         self.path = path
         self.name = name
+        self.group = group
         self.compilerFlags = compilerFlags
         self.excludes = excludes
         self.type = type
@@ -165,6 +168,7 @@ extension TargetSource: JSONObjectConvertible {
     public init(jsonDictionary: JSONDictionary) throws {
         path = try jsonDictionary.json(atKeyPath: "path")
         name = jsonDictionary.json(atKeyPath: "name")
+        group = jsonDictionary.json(atKeyPath: "group")
 
         let maybeCompilerFlagsString: String? = jsonDictionary.json(atKeyPath: "compilerFlags")
         let maybeCompilerFlagsArray: [String]? = jsonDictionary.json(atKeyPath: "compilerFlags")
@@ -193,6 +197,7 @@ extension TargetSource: JSONEncodable {
             "compilerFlags": compilerFlags,
             "excludes": excludes,
             "name": name,
+            "group": group,
             "headerVisibility": headerVisibility?.rawValue,
             "type": type?.rawValue,
             "buildPhase": buildPhase?.toJSONValue(),


### PR DESCRIPTION
As I really need custom grouping support in my team, for keeping a proper structure in our large project, I was looking forward to using #607. Unfortunately I saw some issues with this implementation, specifically the flattening of groups of directories, which was originally solved by #550. Also having multiple target sources in a custom group with a depth larger than 1, did not really seem to work.

For this reason I created this pull request where both issues are solved. This should implement the request mentioned in #478, while keeping the same behaviour for target sources as before.