### PR TITLE
Fix macOS unit test setting preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Fixed
+- Fixed macOS unit test setting preset [#665](https://github.com/yonaskolb/XcodeGen/pull/665) @yonaskolb
+
 ## 2.8.0
 
 #### Added

--- a/SettingPresets/Product_Platform/bundle.unit-test_macOS.yml
+++ b/SettingPresets/Product_Platform/bundle.unit-test_macOS.yml
@@ -1,1 +1,1 @@
-LD_RUNPATH_SEARCH_PATHS: [$(inherited)", "@executable_path/../Frameworks", "@loader_path/../Frameworks]
+LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/../Frameworks", "@loader_path/../Frameworks"]


### PR DESCRIPTION
This was a small regression in the last release. Without this fix the setting preset for macOS unit tests won't be applied