### PR TITLE
Ignore files with orig extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Fixed
 - Fixed included specs that were referenced multiple times from duplicating content [#599](https://github.com/yonaskolb/XcodeGen/pull/599) @haritowa
+- Fixed `.orig` files being added to the project [#627](https://github.com/yonaskolb/XcodeGen/pull/627) @keith
 
 ## 2.6.0
 

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -24,6 +24,9 @@ class SourceGenerator {
     var defaultExcludedFiles = [
         ".DS_Store",
     ]
+    private let defaultExcludedExtensions = [
+        "orig",
+    ]
 
     private(set) var knownRegions: Set<String> = []
 
@@ -317,6 +320,7 @@ class SourceGenerator {
     /// Checks whether the path is not in any default or TargetSource excludes
     func isIncludedPath(_ path: Path) -> Bool {
         return !defaultExcludedFiles.contains(where: { path.lastComponent.contains($0) })
+            && !(path.extension.map(defaultExcludedExtensions.contains) ?? false)
             && !targetSourceExcludePaths.contains(path)
     }
 

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -312,6 +312,24 @@ class SourceGeneratorTests: XCTestCase {
                 try test(generateEmptyDirectories: true)
             }
 
+            $0.it("excludes certain ignored files") {
+                let directories = """
+                Sources:
+                  A:
+                    - a.swift
+                    - .DS_Store
+                    - a.swift.orig
+                """
+                try createDirectories(directories)
+
+                let target = Target(name: "Test", type: .application, platform: .iOS, sources: [TargetSource(path: "Sources")])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
+                let pbxProj = try project.generatePbxProj()
+                try pbxProj.expectFile(paths: ["Sources", "A", "a.swift"])
+                try pbxProj.expectFileMissing(paths: ["Sources", "A", ".DS_Store"])
+                try pbxProj.expectFileMissing(paths: ["Sources", "A", "a.swift.orig"])
+            }
+
             $0.it("generates file sources") {
                 let directories = """
                 Sources:


### PR DESCRIPTION
This is useful for multi-developer projects where you don't want to
delete these files for everyone, since they might actually want them,
but they still aren't useful to show in Xcode.

Fixes https://github.com/yonaskolb/XcodeGen/issues/310