### PR TITLE
Performance Tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 #### Fixed
 
 - Expand template variable in Array of Any [#651](https://github.com/yonaskolb/XcodeGen/pull/651) @kateinoigakukun
+- Significantly improve performance when running with a large number files. [#658](https://github.com/yonaskolb/XcodeGen/pull/658) @kateinoigakukun
 
 ## 2.7.0
 

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -245,8 +245,8 @@ class SourceGenerator {
             var cachedGroupChildren = cachedGroup.children
             for child in children {
                 // only add the children that aren't already in the cachedGroup
-                // Check equality by path because XcodeProj.PBXObject.== is very slow.
-                if !cachedGroupChildren.contains(where: { $0.path == child.path }) {
+                // Check equality by path and sourceTree because XcodeProj.PBXObject.== is very slow.
+                if !cachedGroupChildren.contains(where: { $0.path == child.path && $0.sourceTree == child.sourceTree }) {
                     cachedGroupChildren.append(child)
                 }
             }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -244,7 +244,7 @@ class SourceGenerator {
         if let cachedGroup = groupsByPath[path] {
             for child in children {
                 // only add the children that aren't already in the cachedGroup
-                if !cachedGroup.children.contains(child) {
+                if !cachedGroup.children.contains(where: { $0.path == child.path }) {
                     cachedGroup.children.append(child)
                 }
             }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -245,6 +245,7 @@ class SourceGenerator {
             var cachedGroupChildren = cachedGroup.children
             for child in children {
                 // only add the children that aren't already in the cachedGroup
+                // Check equality by path because XcodeProj.PBXObject.== is very slow.
                 if !cachedGroupChildren.contains(where: { $0.path == child.path }) {
                     cachedGroupChildren.append(child)
                 }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -242,12 +242,14 @@ class SourceGenerator {
         let groupReference: PBXGroup
 
         if let cachedGroup = groupsByPath[path] {
+            var cachedGroupChildren = cachedGroup.children
             for child in children {
                 // only add the children that aren't already in the cachedGroup
-                if !cachedGroup.children.contains(where: { $0.path == child.path }) {
-                    cachedGroup.children.append(child)
+                if !cachedGroupChildren.contains(where: { $0.path == child.path }) {
+                    cachedGroupChildren.append(child)
                 }
             }
+            cachedGroup.children = cachedGroupChildren
             groupReference = cachedGroup
         } else {
 


### PR DESCRIPTION
- https://github.com/yonaskolb/XcodeGen/commit/fa8c71569a0a34b8618734a535d9721f6fea78b8
  While investigating performance issue, I found equality checking for `PBXObject` is very slow.
  So I changed to check only `path` property.
- https://github.com/yonaskolb/XcodeGen/pull/658/commits/0dc4a8de417084b08f800d63effc134da835f80a
  `cachedGroup.children` is called for each loop but it needs some computations every access https://github.com/tuist/XcodeProj/blob/368fb87695e5dbc09c6035ffdb873d4831f5e861/Sources/XcodeProj/Objects/Files/PBXGroup.swift#L11-L18

| before| after|
|:-:|:-:|
|<img width="469" alt="スクリーンショット 2019-09-16 15 39 22" src="https://user-images.githubusercontent.com/11702759/65372504-4fa1cc00-dcac-11e9-8fe2-3b8f2b74d04e.png"> | <img width="538" alt="スクリーンショット 2019-09-21 20 05 55" src="https://user-images.githubusercontent.com/11702759/65372510-56c8da00-dcac-11e9-8b2d-00293f60eadb.png"> |


This change make `getGroup` 4.6 times faster than now in my project.
