### PR TITLE
Select suitable configs for auto-generated schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Fixed
 - Fixed macOS unit test setting preset [#665](https://github.com/yonaskolb/XcodeGen/pull/665) @yonaskolb
 - Add `rcproject` files to sources build phase instead of resources [#669](https://github.com/yonaskolb/XcodeGen/pull/669) @Qusic
+- Fixed configuration selection behaviors for auto-generated schemes [#673](https://github.com/yonaskolb/XcodeGen/pull/673) @giginet
 
 ## 2.8.0
 

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -8,10 +8,18 @@ public class SchemeGenerator {
     let pbxProj: PBXProj
 
     var defaultDebugConfig: Config {
+        if let defaultConfig = Config.defaultConfigs.first(where: { $0.type == .debug }),
+            project.configs.contains(defaultConfig) {
+            return defaultConfig
+        }
         return project.configs.first { $0.type == .debug }!
     }
 
     var defaultReleaseConfig: Config {
+        if let defaultConfig = Config.defaultConfigs.first(where: { $0.type == .release }),
+            project.configs.contains(defaultConfig) {
+            return defaultConfig
+        }
         return project.configs.first { $0.type == .release }!
     }
 

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -2,26 +2,18 @@ import Foundation
 import ProjectSpec
 import XcodeProj
 
+private func defaultConfig(of type: ConfigType, in project: Project) -> Config {
+    if let defaultConfig = Config.defaultConfigs.first(where: { $0.type == type }),
+        project.configs.contains(defaultConfig) {
+        return defaultConfig
+    }
+    return project.configs.first { $0.type == type }!
+}
+
 public class SchemeGenerator {
 
     let project: Project
     let pbxProj: PBXProj
-
-    var defaultDebugConfig: Config {
-        if let defaultConfig = Config.defaultConfigs.first(where: { $0.type == .debug }),
-            project.configs.contains(defaultConfig) {
-            return defaultConfig
-        }
-        return project.configs.first { $0.type == .debug }!
-    }
-
-    var defaultReleaseConfig: Config {
-        if let defaultConfig = Config.defaultConfigs.first(where: { $0.type == .release }),
-            project.configs.contains(defaultConfig) {
-            return defaultConfig
-        }
-        return project.configs.first { $0.type == .release }!
-    }
 
     public init(project: Project, pbxProj: PBXProj) {
         self.project = project
@@ -42,8 +34,8 @@ public class SchemeGenerator {
                 if targetScheme.configVariants.isEmpty {
                     let schemeName = target.name
 
-                    let debugConfig = project.configs.first { $0.type == .debug }!
-                    let releaseConfig = project.configs.first { $0.type == .release }!
+                    let debugConfig = defaultConfig(of: .debug, in: project)
+                    let releaseConfig = defaultConfig(of: .release, in: project)
 
                     let scheme = Scheme(
                         name: schemeName,
@@ -155,7 +147,7 @@ public class SchemeGenerator {
         let profileVariables = scheme.profile.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
 
         let testAction = XCScheme.TestAction(
-            buildConfiguration: scheme.test?.config ?? defaultDebugConfig.name,
+            buildConfiguration: scheme.test?.config ?? defaultConfig(of: .debug, in: project).name,
             macroExpansion: buildableReference,
             testables: testables,
             preActions: scheme.test?.preActions.map(getExecutionAction) ?? [],
@@ -172,7 +164,7 @@ public class SchemeGenerator {
 
         let launchAction = XCScheme.LaunchAction(
             runnable: shouldExecuteOnLaunch ? productRunable : nil,
-            buildConfiguration: scheme.run?.config ?? defaultDebugConfig.name,
+            buildConfiguration: scheme.run?.config ?? defaultConfig(of: .debug, in: project).name,
             preActions: scheme.run?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.run?.postActions.map(getExecutionAction) ?? [],
             macroExpansion: shouldExecuteOnLaunch ? nil : buildableReference,
@@ -187,7 +179,7 @@ public class SchemeGenerator {
 
         let profileAction = XCScheme.ProfileAction(
             buildableProductRunnable: productRunable,
-            buildConfiguration: scheme.profile?.config ?? defaultReleaseConfig.name,
+            buildConfiguration: scheme.profile?.config ?? defaultConfig(of: .release, in: project).name,
             preActions: scheme.profile?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.profile?.postActions.map(getExecutionAction) ?? [],
             shouldUseLaunchSchemeArgsEnv: scheme.profile?.shouldUseLaunchSchemeArgsEnv ?? true,
@@ -195,10 +187,10 @@ public class SchemeGenerator {
             environmentVariables: profileVariables
         )
 
-        let analyzeAction = XCScheme.AnalyzeAction(buildConfiguration: scheme.analyze?.config ?? defaultDebugConfig.name)
+        let analyzeAction = XCScheme.AnalyzeAction(buildConfiguration: scheme.analyze?.config ?? defaultConfig(of: .debug, in: project).name)
 
         let archiveAction = XCScheme.ArchiveAction(
-            buildConfiguration: scheme.archive?.config ?? defaultReleaseConfig.name,
+            buildConfiguration: scheme.archive?.config ?? defaultConfig(of: .release, in: project).name,
             revealArchiveInOrganizer: scheme.archive?.revealArchiveInOrganizer ?? true,
             customArchiveName: scheme.archive?.customArchiveName,
             preActions: scheme.archive?.preActions.map(getExecutionAction) ?? [],

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -14,7 +14,7 @@ public class SchemeGenerator {
 
     let project: Project
     let pbxProj: PBXProj
-    
+
     var defaultDebugConfig: Config {
         return project.configs.first { $0.type == .debug }!
     }
@@ -22,7 +22,7 @@ public class SchemeGenerator {
     var defaultReleaseConfig: Config {
         return project.configs.first { $0.type == .release }!
     }
-    
+
     public init(project: Project, pbxProj: PBXProj) {
         self.project = project
         self.pbxProj = pbxProj

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -117,30 +117,8 @@ class SchemeGeneratorTests: XCTestCase {
                     targets: [framework, frameworkTest]
                 )
                 let xcodeProject = try project.generateXcodeProject()
-                guard let target = xcodeProject.pbxproj.nativeTargets
-                    .first(where: { $0.name == framework.name }) else {
-                    throw failure("Target not found")
-                }
                 guard let xcscheme = xcodeProject.sharedData?.schemes.first else {
                     throw failure("Scheme not found")
-                }
-
-                guard let buildActionEntry = xcscheme.buildAction?.buildActionEntries.first else {
-                    throw failure("Build Action entry not found")
-                }
-                try expect(buildActionEntry.buildFor) == BuildType.all
-
-                let buildableReferences: [XCScheme.BuildableReference] = [
-                    buildActionEntry.buildableReference,
-                    xcscheme.launchAction?.runnable?.buildableReference,
-                    xcscheme.profileAction?.buildableProductRunnable?.buildableReference,
-                    xcscheme.testAction?.macroExpansion
-                ].compactMap { $0 }
-
-                for buildableReference in buildableReferences {
-                    // FIXME: try expect(buildableReference.blueprintIdentifier) == target.reference
-                    try expect(buildableReference.blueprintName) == target.name
-                    try expect(buildableReference.buildableName) == "\(target.name).\(target.productType!.fileExtension!)"
                 }
 
                 try expect(xcscheme.launchAction?.buildConfiguration) == "Debug"


### PR DESCRIPTION
# Motivation and Context

In a situation, there is the following project definition.

```yaml
name: MyApp
configs:
  Beta: debug
  Debug: debug
  Production: release
  Release: release
targets:
  MyFramework:
    type: framework
    platform: iOS
    sources: MyFramework
    scheme:
      testTargets:
        - MyFrameworkTests
  MyFrameworkTests:
    type: bundle.unit-test
    platform: iOS
    sources: MyFrameworkTests
```

Auto-generated schemes select `Beta` as debug config and `Production` as release config.
Because there are prior ones by alphabetical order.

<img width="199" alt="Screen Shot 2019-10-03 at 0 19 24" src="https://user-images.githubusercontent.com/147051/66057390-9678a700-e573-11e9-838b-abac13620df4.png">

However, we'll expect they select `Debug` and `Release` configuration.
This behavior seems to be ambigious.

# Description

This PR make to use `Debug` and `Release` piror to first ones.

And I added test cases for `SchemeGenerator`.

|Before|After|
|------|------|
|<img width="199" alt="Screen Shot 2019-10-03 at 0 19 24" src="https://user-images.githubusercontent.com/147051/66057390-9678a700-e573-11e9-838b-abac13620df4.png">|<img width="203" alt="Screen Shot 2019-10-03 at 0 19 59" src="https://user-images.githubusercontent.com/147051/66057398-98426a80-e573-11e9-877c-41c6ea88bb7c.png">|
