### PR TITLE
Add .rcproject path to sources build phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Fixed
 - Fixed macOS unit test setting preset [#665](https://github.com/yonaskolb/XcodeGen/pull/665) @yonaskolb
+- Add `rcproject` files to sources build phase instead of resources [#669](https://github.com/yonaskolb/XcodeGen/pull/669) @Qusic
 
 ## 2.8.0
 

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -221,7 +221,8 @@ class SourceGenerator {
                  "xcdatamodeld",
                  "intentdefinition",
                  "metal",
-                 "mlmodel":
+                 "mlmodel",
+                 "rcproject":
                 return .sources
             case "h",
                  "hh",


### PR DESCRIPTION
.rcproject directories are projects of Reality Composer app bundled in Xcode 11 or later.