### PR TITLE
Support Swift Packages

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -584,6 +584,26 @@ public class PBXProjGenerator {
                 )
                 targetFrameworkBuildFiles.append(buildFile)
 
+            case .swiftpm(let config):
+                if let config: XCRemoteSwiftPackageReference = config {
+                    let remotePackageReference = addObject(config)
+                    let packageProductDependency = addObject(
+                        XCSwiftPackageProductDependency(
+                            productName: remotePackageReference.name!,
+                            package: remotePackageReference
+                        )
+                    )
+
+                    pbxProj.rootObject!.packages.append(remotePackageReference)
+                    targetObjects[target.name]!.packageProductDependencies.append(packageProductDependency)
+
+                    let buildFile = addObject(
+                        PBXBuildFile(product: packageProductDependency)
+                    )
+
+                    targetFrameworkBuildFiles.append(buildFile)
+                }
+
             case .carthage(let findFrameworks):
                 let findFrameworks = findFrameworks ?? project.options.findCarthageFrameworks
                 let allDependencies = findFrameworks
@@ -992,6 +1012,8 @@ public class PBXProjGenerator {
                             dependencies[dependency.reference] = dependency
                         }
                     }
+                case .swiftpm(let config):
+                    break
                 }
             }
 


### PR DESCRIPTION
#606

I personally needed this feature, so implemented.
Looks like Yonas already has an implementation, so feel free to just close this one, but otherwise people can use this branch for now.

If you want me to keep going, I will clean up the dirty codes and add tests etc.👌

## project spec consideration

I chose yml format to be rather **simple than elegant**, using `XCRemoteSwiftPackageReference` directly.

Sample `project.yml`:

```yml
name: App
targets:
  App:
    type: application
    platform: iOS
    dependencies:
      - swiftpm:
        repositoryURL: "https://github.com/tuist/xcodeproj"
        versionRequirement:
          kind: upToNextMajorVersion
          minimumVersion: 7.0.0
```

See: https://github.com/tuist/xcodeproj/blob/58c6acf1111b92a9acf633359a10249cf7940045/Sources/xcodeproj/Objects/SwiftPackage/XCRemoteSwiftPackageReference.swift

## swiftpm process

SwiftPM's package resolving and fetching process begins when you open the generated xcodeproj with Xcode11beta.