### PR TITLE
Stabilize sorting of groups with duplicate names/paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed resolving relative path passed to `XcodeProj` [#751](https://github.com/yonaskolb/XcodeGen/pull/751) @PycKamil
 - Prefer configurations named "Debug" or "Release" for default scheme build configurations [#752](https://github.com/yonaskolb/XcodeGen/pull/752) @john-flanagan
 - Added an extra check for package versions. [#755](https://github.com/yonaskolb/XcodeGen/pull/755) @basvankuijck
+- Stabilized sorting of groups with duplicate names/paths. [#671](https://github.com/yonaskolb/XcodeGen/pull/671) @ChristopherRogers
 
 #### Internal
 - Update to SwiftCLI 6.0 and use the new property wrappers [#749](https://github.com/yonaskolb/XcodeGen/pull/749) @yonaskolb

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -185,7 +185,7 @@ public class PBXProjGenerator {
             for (platform, files) in carthageFrameworksByPlatform {
                 let platformGroup: PBXGroup = addObject(
                     PBXGroup(
-                        children: files.sorted(),
+                        children: files.sorted(by: PBXFileElement.areNamePathInIncreasingOrder(_:_:)),
                         sourceTree: .group,
                         path: platform
                     )
@@ -230,7 +230,7 @@ public class PBXProjGenerator {
         // add derived groups at the end
         derivedGroups.forEach(sortGroups)
         mainGroup.children += derivedGroups
-            .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+            .sorted { $0.namePathLocalizedStandardCompare($1) == .orderedAscending }
             .map { $0 }
 
         let projectAttributes: [String: Any] = ["LastUpgradeCheck": project.xcodeVersion]
@@ -416,7 +416,7 @@ public class PBXProjGenerator {
                     return sortOrder1 < sortOrder2
                 } else {
                     if (child1.name, child1.path) != (child2.name, child2.path) {
-                        return child1.localizedStandardCompare(child2) == .orderedAscending
+                        return child1.namePathLocalizedStandardCompare(child2) == .orderedAscending
                     } else {
                         return child1.context ?? "" < child2.context ?? ""
                     }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -185,7 +185,7 @@ public class PBXProjGenerator {
             for (platform, files) in carthageFrameworksByPlatform {
                 let platformGroup: PBXGroup = addObject(
                     PBXGroup(
-                        children: files.sorted { $0.nameOrPath < $1.nameOrPath },
+                        children: files.sorted(),
                         sourceTree: .group,
                         path: platform
                     )
@@ -230,7 +230,7 @@ public class PBXProjGenerator {
         // add derived groups at the end
         derivedGroups.forEach(sortGroups)
         mainGroup.children += derivedGroups
-            .sorted { $0.nameOrPath.localizedStandardCompare($1.nameOrPath) == .orderedAscending }
+            .sorted { $0.localizedStandardCompare($1) == .orderedAscending }
             .map { $0 }
 
         let projectAttributes: [String: Any] = ["LastUpgradeCheck": project.xcodeVersion]
@@ -415,8 +415,8 @@ public class PBXProjGenerator {
                 if sortOrder1 != sortOrder2 {
                     return sortOrder1 < sortOrder2
                 } else {
-                    if child1.nameOrPath != child2.nameOrPath {
-                        return child1.nameOrPath.localizedStandardCompare(child2.nameOrPath) == .orderedAscending
+                    if (child1.name, child1.path) != (child2.name, child2.path) {
+                        return child1.localizedStandardCompare(child2) == .orderedAscending
                     } else {
                         return child1.context ?? "" < child2.context ?? ""
                     }

--- a/Sources/XcodeGenKit/XCProjExtensions.swift
+++ b/Sources/XcodeGenKit/XCProjExtensions.swift
@@ -3,9 +3,23 @@ import PathKit
 import XcodeProj
 
 extension PBXFileElement {
-
     public var nameOrPath: String {
-        name ?? path ?? ""
+        return name ?? path ?? ""
+    }
+
+    func localizedStandardCompare(_ rhs: PBXFileElement) -> ComparisonResult {
+        return sortString.localizedStandardCompare(rhs.sortString)
+    }
+}
+
+extension PBXFileElement: Comparable {
+    public static func < (lhs: PBXFileElement, rhs: PBXFileElement) -> Bool {
+        return lhs.sortString < rhs.sortString
+    }
+
+    private var sortString: String {
+        // This string needs to be unique for all combinations of name & path or the order won't be stable.
+        return "\(name ?? path ?? "")\t\(name ?? "")\t\(path ?? "")"
     }
 }
 

--- a/Sources/XcodeGenKit/XCProjExtensions.swift
+++ b/Sources/XcodeGenKit/XCProjExtensions.swift
@@ -7,13 +7,11 @@ extension PBXFileElement {
         return name ?? path ?? ""
     }
 
-    func localizedStandardCompare(_ rhs: PBXFileElement) -> ComparisonResult {
+    func namePathLocalizedStandardCompare(_ rhs: PBXFileElement) -> ComparisonResult {
         return sortString.localizedStandardCompare(rhs.sortString)
     }
-}
 
-extension PBXFileElement: Comparable {
-    public static func < (lhs: PBXFileElement, rhs: PBXFileElement) -> Bool {
+    static func areNamePathInIncreasingOrder(_ lhs: PBXFileElement, _ rhs: PBXFileElement) -> Bool {
         return lhs.sortString < rhs.sortString
     }
 

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -515,7 +515,7 @@ class ProjectSpecTests: XCTestCase {
                 let json = proj.toJSONDictionary()
                 let restoredProj = try Project(basePath: Path.current, jsonDictionary: json)
 
-                // Examin some properties to make debugging easier
+                // Examine some properties to make debugging easier
                 try expect(proj.aggregateTargets) == restoredProj.aggregateTargets
                 try expect(proj.configFiles) == restoredProj.configFiles
                 try expect(proj.settings) == restoredProj.settings


### PR DESCRIPTION
For example, previously a group with (name: nil, path: "Sources") would be considered equal to (name: "Sources", path: "../Sources"), even though they are distinct groups.

I think this was causing churn in the UUIDs for the files contained in such groups, but I'm not 100% sure.