### PR TITLE
Release 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Next Version
 
+## 2.7.0
+
 #### Added
 
-- Added Bash 4 style recursive globbing (`**/*`) when excluding files from target sources. [#636](https://github.com/yonaskolb/XcodeGen/pull/636) @bclymer
-- Added ability to disable main thread checker on Run and Test schemes and TargetSchemes [#601](https://github.com/yonaskolb/XcodeGen/pull/601) @wag-miles
+- Added Bash 4 style recursive globbing (`**/*`) in target sources `excludes` [#636](https://github.com/yonaskolb/XcodeGen/pull/636) @bclymer
+- Added ability to disable main thread checker in Schemes [#601](https://github.com/yonaskolb/XcodeGen/pull/601) @wag-miles
 
 #### Fixed
 - Fixed included specs that were referenced multiple times from duplicating content [#599](https://github.com/yonaskolb/XcodeGen/pull/599) @haritowa
@@ -13,6 +15,8 @@
 
 #### Changed
 - Allow linking of dependencies into static libraries when `link` is set to true [#635](https://github.com/yonaskolb/XcodeGen/pull/635) @kateinoigakukun
+
+[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.6.0...2.7.0)
 
 ## 2.6.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOOL_NAME = XcodeGen
 export EXECUTABLE_NAME = xcodegen
-VERSION = 2.6.0
+VERSION = 2.7.0
 
 PREFIX = /usr/local
 INSTALL_PATH = $(PREFIX)/bin/$(EXECUTABLE_NAME)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ swift run xcodegen
 Add the following to your Package.swift file's dependencies:
 
 ```swift
-.package(url: "https://github.com/yonaskolb/XcodeGen.git", from: "2.6.0"),
+.package(url: "https://github.com/yonaskolb/XcodeGen.git", from: "2.7.0"),
 ```
 
 And then import wherever needed: `import XcodeGenKit`

--- a/Sources/ProjectSpec/AggregateTarget.swift
+++ b/Sources/ProjectSpec/AggregateTarget.swift
@@ -70,7 +70,7 @@ extension AggregateTarget: JSONEncodable {
             "configFiles": configFiles,
             "attributes": attributes,
             "buildScripts": buildScripts.map { $0.toJSONValue() },
-            "scheme": scheme?.toJSONValue()
+            "scheme": scheme?.toJSONValue(),
         ] as [String: Any?]
     }
 }

--- a/Sources/ProjectSpec/BuildRule.swift
+++ b/Sources/ProjectSpec/BuildRule.swift
@@ -86,7 +86,7 @@ extension BuildRule: JSONEncodable {
         var dict: [String: Any?] = [
             "outputFiles": outputFiles,
             "outputFilesCompilerFlags": outputFilesCompilerFlags,
-            "name": name
+            "name": name,
         ]
 
         switch fileType {

--- a/Sources/ProjectSpec/BuildScript.swift
+++ b/Sources/ProjectSpec/BuildScript.swift
@@ -63,6 +63,7 @@ extension BuildScript: JSONObjectConvertible {
         showEnvVars = jsonDictionary.json(atKeyPath: "showEnvVars") ?? BuildScript.showEnvVarsDefault
     }
 }
+
 extension BuildScript: JSONEncodable {
     public func toJSONValue() -> Any {
         var dict: [String: Any?] = [
@@ -72,7 +73,7 @@ extension BuildScript: JSONEncodable {
             "outputFileLists": outputFileLists,
             "runOnlyWhenInstalling": runOnlyWhenInstalling,
             "name": name,
-            "shell": shell
+            "shell": shell,
         ]
 
         if showEnvVars != BuildScript.showEnvVarsDefault {

--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -89,7 +89,7 @@ extension Dependency: JSONEncodable {
         var dict: [String: Any?] = [
             "embed": embed,
             "codeSign": codeSign,
-            "link": link
+            "link": link,
         ]
 
         if removeHeaders != Dependency.removeHeadersDefault {

--- a/Sources/ProjectSpec/Plist.swift
+++ b/Sources/ProjectSpec/Plist.swift
@@ -29,7 +29,7 @@ extension Plist: JSONEncodable {
     public func toJSONValue() -> Any {
         return [
             "path": path,
-            "properties": properties
+            "properties": properties,
         ]
     }
 }

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -254,7 +254,7 @@ extension Project: JSONEncodable {
             "configs": Dictionary(uniqueKeysWithValues: configsPairs),
             "aggregateTargets": Dictionary(uniqueKeysWithValues: aggregateTargetsPairs),
             "schemes": Dictionary(uniqueKeysWithValues: schemesPairs),
-            "settingGroups": settingGroups.mapValues { $0.toJSONValue() }
+            "settingGroups": settingGroups.mapValues { $0.toJSONValue() },
         ]
     }
 }

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -197,7 +197,7 @@ public struct Scheme: Equatable {
 
     public struct Archive: BuildAction {
         public static let revealArchiveInOrganizerDefault = true
-        
+
         public var config: String?
         public var customArchiveName: String?
         public var revealArchiveInOrganizer: Bool
@@ -247,7 +247,7 @@ extension Scheme.ExecutionAction: JSONEncodable {
         return [
             "script": script,
             "name": name,
-            "settingsTarget": settingsTarget
+            "settingsTarget": settingsTarget,
         ]
     }
 }
@@ -271,7 +271,7 @@ extension Scheme.Run: JSONEncodable {
             "preActions": preActions.map { $0.toJSONValue() },
             "postActions": postActions.map { $0.toJSONValue() },
             "environmentVariables": environmentVariables.map { $0.toJSONValue() },
-            "config": config
+            "config": config,
         ]
 
         if disableMainThreadChecker != Scheme.Run.disableMainThreadCheckerDefault {
@@ -316,7 +316,7 @@ extension Scheme.Test: JSONEncodable {
             "preActions": preActions.map { $0.toJSONValue() },
             "postActions": postActions.map { $0.toJSONValue() },
             "environmentVariables": environmentVariables.map { $0.toJSONValue() },
-            "config": config
+            "config": config,
         ]
 
         if gatherCoverageData != Scheme.Test.gatherCoverageDataDefault {
@@ -348,7 +348,7 @@ extension Scheme.Test.TestTarget: JSONEncodable {
         }
 
         var dict: JSONDictionary = [
-            "name": name
+            "name": name,
         ]
 
         if randomExecutionOrder != Scheme.Test.TestTarget.randomExecutionOrderDefault {
@@ -380,7 +380,7 @@ extension Scheme.Profile: JSONEncodable {
             "preActions": preActions.map { $0.toJSONValue() },
             "postActions": postActions.map { $0.toJSONValue() },
             "environmentVariables": environmentVariables.map { $0.toJSONValue() },
-            "config": config
+            "config": config,
         ] as [String: Any?]
     }
 }
@@ -395,7 +395,7 @@ extension Scheme.Analyze: JSONObjectConvertible {
 extension Scheme.Analyze: JSONEncodable {
     public func toJSONValue() -> Any {
         return [
-            "config": config
+            "config": config,
         ]
     }
 }
@@ -581,7 +581,7 @@ extension XCScheme.EnvironmentVariable: JSONEncodable {
     public func toJSONValue() -> Any {
         var dict: [String: Any] = [
             "variable": variable,
-            "value": value
+            "value": value,
         ]
 
         if enabled != XCScheme.EnvironmentVariable.enabledDefault {

--- a/Sources/ProjectSpec/Settings.swift
+++ b/Sources/ProjectSpec/Settings.swift
@@ -112,7 +112,7 @@ extension Settings: JSONEncodable {
             return [
                 "base": buildSettings,
                 "groups": groups,
-                "configs": configSettings.mapValues { $0.toJSONValue() }
+                "configs": configSettings.mapValues { $0.toJSONValue() },
             ]
         }
         return buildSettings

--- a/Sources/ProjectSpec/SpecFile.swift
+++ b/Sources/ProjectSpec/SpecFile.swift
@@ -9,7 +9,7 @@ public struct SpecFile {
     public let subSpecs: [SpecFile]
 
     private let filename: String
-    
+
     fileprivate struct Include {
         let path: Path
         let relativePaths: Bool
@@ -92,27 +92,27 @@ public struct SpecFile {
 
     private func resolvedDictionaryWithUniqueTargets() -> JSONDictionary {
         let resolvedSpec = resolvingPaths()
-        
+
         var value = Set<String>()
         return resolvedSpec.mergedDictionary(set: &value)
     }
-    
+
     private func substitute(variables: [String: String], in mergedDictionary: JSONDictionary) -> JSONDictionary {
         var resolvedSpec = mergedDictionary
-        
+
         for (key, value) in variables {
             resolvedSpec = resolvedSpec.replaceString("${\(key)}", with: value)
         }
-        
+
         return resolvedSpec
     }
-    
+
     func mergedDictionary(set mergedTargets: inout Set<String>) -> JSONDictionary {
         let name = (basePath + relativePath + Path(filename)).description
-        
+
         guard !mergedTargets.contains(name) else { return [:] }
         mergedTargets.insert(name)
-        
+
         return jsonDictionary.merged(onto:
             subSpecs
                 .map { $0.mergedDictionary(set: &mergedTargets) }
@@ -137,14 +137,14 @@ public struct SpecFile {
 
 extension Dictionary where Key == String, Value: Any {
 
-    func merged(onto other: Dictionary<Key, Value>) -> Dictionary<Key, Value> {
+    func merged(onto other: [Key: Value]) -> [Key: Value] {
         var merged = other
 
         for (key, value) in self {
             if key.hasSuffix(":REPLACE") {
                 let newKey = key[key.startIndex..<key.index(key.endIndex, offsetBy: -8)]
                 merged[Key(newKey)] = value
-            } else if let dictionary = value as? Dictionary<Key, Value>, let base = merged[key] as? Dictionary<Key, Value> {
+            } else if let dictionary = value as? [Key: Value], let base = merged[key] as? [Key: Value] {
                 merged[key] = dictionary.merged(onto: base) as? Value
             } else if let array = value as? [Any], let base = merged[key] as? [Any] {
                 merged[key] = (base + array) as? Value

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -361,7 +361,6 @@ extension Target: NamedJSONDictionaryConvertible {
     }
 }
 
-
 extension Target: JSONEncodable {
     public func toJSONValue() -> Any {
         var dict: [String: Any?] = [
@@ -372,10 +371,10 @@ extension Target: JSONEncodable {
             "attributes": attributes,
             "sources": sources.map { $0.toJSONValue() },
             "dependencies": dependencies.map { $0.toJSONValue() },
-            "postCompileScripts": postCompileScripts.map{ $0.toJSONValue() },
-            "prebuildScripts": preBuildScripts.map{ $0.toJSONValue() },
-            "postbuildScripts": postBuildScripts.map{ $0.toJSONValue() },
-            "buildRules": buildRules.map{ $0.toJSONValue() },
+            "postCompileScripts": postCompileScripts.map { $0.toJSONValue() },
+            "prebuildScripts": preBuildScripts.map { $0.toJSONValue() },
+            "postbuildScripts": postBuildScripts.map { $0.toJSONValue() },
+            "buildRules": buildRules.map { $0.toJSONValue() },
             "deploymentTarget": deploymentTarget?.deploymentTarget,
             "info": info?.toJSONValue(),
             "entitlements": entitlements?.toJSONValue(),

--- a/Sources/ProjectSpec/TargetScheme.swift
+++ b/Sources/ProjectSpec/TargetScheme.swift
@@ -72,7 +72,7 @@ extension TargetScheme: JSONEncodable {
             "preActions": preActions.map { $0.toJSONValue() },
             "postActions": postActions.map { $0.toJSONValue() },
         ]
-        
+
         if gatherCoverageData != TargetScheme.gatherCoverageDataDefault {
             dict["gatherCoverageData"] = gatherCoverageData
         }

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -264,7 +264,7 @@ extension TargetSource.BuildPhase.CopyFilesSettings: JSONEncodable {
     public func toJSONValue() -> Any {
         return [
             "destination": destination.rawValue,
-            "subpath": subpath
+            "subpath": subpath,
         ]
     }
 }

--- a/Sources/XcodeGen/main.swift
+++ b/Sources/XcodeGen/main.swift
@@ -2,6 +2,6 @@ import Foundation
 import ProjectSpec
 import XcodeGenCLI
 
-let version = Version("2.6.0")
+let version = Version("2.7.0")
 let cli = XcodeGenCLI(version: version)
 cli.execute()

--- a/Sources/XcodeGenKit/Glob.swift
+++ b/Sources/XcodeGenKit/Glob.swift
@@ -6,9 +6,7 @@
 //  Adapted from https://gist.github.com/blakemerryman/76312e1cbf8aec248167
 //  Adapted from https://gist.github.com/efirestone/ce01ae109e08772647eb061b3bb387c3
 
-
 import Foundation
-
 
 public let GlobBehaviorBashV3 = Glob.Behavior(
     supportsGlobstar: false,
@@ -28,7 +26,6 @@ public let GlobBehaviorGradle = Glob.Behavior(
     includesDirectoriesInResults: false,
     includesFilesInResultsIfTrailingSlash: true
 )
-
 
 /**
  Finds files on the file system using pattern matching.
@@ -66,7 +63,7 @@ public class Glob: Collection {
     public let blacklistedDirectories: [String]
     var paths = [String]()
     public var startIndex: Int { return paths.startIndex }
-    public var endIndex: Int   { return paths.endIndex   }
+    public var endIndex: Int { return paths.endIndex }
 
     /// Initialize a glob
     ///
@@ -126,7 +123,7 @@ public class Glob: Collection {
     private var globalFlags = GLOB_TILDE | GLOB_BRACE | GLOB_MARK
 
     private func executeGlob(pattern: UnsafePointer<CChar>, gt: UnsafeMutablePointer<glob_t>) -> Bool {
-        return 0 == glob(pattern, globalFlags, nil, gt)
+        return glob(pattern, globalFlags, nil, gt) == 0
     }
 
     private func expandGlobstar(pattern: String) -> [String] {
@@ -234,4 +231,3 @@ private extension Sequence {
         return Array(self)
     }
 }
-

--- a/Sources/XcodeGenKit/MD5.swift
+++ b/Sources/XcodeGenKit/MD5.swift
@@ -21,7 +21,7 @@ extension String {
     public var md5: String {
         if let data = data(using: .utf8, allowLossyConversion: true) {
             let message = data.withUnsafeBytes { (bytes: UnsafeRawBufferPointer) -> [UInt8] in
-                return Array(bytes)
+                Array(bytes)
             }
 
             let MD5Calculator = MD5(message)
@@ -80,14 +80,14 @@ extension NSMutableData {
 }
 
 protocol HashProtocol {
-    var message: Array<UInt8> { get }
+    var message: [UInt8] { get }
 
     /** Common part for hash calculation. Prepare header data. */
-    func prepare(_ len: Int) -> Array<UInt8>
+    func prepare(_ len: Int) -> [UInt8]
 }
 
 extension HashProtocol {
-    func prepare(_ len: Int) -> Array<UInt8> {
+    func prepare(_ len: Int) -> [UInt8] {
         var tmpMessage = message
 
         // Step 1. Append Padding Bits
@@ -102,13 +102,13 @@ extension HashProtocol {
             msgLength += 1
         }
 
-        tmpMessage += Array<UInt8>(repeating: 0, count: counter)
+        tmpMessage += [UInt8](repeating: 0, count: counter)
         return tmpMessage
     }
 }
 
-func toUInt32Array(_ slice: ArraySlice<UInt8>) -> Array<UInt32> {
-    var result = Array<UInt32>()
+func toUInt32Array(_ slice: ArraySlice<UInt8>) -> [UInt32] {
+    var result = [UInt32]()
     result.reserveCapacity(16)
 
     for idx in stride(from: slice.startIndex, to: slice.endIndex, by: MemoryLayout<UInt32>.size) {
@@ -230,26 +230,22 @@ class MD5: HashProtocol {
                 case 0...15:
                     F = (B & C) | ((~B) & D)
                     g = j
-                    break
                 case 16...31:
                     F = (D & B) | (~D & C)
                     g = (5 * j + 1) % 16
-                    break
                 case 32...47:
                     F = B ^ C ^ D
                     g = (3 * j + 5) % 16
-                    break
                 case 48...63:
                     F = C ^ (B | (~D))
                     g = (7 * j) % 16
-                    break
                 default:
                     break
                 }
                 dTemp = D
                 D = C
                 C = B
-                B = B &+ rotateLeft((A &+ F &+ sines[j] &+ M[g]), bits: shifts[j])
+                B = B &+ rotateLeft(A &+ F &+ sines[j] &+ M[g], bits: shifts[j])
                 A = dTemp
             }
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -999,7 +999,7 @@ extension Target {
     var shouldEmbedDependencies: Bool {
         return type.isApp || type.isTest
     }
-    
+
     var shouldEmbedCarthageDependencies: Bool {
         return (type.isApp && platform != .watchOS)
             || type == .watch2Extension

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -107,7 +107,7 @@ public class SchemeGenerator {
         func getExecutionAction(_ action: Scheme.ExecutionAction) -> XCScheme.ExecutionAction {
             // ExecutionActions can require the use of build settings. Xcode allows the settings to come from a build or test target.
             let environmentBuildable = action.settingsTarget.flatMap { settingsTarget in
-                return (buildActionEntries + testBuildTargetEntries)
+                (buildActionEntries + testBuildTargetEntries)
                     .first { settingsTarget == $0.buildableReference.blueprintName }?
                     .buildableReference
             }

--- a/Sources/XcodeGenKit/XCProjExtensions.swift
+++ b/Sources/XcodeGenKit/XCProjExtensions.swift
@@ -38,7 +38,7 @@ extension PBXProj {
 
 extension Dictionary {
 
-    public var valueArray: Array<Value> {
+    public var valueArray: [Value] {
         return Array(values)
     }
 }

--- a/Tests/XcodeGenKitTests/GlobTests.swift
+++ b/Tests/XcodeGenKitTests/GlobTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import XcodeGenKit
 
-class GlobTests : XCTestCase {
+class GlobTests: XCTestCase {
 
     let tmpFiles = ["foo", "bar", "baz", "dir1/file1.ext", "dir1/dir2/dir3/file2.ext", "dir1/file1.extfoo"]
     var tmpDir = ""
@@ -17,7 +17,7 @@ class GlobTests : XCTestCase {
     override func setUp() {
         super.setUp()
 
-        self.tmpDir = newTmpDir()
+        tmpDir = newTmpDir()
 
         let flags = S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH
         mkdir("\(tmpDir)/dir1/", flags)
@@ -36,7 +36,7 @@ class GlobTests : XCTestCase {
         rmdir("\(tmpDir)/dir1/dir2/dir3")
         rmdir("\(tmpDir)/dir1/dir2")
         rmdir("\(tmpDir)/dir1")
-        rmdir(self.tmpDir)
+        rmdir(tmpDir)
 
         super.tearDown()
     }
@@ -139,7 +139,7 @@ class GlobTests : XCTestCase {
             "\(tmpDir)/dir1/dir2/dir3/file2.ext",
             "\(tmpDir)/dir1/file1.ext",
             "\(tmpDir)/dir1/file1.extfoo",
-            "\(tmpDir)/foo"
+            "\(tmpDir)/foo",
         ])
     }
 
@@ -188,7 +188,7 @@ class GlobTests : XCTestCase {
         let glob = Glob(pattern: pattern, behavior: GlobBehaviorBashV4)
         XCTAssertEqual(glob.paths, [
             "\(tmpDir)/dir1/dir2/dir3/file2.ext",
-            "\(tmpDir)/dir1/file1.ext"
+            "\(tmpDir)/dir1/file1.ext",
         ])
     }
 

--- a/Tests/XcodeGenKitTests/ProjectFixtureTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectFixtureTests.swift
@@ -16,7 +16,7 @@ class ProjectFixtureTests: XCTestCase {
     }
 }
 
-fileprivate func generateXcodeProject(specPath: Path, file: String = #file, line: Int = #line) throws {
+private func generateXcodeProject(specPath: Path, file: String = #file, line: Int = #line) throws {
     let project = try Project(path: specPath)
     let generator = ProjectGenerator(project: project)
     let writer = FileWriter(project: project)

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 import XCTest
 import Yams
 
-fileprivate let app = Target(
+private let app = Target(
     name: "MyApp",
     type: .application,
     platform: .iOS,
@@ -14,20 +14,20 @@ fileprivate let app = Target(
     dependencies: [Dependency(type: .target, reference: "MyFramework")]
 )
 
-fileprivate let framework = Target(
+private let framework = Target(
     name: "MyFramework",
     type: .framework,
     platform: .iOS,
     settings: Settings(buildSettings: ["SETTING_2": "VALUE"])
 )
 
-fileprivate let optionalFramework = Target(
+private let optionalFramework = Target(
     name: "MyOptionalFramework",
     type: .framework,
     platform: .iOS
 )
 
-fileprivate let uiTest = Target(
+private let uiTest = Target(
     name: "MyAppUITests",
     type: .uiTestBundle,
     platform: .iOS,
@@ -35,7 +35,7 @@ fileprivate let uiTest = Target(
     dependencies: [Dependency(type: .target, reference: "MyApp")]
 )
 
-fileprivate let targets = [app, framework, optionalFramework, uiTest]
+private let targets = [app, framework, optionalFramework, uiTest]
 
 class ProjectGeneratorTests: XCTestCase {
 
@@ -449,8 +449,8 @@ class ProjectGeneratorTests: XCTestCase {
                     dependencies: [
                         Dependency(type: .target, reference: iosFrameworkZ.name, link: true),
                         Dependency(type: .framework, reference: "FrameworkZ.framework", link: true),
-                        Dependency(type: .target, reference: iosFrameworkX.name/*, link: false */),
-                        Dependency(type: .framework, reference: "FrameworkX.framework"/*, link: false */),
+                        Dependency(type: .target, reference: iosFrameworkX.name /* , link: false */ ),
+                        Dependency(type: .framework, reference: "FrameworkX.framework" /* , link: false */ ),
                         Dependency(type: .carthage(findFrameworks: false), reference: "CarthageZ"),
                     ]
                 )
@@ -902,9 +902,9 @@ class ProjectGeneratorTests: XCTestCase {
                 let buildFileSettings = frameworkBuildFiles.map { $0.settings }
 
                 try expect(frameworkBuildFiles.count) == 2
-                try expect(buildFileSettings.compactMap({ $0 }).count) == 1
-                try expect(buildFileSettings.compactMap({ $0?["ATTRIBUTES"] }).count) == 1
-                try expect(buildFileSettings.compactMap({ $0?["ATTRIBUTES"] as? [String] }).first) == ["Weak"]
+                try expect(buildFileSettings.compactMap { $0 }.count) == 1
+                try expect(buildFileSettings.compactMap { $0?["ATTRIBUTES"] }.count) == 1
+                try expect(buildFileSettings.compactMap { $0?["ATTRIBUTES"] as? [String] }.first) == ["Weak"]
             }
 
             $0.it("generates info.plist") {

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -269,9 +269,9 @@ class ProjectSpecTests: XCTestCase {
                                                     productName: "App",
                                                     deploymentTarget: Version(major: 0, minor: 1, patch: 2),
                                                     settings: Settings(buildSettings: ["foo": "bar"],
-                                                                       configSettings: ["foo" : Settings(buildSettings: ["nested": "config"],
-                                                                                                         configSettings: [:],
-                                                                                                         groups: ["config-setting-group"])],
+                                                                       configSettings: ["foo": Settings(buildSettings: ["nested": "config"],
+                                                                                                        configSettings: [:],
+                                                                                                        groups: ["config-setting-group"])],
                                                                        groups: ["setting-group"]),
                                                     configFiles: ["foo": "bar"],
                                                     sources: [TargetSource(path: "Source",
@@ -331,7 +331,7 @@ class ProjectSpecTests: XCTestCase {
                                                                            action: .compilerSpec("com.apple.xcode.tools.swift.compiler"),
                                                                            name: nil,
                                                                            outputFiles: ["bar"],
-                                                                           outputFilesCompilerFlags: ["foo"]),],
+                                                                           outputFilesCompilerFlags: ["foo"])],
                                                     scheme: TargetScheme(testTargets: [Scheme.Test.TestTarget(name: "test target",
                                                                                                               randomExecutionOrder: false,
                                                                                                               parallelizable: false)],
@@ -388,14 +388,14 @@ class ProjectSpecTests: XCTestCase {
                                                                                                                                 settingsTarget: "foo")]),
                                                                       attributes: ["foo": "bar"])],
                                    settings: Settings(buildSettings: ["foo": "bar"],
-                                                      configSettings: ["foo" : Settings(buildSettings: ["nested": "config"],
-                                                                                        configSettings: [:],
-                                                                                        groups: ["config-setting-group"])],
+                                                      configSettings: ["foo": Settings(buildSettings: ["nested": "config"],
+                                                                                       configSettings: [:],
+                                                                                       groups: ["config-setting-group"])],
                                                       groups: ["setting-group"]),
                                    settingGroups: ["foo": Settings(buildSettings: ["foo": "bar"],
-                                                                   configSettings: ["foo" : Settings(buildSettings: ["nested": "config"],
-                                                                                                     configSettings: [:],
-                                                                                                     groups: ["config-setting-group"])],
+                                                                   configSettings: ["foo": Settings(buildSettings: ["nested": "config"],
+                                                                                                    configSettings: [:],
+                                                                                                    groups: ["config-setting-group"])],
                                                                    groups: ["setting-group"])],
                                    schemes: [Scheme(name: "scheme",
                                                     build: Scheme.Build(targets: [Scheme.BuildTarget(target: "foo",
@@ -503,7 +503,7 @@ class ProjectSpecTests: XCTestCase {
     }
 }
 
-fileprivate func expectValidationError(_ project: Project, _ expectedError: SpecValidationError.ValidationError, file: String = #file, line: Int = #line) throws {
+private func expectValidationError(_ project: Project, _ expectedError: SpecValidationError.ValidationError, file: String = #file, line: Int = #line) throws {
     do {
         try project.validate()
     } catch let error as SpecValidationError {

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -6,26 +6,26 @@ import XcodeProj
 import XCTest
 import Yams
 
-fileprivate let app = Target(
+private let app = Target(
     name: "MyApp",
     type: .application,
     platform: .iOS,
     dependencies: [Dependency(type: .target, reference: "MyFramework")]
 )
 
-fileprivate let framework = Target(
+private let framework = Target(
     name: "MyFramework",
     type: .framework,
     platform: .iOS
 )
 
-fileprivate let optionalFramework = Target(
+private let optionalFramework = Target(
     name: "MyOptionalFramework",
     type: .framework,
     platform: .iOS
 )
 
-fileprivate let uiTest = Target(
+private let uiTest = Target(
     name: "MyAppUITests",
     type: .uiTestBundle,
     platform: .iOS,

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -617,7 +617,7 @@ class SourceGeneratorTests: XCTestCase {
                     TargetSource(path: "File1.swift", optional: true),
                     TargetSource(path: "File2.swift", type: .file, optional: true),
                     TargetSource(path: "Group", type: .folder, optional: true),
-                    ])
+                ])
                 let project = Project(basePath: directoryPath, name: "Test", targets: [target])
                 let pbxProj = try project.generatePbxProj()
                 try pbxProj.expectFile(paths: ["File1.swift"])
@@ -630,11 +630,11 @@ class SourceGeneratorTests: XCTestCase {
                     TargetSource(path: "Group1", optional: true),
                     TargetSource(path: "Group2", type: .group, optional: true),
                     TargetSource(path: "Group3", type: .group, optional: true),
-                    ])
+                ])
                 let project = Project(basePath: directoryPath, name: "Test", targets: [target])
                 _ = try project.generatePbxProj()
             }
-            
+
             $0.it("relative path items outside base path are grouped together") {
                 let directories = """
                 Sources:
@@ -644,21 +644,21 @@ class SourceGeneratorTests: XCTestCase {
                         - b.swift
                 """
                 try createDirectories(directories)
-                
+
                 let outOfSourceFile1 = outOfRootPath + "Outside/a.swift"
                 try outOfSourceFile1.parent().mkpath()
                 try outOfSourceFile1.write("")
-                
+
                 let outOfSourceFile2 = outOfRootPath + "Outside/Outside2/b.swift"
                 try outOfSourceFile2.parent().mkpath()
                 try outOfSourceFile2.write("")
-                
+
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: [
                     "Sources",
                     "../OtherDirectory",
                 ])
                 let project = Project(basePath: directoryPath, name: "Test", targets: [target])
-                
+
                 let pbxProj = try project.generatePbxProj()
                 try pbxProj.expectFile(paths: ["Sources", "Inside", "a.swift"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["Sources", "Inside", "Inside2", "b.swift"], buildPhase: .sources)
@@ -676,7 +676,7 @@ class SourceGeneratorTests: XCTestCase {
                 let definition: String = "Intent.intentdefinition"
 
                 let target = Target(name: "Test", type: .framework, platform: .iOS, sources: [
-                    TargetSource(path: "A/\(definition)", buildPhase: .sources, attributes: ["no_codegen"])
+                    TargetSource(path: "A/\(definition)", buildPhase: .sources, attributes: ["no_codegen"]),
                 ])
                 let project = Project(basePath: directoryPath, name: "Test", targets: [target])
 

--- a/Tests/XcodeGenKitTests/SpecLoadingTests.swift
+++ b/Tests/XcodeGenKitTests/SpecLoadingTests.swift
@@ -14,16 +14,16 @@ class SpecLoadingTests: XCTestCase {
             $0.it("merges each file only once") {
                 let path = fixturePath + "duplicated_include/duplicated_import_sut.yml"
                 let project = try loadSpec(path: path)
-                
+
                 try expect(project.fileGroups) == ["First", "Second"]
-                
+
                 let sutTarget = project.targets.first
                 try expect(sutTarget?.sources) == [TargetSource(path: "template")]
                 try expect(sutTarget?.preBuildScripts) == [BuildScript(script: .script("swiftlint"), name: "Swiftlint")]
             }
         }
     }
-    
+
     func testSpecLoader() {
         describe {
             $0.it("merges includes") {
@@ -207,12 +207,12 @@ class SpecLoadingTests: XCTestCase {
                 let project = try loadSpec(path: path, variables: [
                     "SETTING1": "ENV VALUE1",
                     "SETTING4": "ENV VALUE4",
-                    "variable": "doesWin"
+                    "variable": "doesWin",
                 ])
 
                 try expect(project.name) == "NewName"
                 try expect(project.settingGroups) == [
-                     "test": Settings(dictionary: ["MY_SETTING1": "ENV VALUE1", "MY_SETTING2": "VALUE2", "MY_SETTING4": "ENV VALUE4"]),
+                    "test": Settings(dictionary: ["MY_SETTING1": "ENV VALUE1", "MY_SETTING2": "VALUE2", "MY_SETTING4": "ENV VALUE4"]),
                     "toReplace": Settings(dictionary: ["MY_SETTING1": "VALUE1"]),
                 ]
                 try expect(project.targets.last?.sources) == ["SomeTarget", "doesWin", "templateVariable"]
@@ -277,7 +277,7 @@ class SpecLoadingTests: XCTestCase {
                 try expectError(SpecValidationError(errors: [
                     .deprecatedUsageOfPlaceholder(placeholderName: "target_name"),
                     .deprecatedUsageOfPlaceholder(placeholderName: "platform"),
-                ]), { try specLoader.validateProjectDictionaryWarnings() })
+                ])) { try specLoader.validateProjectDictionaryWarnings() }
             }
 
             $0.it("successfully validates warnings for new placeholder usage") {
@@ -762,11 +762,11 @@ class SpecLoadingTests: XCTestCase {
                                 "name": "Target2",
                                 "parallelizable": true,
                                 "randomExecutionOrder": true,
-                                "skippedTests": ["Test/testExample()"]
+                                "skippedTests": ["Test/testExample()"],
                             ],
                         ],
                         "gatherCoverageData": true,
-                        "disableMainThreadChecker": true
+                        "disableMainThreadChecker": true,
                     ],
                 ]
                 let scheme = try Scheme(name: "Scheme", jsonDictionary: schemeDictionary)
@@ -977,7 +977,7 @@ class SpecLoadingTests: XCTestCase {
 }
 
 @discardableResult
-fileprivate func getProjectSpec(_ project: [String: Any], file: String = #file, line: Int = #line) throws -> Project {
+private func getProjectSpec(_ project: [String: Any], file: String = #file, line: Int = #line) throws -> Project {
     var projectDictionary: [String: Any] = ["name": "test"]
     for (key, value) in project {
         projectDictionary[key] = value
@@ -989,7 +989,7 @@ fileprivate func getProjectSpec(_ project: [String: Any], file: String = #file, 
     }
 }
 
-fileprivate func loadSpec(path: Path, variables: [String: String] = [:], file: String = #file, line: Int = #line) throws -> Project {
+private func loadSpec(path: Path, variables: [String: String] = [:], file: String = #file, line: Int = #line) throws -> Project {
     do {
         let specLoader = SpecLoader(version: "1.1.0")
         return try specLoader.loadProject(path: path, variables: variables)
@@ -998,13 +998,13 @@ fileprivate func loadSpec(path: Path, variables: [String: String] = [:], file: S
     }
 }
 
-fileprivate func expectSpecError(_ project: [String: Any], _ expectedError: SpecParsingError, file: String = #file, line: Int = #line) throws {
+private func expectSpecError(_ project: [String: Any], _ expectedError: SpecParsingError, file: String = #file, line: Int = #line) throws {
     try expectError(expectedError, file: file, line: line) {
         try getProjectSpec(project)
     }
 }
 
-fileprivate func expectTargetError(_ target: [String: Any], _ expectedError: SpecParsingError, file: String = #file, line: Int = #line) throws {
+private func expectTargetError(_ target: [String: Any], _ expectedError: SpecParsingError, file: String = #file, line: Int = #line) throws {
     try expectError(expectedError, file: file, line: line) {
         _ = try Target(name: "test", jsonDictionary: target)
     }

--- a/Tests/XcodeGenKitTests/TestHelpers.swift
+++ b/Tests/XcodeGenKitTests/TestHelpers.swift
@@ -43,7 +43,7 @@ struct ExpectationFailure: FailureType {
 }
 
 open class ArrayExpectation<T>: ExpectationType {
-    public typealias ValueType = Array<T>
+    public typealias ValueType = [T]
     public let expression: () throws -> ValueType?
 
     let file: String


### PR DESCRIPTION
## 2.7.0

#### Added

- Added Bash 4 style recursive globbing (`**/*`) in target sources `excludes` [#636](https://github.com/yonaskolb/XcodeGen/pull/636) @bclymer
- Added ability to disable main thread checker in Schemes [#601](https://github.com/yonaskolb/XcodeGen/pull/601) @wag-miles

#### Fixed
- Fixed included specs that were referenced multiple times from duplicating content [#599](https://github.com/yonaskolb/XcodeGen/pull/599) @haritowa
- Fixed `.orig` files being added to the project [#627](https://github.com/yonaskolb/XcodeGen/pull/627) @keith

#### Changed
- Allow linking of dependencies into static libraries when `link` is set to true [#635](https://github.com/yonaskolb/XcodeGen/pull/635) @kateinoigakukun

[Commits](https://github.com/yonaskolb/XcodeGen/compare/2.6.0...2.7.0)