### PR TITLE
Allow dylib extension for SDK linkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Added
 
 - Added `includes` to `sources` for a Target. This follows the same glob-style as `excludes` but functions as a way to only include files that match a specified pattern. Useful if you only want a certain file type, for example specifying `**/*.swift`. [#637](https://github.com/yonaskolb/XcodeGen/pull/637) @bclymer
+- Support `dylib` SDK. [#650](https://github.com/yonaskolb/XcodeGen/pull/650)
 
 ## 2.7.0
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -411,6 +411,7 @@ targets:
         findFrameworks: true
       - sdk: Contacts.framework
       - sdk: libc++.tbd
+      - sdk: libz.dylib
   MyFramework:
     type: framework
 ```

--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -154,7 +154,7 @@ options:
 ```
 
 ### SDK
-System frameworks and libs can be linked by using the `sdk` dependency type. You can either specify frameworks or libs by using a `.framework` or `.tbd` filename, respectively
+System frameworks and libs can be linked by using the `sdk` dependency type. You can either specify frameworks or libs by using a `.framework`, `.tbd` or `dylib` filename, respectively
 
 ```yaml
 targets:
@@ -162,6 +162,7 @@ targets:
     dependencies:
       - sdk: Contacts.framework
       - sdk: libc++.tbd
+      - sdk: libz.dylib
 ```
 
 ### Framework

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ targets:
       - framework: Vendor/MyFramework.framework
       - sdk: Contacts.framework
       - sdk: libc++.tbd
+      - sdk: libz.dylib
   MyFramework:
     type: framework
     platform: iOS

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -149,7 +149,8 @@ extension Project {
                     if !dependency.reference.contains("/") {
                         switch path.extension {
                         case "framework"?,
-                             "tbd"?:
+                             "tbd"?,
+                             "dylib"?:
                             break
                         default:
                             errors.append(.invalidSDKDependency(target: target.name, dependency: dependency.reference))

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -545,6 +545,8 @@ public class PBXProjGenerator {
                         dependencyPath = Path("System/Library/Frameworks") + dependencyPath
                     case "tbd":
                         dependencyPath = Path("usr/lib") + dependencyPath
+                    case "dylib":
+                        dependencyPath = Path("usr/lib") + dependencyPath
                     default: break
                     }
                 }

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		9D80BD5FAE6BE61CFD74CF1B /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		9DF5931DAD58C35B830A0A75 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B76E17CE3574081D5BF45B44 /* Result.framework */; };
 		A1AEAAB53EAEDA1C307871FA /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB178D03E75929F3F5B10C56 /* Result.framework */; };
+		A59B3F08914812573AFF6C2D /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD4A16C7B8FEB7F97F3CBE3F /* libz.dylib */; };
 		A7D1A9942302569A9515696A /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A9548E5DCFE92236494164DF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1F06D99242F4223D081F0D /* LaunchScreen.storyboard */; };
 		AFF19412E9B35635D3AF48CB /* XPC_Service.m in Sources */ = {isa = PBXBuildFile; fileRef = 148B7C933698BCC4F1DBA979 /* XPC_Service.m */; };
@@ -510,6 +511,7 @@
 		F2950763C4C568CC85021D18 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.module; path = module.modulemap; sourceTree = "<group>"; };
 		FC60FF5527FEDF545816FFCF /* Folder */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Folder; sourceTree = SOURCE_ROOT; };
 		FD05F36F95D6F098A76F220B /* XPC_Service.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPC_Service.h; sourceTree = "<group>"; };
+		FD4A16C7B8FEB7F97F3CBE3F /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		FDB2B6A77D39CD5602F2125F /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
 		FED40A89162E446494DDE7C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -568,6 +570,7 @@
 				078FAAF5C2B851C7D5EA714F /* Result.framework in Frameworks */,
 				CE3D039C3014A07F32D2BEAA /* StaticLibrary_ObjC.a in Frameworks */,
 				BAA1C1E3828F5D43546AF997 /* libc++.tbd in Frameworks */,
+				A59B3F08914812573AFF6C2D /* libz.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -910,6 +913,7 @@
 				12809A79ACE69F501A5FE815 /* Carthage */,
 				FDB2B6A77D39CD5602F2125F /* Contacts.framework */,
 				0BB1B49A91B892152D68ED76 /* libc++.tbd */,
+				FD4A16C7B8FEB7F97F3CBE3F /* libz.dylib */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -48,6 +48,7 @@ targets:
       - target: XPC Service
       - sdk: Contacts.framework
       - sdk: libc++.tbd
+      - sdk: libz.dylib
 
   App_iOS:
     type: application


### PR DESCRIPTION
`invalidSDKDependency` says extension of SDK dependency must be one of `.framework`, `.dylib` or `.tbd`.
https://github.com/yonaskolb/XcodeGen/blob/6620187d8ab0f9eb2f524d328ac95856bacb06d0/Sources/ProjectSpec/SpecValidationError.swift#L36-L37

But in current implementation prevents to use `dylib` extension.