### PR TITLE
Resolving relative paths with custom project destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed macOS unit test setting preset [#665](https://github.com/yonaskolb/XcodeGen/pull/665) @yonaskolb
 - Add `rcproject` files to sources build phase instead of resources [#669](https://github.com/yonaskolb/XcodeGen/pull/669) @Qusic
 - Prefer default configuration names for generated schemes [#673](https://github.com/yonaskolb/XcodeGen/pull/673) @giginet
+- Fixed resolving relative paths with custom project destination [#681](https://github.com/yonaskolb/XcodeGen/pull/681) @giginet
 
 #### Internal
 

--- a/Sources/XcodeGenCLI/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/GenerateCommand.swift
@@ -125,7 +125,7 @@ class GenerateCommand: Command {
         let xcodeProject: XcodeProj
         do {
             let projectGenerator = ProjectGenerator(project: project)
-            xcodeProject = try projectGenerator.generateXcodeProject()
+            xcodeProject = try projectGenerator.generateXcodeProject(to: projectDirectory)
         } catch {
             throw GenerationError.generationError(error)
         }

--- a/Sources/XcodeGenCLI/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/GenerateCommand.swift
@@ -125,7 +125,7 @@ class GenerateCommand: Command {
         let xcodeProject: XcodeProj
         do {
             let projectGenerator = ProjectGenerator(project: project)
-            xcodeProject = try projectGenerator.generateXcodeProject(to: projectDirectory)
+            xcodeProject = try projectGenerator.generateXcodeProject(in: projectDirectory)
         } catch {
             throw GenerationError.generationError(error)
         }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -24,11 +24,13 @@ public class PBXProjGenerator {
 
     var generated = false
 
-    public init(project: Project) {
+    public init(project: Project, projectDestinationDirectory: Path?) {
         self.project = project
         carthageResolver = CarthageDependencyResolver(project: project)
         pbxProj = PBXProj(rootObject: nil, objectVersion: project.objectVersion)
-        sourceGenerator = SourceGenerator(project: project, pbxProj: pbxProj)
+        sourceGenerator = SourceGenerator(project: project,
+                                          pbxProj: pbxProj,
+                                          projectDestinationDirectory: projectDestinationDirectory)
     }
 
     @discardableResult

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -24,7 +24,7 @@ public class PBXProjGenerator {
 
     var generated = false
 
-    public init(project: Project, projectDirectory: Path?) {
+    public init(project: Project, projectDirectory: Path? = nil) {
         self.project = project
         carthageResolver = CarthageDependencyResolver(project: project)
         pbxProj = PBXProj(rootObject: nil, objectVersion: project.objectVersion)

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -24,13 +24,13 @@ public class PBXProjGenerator {
 
     var generated = false
 
-    public init(project: Project, projectDestinationDirectory: Path?) {
+    public init(project: Project, projectDirectory: Path?) {
         self.project = project
         carthageResolver = CarthageDependencyResolver(project: project)
         pbxProj = PBXProj(rootObject: nil, objectVersion: project.objectVersion)
         sourceGenerator = SourceGenerator(project: project,
                                           pbxProj: pbxProj,
-                                          projectDestinationDirectory: projectDestinationDirectory)
+                                          projectDirectory: projectDirectory)
     }
 
     @discardableResult

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -13,11 +13,11 @@ public class ProjectGenerator {
         self.project = project
     }
 
-    public func generateXcodeProject(to projectDestinationDirectory: Path? = nil) throws -> XcodeProj {
+    public func generateXcodeProject(to projectDirectory: Path? = nil) throws -> XcodeProj {
 
         // generate PBXProj
         let pbxProjGenerator = PBXProjGenerator(project: project,
-                                                projectDestinationDirectory: projectDestinationDirectory)
+                                                projectDirectory: projectDirectory)
         let pbxProj = try pbxProjGenerator.generate()
 
         // generate Schemes

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -13,7 +13,7 @@ public class ProjectGenerator {
         self.project = project
     }
 
-    public func generateXcodeProject(to projectDirectory: Path? = nil) throws -> XcodeProj {
+    public func generateXcodeProject(in projectDirectory: Path? = nil) throws -> XcodeProj {
 
         // generate PBXProj
         let pbxProjGenerator = PBXProjGenerator(project: project,

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -13,10 +13,11 @@ public class ProjectGenerator {
         self.project = project
     }
 
-    public func generateXcodeProject() throws -> XcodeProj {
+    public func generateXcodeProject(to projectDestinationDirectory: Path? = nil) throws -> XcodeProj {
 
         // generate PBXProj
-        let pbxProjGenerator = PBXProjGenerator(project: project)
+        let pbxProjGenerator = PBXProjGenerator(project: project,
+                                                projectDestinationDirectory: projectDestinationDirectory)
         let pbxProj = try pbxProjGenerator.generate()
 
         // generate Schemes

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -289,11 +289,14 @@ class SourceGenerator {
             let groupPath = isTopLevelGroup ?
                 ((try? path.relativePath(from: project.basePath)) ?? path).string :
                 path.lastComponent
+            let projectPath = Path("/Users/giginet/.ghq/github.com/yonaskolb/XcodeGen")
+            let relativePath = try? path.relativePath(from: projectPath)
+            let shouldSetGroupName = (groupName != groupPath) || (relativePath?.string != groupPath)
             let group = PBXGroup(
                 children: children,
                 sourceTree: .group,
-                name: groupName != groupPath ? groupName : nil,
-                path: groupPath
+                name: shouldSetGroupName ? groupName : nil,
+                path: relativePath?.string ?? path.string
             )
             groupReference = addObject(group)
             groupsByPath[path] = groupReference

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -296,7 +296,7 @@ class SourceGenerator {
             if let projectDestinationDirectory = projectDestinationDirectory {
                 relativePath = try? path.relativePath(from: projectDestinationDirectory)
             } else {
-                relativePath = Path(groupPath)
+                relativePath = Path(groupName)
             }
             
             let shouldSetGroupName = (groupName != groupPath) || (relativePath?.string != groupPath)
@@ -304,7 +304,7 @@ class SourceGenerator {
                 children: children,
                 sourceTree: .group,
                 name: shouldSetGroupName ? groupName : nil,
-                path: relativePath?.string ?? path.string
+                path: relativePath?.string
             )
             groupReference = addObject(group)
             groupsByPath[path] = groupReference

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -36,6 +36,14 @@ class SourceGenerator {
         self.pbxProj = pbxProj
         self.projectDirectory = projectDirectory
     }
+    
+    private func resolveGroupPath(_ path: Path, isTopLevelGroup: Bool) -> String {
+        if isTopLevelGroup, let relativePath = try? path.relativePath(from: projectDirectory ?? project.basePath).string {
+            return relativePath
+        } else {
+            return path.lastComponent
+        }
+    }
 
     @discardableResult
     func addObject<T: PBXObject>(_ object: T, context: String? = nil) -> T {
@@ -288,13 +296,8 @@ class SourceGenerator {
             let isTopLevelGroup = (isBaseGroup && !createIntermediateGroups) || isRootPath
 
             let groupName = name ?? path.lastComponent
-            let groupPath: String
-            switch try? path.relativePath(from: projectDirectory ?? project.basePath).string {
-            case .some(let relativePath) where isTopLevelGroup:
-                groupPath = relativePath
-            default:
-                groupPath = path.lastComponent
-            }
+            let groupPath = resolveGroupPath(path, isTopLevelGroup: isTopLevelGroup)
+            
             let group = PBXGroup(
                 children: children,
                 sourceTree: .group,

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -289,13 +289,10 @@ class SourceGenerator {
 
             let groupName = name ?? path.lastComponent
             let groupPath: String
-            if isTopLevelGroup {
-                if let relativePath = try? path.relativePath(from: projectDestinationDirectory ?? project.basePath).string {
-                    groupPath = relativePath
-                } else {
-                    groupPath = path.lastComponent
-                }
-            } else {
+            switch try? path.relativePath(from: projectDestinationDirectory ?? project.basePath).string {
+            case .some(let relativePath) where isTopLevelGroup:
+                groupPath = relativePath
+            default:
                 groupPath = path.lastComponent
             }
             let group = PBXGroup(

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -288,23 +288,21 @@ class SourceGenerator {
             let isTopLevelGroup = (isBaseGroup && !createIntermediateGroups) || isRootPath
 
             let groupName = name ?? path.lastComponent
-            let groupPath = isTopLevelGroup ?
-                ((try? path.relativePath(from: project.basePath)) ?? path).string :
-                path.lastComponent
-            
-            let relativePath: Path?
-            if let projectDestinationDirectory = projectDestinationDirectory {
-                relativePath = try? path.relativePath(from: projectDestinationDirectory)
+            let groupPath: String
+            if isTopLevelGroup {
+                if let relativePath = try? path.relativePath(from: projectDestinationDirectory ?? project.basePath).string {
+                    groupPath = relativePath
+                } else {
+                    groupPath = path.lastComponent
+                }
             } else {
-                relativePath = Path(groupName)
+                groupPath = path.lastComponent
             }
-            
-            let shouldSetGroupName = (groupName != groupPath) || (relativePath?.string != groupPath)
             let group = PBXGroup(
                 children: children,
                 sourceTree: .group,
-                name: shouldSetGroupName ? groupName : nil,
-                path: relativePath?.string
+                name: groupName != groupPath ? groupName : nil,
+                path: groupPath
             )
             groupReference = addObject(group)
             groupsByPath[path] = groupReference

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -13,7 +13,7 @@ struct SourceFile {
 class SourceGenerator {
 
     var rootGroups: Set<PBXFileElement> = []
-    private let projectDestinationDirectory: Path?
+    private let projectDirectory: Path?
     private var fileReferencesByPath: [String: PBXFileElement] = [:]
     private var groupsByPath: [Path: PBXGroup] = [:]
     private var variantGroupsByPath: [Path: PBXVariantGroup] = [:]
@@ -31,10 +31,10 @@ class SourceGenerator {
 
     private(set) var knownRegions: Set<String> = []
 
-    init(project: Project, pbxProj: PBXProj, projectDestinationDirectory: Path?) {
+    init(project: Project, pbxProj: PBXProj, projectDirectory: Path?) {
         self.project = project
         self.pbxProj = pbxProj
-        self.projectDestinationDirectory = projectDestinationDirectory
+        self.projectDirectory = projectDirectory
     }
 
     @discardableResult
@@ -289,7 +289,7 @@ class SourceGenerator {
 
             let groupName = name ?? path.lastComponent
             let groupPath: String
-            switch try? path.relativePath(from: projectDestinationDirectory ?? project.basePath).string {
+            switch try? path.relativePath(from: projectDirectory ?? project.basePath).string {
             case .some(let relativePath) where isTopLevelGroup:
                 groupPath = relativePath
             default:

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1016,7 +1016,7 @@ class ProjectGeneratorTests: XCTestCase {
         )
         
         describe("generateXcodeProject") {
-            $0.context("without projectDestinationDirectory") {
+            $0.context("without projectDirectory") {
                 $0.it("generate groups") {
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
@@ -1026,7 +1026,7 @@ class ProjectGeneratorTests: XCTestCase {
                 }
             }
             
-            $0.context("with projectDestinationDirectory") {
+            $0.context("with projectDirectory") {
                 $0.it("generate groups") {
                     let destinationPath = fixturePath
                     let project = Project(name: "test", targets: [frameworkWithSources])

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1005,7 +1005,7 @@ class ProjectGeneratorTests: XCTestCase {
         }
     }
     
-    func testWithDifferentDestination() throws {
+    func testGenerateXcodeProjectWithDestination() throws {
         let groupName = "App_iOS"
         let sourceDirectory = fixturePath + "TestProject" + groupName
         let frameworkWithSources = Target(
@@ -1021,7 +1021,7 @@ class ProjectGeneratorTests: XCTestCase {
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
                     let generatedProject = try generator.generateXcodeProject()
-                    let group = try XCTUnwrap( generatedProject.pbxproj.groups.first(where: { $0.name == groupName }))
+                    let group = try XCTUnwrap(generatedProject.pbxproj.groups.first(where: { $0.name == groupName }))
                     try expect(group.path) == "App_iOS"
                 }
             }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1021,8 +1021,8 @@ class ProjectGeneratorTests: XCTestCase {
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
                     let generatedProject = try generator.generateXcodeProject()
-                    let group = try XCTUnwrap(generatedProject.pbxproj.groups.first(where: { $0.name == groupName }))
-                    try expect(group.path) == "App_iOS"
+                    let group = generatedProject.pbxproj.groups.first(where: { $0.name == groupName })
+                    try expect(group?.path) == "App_iOS"
                 }
             }
             
@@ -1032,8 +1032,8 @@ class ProjectGeneratorTests: XCTestCase {
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
                     let generatedProject = try generator.generateXcodeProject(to: destinationPath)
-                    let group = try XCTUnwrap( generatedProject.pbxproj.groups.first(where: { $0.name == groupName }))
-                    try expect(group.path) == "TestProject/App_iOS"
+                    let group = generatedProject.pbxproj.groups.first(where: { $0.name == groupName })
+                    try expect(group?.path) == "TestProject/App_iOS"
                 }
             }
         }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1004,4 +1004,38 @@ class ProjectGeneratorTests: XCTestCase {
             }
         }
     }
+    
+    func testWithDifferentDestination() throws {
+        let groupName = "App_iOS"
+        let sourceDirectory = fixturePath + "TestProject" + groupName
+        let frameworkWithSources = Target(
+            name: "MyFramework",
+            type: .framework,
+            platform: .iOS,
+            sources: [TargetSource(path: sourceDirectory.string)]
+        )
+        
+        describe("generateXcodeProject") {
+            $0.context("without projectDestinationDirectory") {
+                $0.it("generate groups") {
+                    let project = Project(name: "test", targets: [frameworkWithSources])
+                    let generator = ProjectGenerator(project: project)
+                    let generatedProject = try generator.generateXcodeProject()
+                    let group = try XCTUnwrap( generatedProject.pbxproj.groups.first(where: { $0.name == groupName }))
+                    try expect(group.path) == "App_iOS"
+                }
+            }
+            
+            $0.context("with projectDestinationDirectory") {
+                $0.it("generate groups") {
+                    let destinationPath = fixturePath
+                    let project = Project(name: "test", targets: [frameworkWithSources])
+                    let generator = ProjectGenerator(project: project)
+                    let generatedProject = try generator.generateXcodeProject(to: destinationPath)
+                    let group = try XCTUnwrap( generatedProject.pbxproj.groups.first(where: { $0.name == groupName }))
+                    try expect(group.path) == "TestProject/App_iOS"
+                }
+            }
+        }
+    }
 }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1031,7 +1031,7 @@ class ProjectGeneratorTests: XCTestCase {
                     let destinationPath = fixturePath
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
-                    let generatedProject = try generator.generateXcodeProject(to: destinationPath)
+                    let generatedProject = try generator.generateXcodeProject(in: destinationPath)
                     let group = generatedProject.pbxproj.groups.first(where: { $0.nameOrPath == groupName })
                     try expect(group?.path) == "TestProject/App_iOS"
                 }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1021,7 +1021,7 @@ class ProjectGeneratorTests: XCTestCase {
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
                     let generatedProject = try generator.generateXcodeProject()
-                    let group = generatedProject.pbxproj.groups.first(where: { $0.name == groupName })
+                    let group = generatedProject.pbxproj.groups.first(where: { $0.nameOrPath == groupName })
                     try expect(group?.path) == "App_iOS"
                 }
             }
@@ -1032,7 +1032,7 @@ class ProjectGeneratorTests: XCTestCase {
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
                     let generatedProject = try generator.generateXcodeProject(to: destinationPath)
-                    let group = generatedProject.pbxproj.groups.first(where: { $0.name == groupName })
+                    let group = generatedProject.pbxproj.groups.first(where: { $0.nameOrPath == groupName })
                     try expect(group?.path) == "TestProject/App_iOS"
                 }
             }


### PR DESCRIPTION
# Motivation and Context

In the situation generating with `--project` option different with spec's directory, All containing files are missing on the generated projects.

```console
$ xcodegen -p ./GeneratedProjects
```

<img width="962" alt="Screen Shot 2019-10-08 at 21 19 41" src="https://user-images.githubusercontent.com/147051/66395170-bc89c580-ea11-11e9-8992-d460d4fda20c.png">

There is following directory structure.

```
.
├── GeneratedProjects
│   └── MyFramework.xcodeproj
├── MyFramework
│   ├── SubGroup
│   │   └── A.swift
│   └── main.swift
└── project.yml
```

# Description

This PR solve this issue. Top Level group's location must be the relative path from the generated project.

|Before|After|
|---------|-----------|
|<img width="962" alt="Screen Shot 2019-10-08 at 21 19 41" src="https://user-images.githubusercontent.com/147051/66395170-bc89c580-ea11-11e9-8992-d460d4fda20c.png">|<img width="959" alt="Screen Shot 2019-10-08 at 21 20 08" src="https://user-images.githubusercontent.com/147051/66395187-c3183d00-ea11-11e9-9c20-bdf0742017ab.png">|

Before : `MyFramework` group's location was `MyFramework`. This value comes from a relative path **from the project spec**. It should be a relative path from `PROJECT_ROOT`.

After: `MyFramework` group's location chages to `../MyFramework`. It's a relative path **from `PROJECT_ROOT`**.