### PR TITLE
[WIP] Spec generation

### DIFF
--- a/Sources/ProjectSpec/CollectionExtensions.swift
+++ b/Sources/ProjectSpec/CollectionExtensions.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+private protocol EmptyRemovable {
+    func removeEmpty() -> Self
+    var isEmpty: Bool { get }
+}
+
+extension Array: EmptyRemovable {
+    public func removeEmpty() -> Array {
+        return compactMap {
+            if let e = ($0 as? EmptyRemovable)?.removeEmpty() {
+                return e.isEmpty ? nil : e as? Element
+            }
+            return $0
+        }
+    }
+}
+
+extension Dictionary: EmptyRemovable {
+    // this is a little trick that defines the generics parameter from optional Value to unwrapped Value
+    private static func removeEmpty<Key, Value>(dict: Dictionary<Key, Value?>) -> Dictionary<Key, Value> {
+        return dict.compactMapValues {
+            if let e = ($0 as? EmptyRemovable)?.removeEmpty() {
+                return e.isEmpty ? nil : e as? Value
+            }
+            return $0
+        }
+    }
+
+    public func removeEmpty() -> Dictionary<Key, Value> {
+        return Dictionary.removeEmpty(dict: self)
+    }
+}

--- a/Sources/ProjectSpec/Settings.swift
+++ b/Sources/ProjectSpec/Settings.swift
@@ -110,11 +110,35 @@ extension Settings: JSONEncodable {
     public func toJSONValue() -> Any {
         if groups.count > 0 || configSettings.count > 0 {
             return [
-                "base": buildSettings,
+                "base": buildSettings.toJSONValue(),
                 "groups": groups,
                 "configs": configSettings.mapValues { $0.toJSONValue() },
             ]
         }
-        return buildSettings
+        return buildSettings.toJSONValue()
+    }
+}
+
+extension BuildSettings: JSONEncodable {
+    private func asJSONValue(_ value: Any) -> Any {
+        switch value {
+        case let value as Path:
+            return value.string
+        case let value as [Any]:
+            return value.map(asJSONValue)
+        case let value as [String: Any]:
+            return value.mapValues(asJSONValue)
+        case is Bool: fallthrough
+        case is Int: fallthrough
+        case is Double: fallthrough
+        case is String:
+            return value
+        default:
+            fatalError("not supported type")
+        }
+    }
+
+    public func toJSONValue() -> Any {
+        return mapValues(asJSONValue)
     }
 }

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -208,7 +208,7 @@ extension TargetSource: JSONEncodable {
             dict["optional"] = optional
         }
 
-        if dict.count == 0 {
+        if dict.removeEmpty().isEmpty {
             return path
         }
 

--- a/Sources/XcodeGenCLI/GenerateSpecCommand.swift
+++ b/Sources/XcodeGenCLI/GenerateSpecCommand.swift
@@ -1,0 +1,32 @@
+import Foundation
+import PathKit
+import ProjectSpec
+import SwiftCLI
+import XcodeGenKit
+import XcodeProj
+import Yams
+
+class GenerateSpecCommand: Command {
+    let name: String = "generate-spec"
+
+    let projectFile = Key<Path>("-p", "--project", description: "The path to the project file")
+
+    let spec = Key<Path>(
+        "-s",
+        "--spec",
+        description: "The path to the project spec file should be generated. Defaults to project.yml"
+    )
+
+    func execute() throws {
+        guard let file = projectFile.value else {
+            return
+        }
+        let xcodeProj = try XcodeProj(path: file)
+        let project = try generateSpec(xcodeProj: xcodeProj, projectDirectory: file.parent())
+        let projectDict = project?.toJSONDictionary().removeEmpty()
+        let encodedYAML = try Yams.dump(object: projectDict)
+        let defaultOutPath = file.parent() + "project.yml"
+        let outPath = spec.value ?? defaultOutPath
+        try encodedYAML.write(toFile: outPath.string, atomically: true, encoding: .utf8)
+    }
+}

--- a/Sources/XcodeGenCLI/XcodeGenCLI.swift
+++ b/Sources/XcodeGenCLI/XcodeGenCLI.swift
@@ -7,12 +7,13 @@ public class XcodeGenCLI {
 
     public init(version: Version) {
         let generateCommand = GenerateCommand(version: version)
+        let specGenerationCommand = GenerateSpecCommand()
 
         cli = CLI(
             name: "xcodegen",
             version: version.string,
             description: "Generates Xcode projects",
-            commands: [generateCommand]
+            commands: [generateCommand, specGenerationCommand]
         )
         cli.parser.routeBehavior = .searchWithFallback(generateCommand)
     }

--- a/Sources/XcodeGenKit/SpecGenerator.swift
+++ b/Sources/XcodeGenKit/SpecGenerator.swift
@@ -1,0 +1,272 @@
+import Foundation
+import ProjectSpec
+import XcodeProj
+import PathKit
+
+public func generateSpec(xcodeProj: XcodeProj, projectDirectory: Path) throws -> Project? {
+    guard let pbxproj = xcodeProj.pbxproj.rootObject else {
+        return nil
+    }
+    return try generateProjectSpec(pbxproj: pbxproj, projectDirectory: projectDirectory)
+}
+
+private func generateProjectSpec(pbxproj: PBXProject, projectDirectory: Path) throws -> Project {
+    let targets = try pbxproj.targets
+        .compactMap { $0 as? PBXNativeTarget }
+        .map { try generateTargetSpec(target: $0,
+                                      mainGroup: pbxproj.mainGroup,
+                                      sourceRoot: projectDirectory + pbxproj.projectDirPath) }
+
+    let aggregateTargets = pbxproj.targets
+        .compactMap { $0 as? PBXAggregateTarget }
+        .map(AggregateTarget.init)
+
+    return Project(basePath: Path(pbxproj.projectDirPath),
+                   name: pbxproj.name,
+                   targets: targets,
+                   aggregateTargets: aggregateTargets,
+                   settingGroups: pbxproj.settingGroups,
+                   options: .init(),
+                   attributes: pbxproj.attributes)
+}
+
+private func generateTargetSpec(target: PBXNativeTarget, mainGroup: PBXGroup, sourceRoot: Path) throws -> Target {
+    let sources = try target.sourceFiles().compactMap { fileElement -> TargetSource? in
+        guard let path = try fileElement.fullPath(sourceRoot: sourceRoot) else {
+            return nil
+        }
+        return TargetSource(path: try path.relativePath(from: sourceRoot).string,
+                            name: fileElement.name)
+    }
+
+    let headers = try target.buildPhases
+        .compactMap { $0 as? PBXHeadersBuildPhase }
+        .compactMap { $0.files }
+        .reduce([], { $0 + $1 })
+        .compactMap { buildFile -> TargetSource? in
+            guard let fileElement = buildFile.file,
+                let path = try fileElement.fullPath(sourceRoot: sourceRoot) else {
+                    return nil
+            }
+            let headerVisibility = TargetSource.HeaderVisibility(attribute: (buildFile.settings?["ATTRIBUTES"] as? [String])?.first)
+            return TargetSource(path: try path.relativePath(from: sourceRoot).string,
+                                name: fileElement.name,
+                                headerVisibility: headerVisibility)
+    }
+
+    // For application targets, header files are not included in the build phase. The project should also contain header files, so search for them from groups and add to source.
+    let implicitHeaders: [TargetSource]
+    if let productType = target.productType, productType == .application || productType == .unitTestBundle {
+        let targetRootGroup = mainGroup.children
+            .compactMap { $0 as? PBXGroup }
+            .first { $0.path == target.name }
+
+        let headerFiles = targetRootGroup?.allHeaderFiles ?? []
+
+        implicitHeaders = try headerFiles
+            .compactMap { fileElement -> TargetSource? in
+                guard let path = try fileElement.fullPath(sourceRoot: sourceRoot) else {
+                    return nil
+                }
+                return TargetSource(path: try path.relativePath(from: sourceRoot).string,
+                                    name: fileElement.name)
+        }
+    } else {
+        implicitHeaders = []
+    }
+
+    let resources = try target.resourcesBuildPhase()?.files?
+        .compactMap { $0.file }
+        .compactMap { fileElement -> [TargetSource]? in
+            if let variantGroup = fileElement as? PBXVariantGroup {
+                return try variantGroup.children.compactMap { fileElement -> TargetSource? in
+                    guard let parent = try fileElement.parent?.parent?.fullPath(sourceRoot: sourceRoot),
+                        let path = fileElement.path else {
+                        return nil
+                    }
+                    let fullpath = parent + path
+                    return TargetSource(path: try fullpath.relativePath(from: sourceRoot).string,
+                                        name: fileElement.name)
+                }
+            }
+            guard let path = try fileElement.fullPath(sourceRoot: sourceRoot) else {
+                return nil
+            }
+            return [TargetSource(path: try path.relativePath(from: sourceRoot).string,
+                                 name: fileElement.name)]
+        }.reduce([], { $0 + $1 }) ?? []
+
+    let frameworks = target.buildPhases
+        .compactMap { $0 as? PBXFrameworksBuildPhase }
+        .compactMap { $0.files?.compactMap { $0.file } }
+        .reduce([], { $0 + $1 })
+
+    let dependencies: [Dependency] = frameworks.compactMap { fileElement in
+        guard let path = fileElement.path else {
+            return nil
+        }
+        if let sourceTree = fileElement.sourceTree, sourceTree == .sdkRoot {
+            return Dependency(type: .sdk(root: Path(path).parent().string),
+                              reference: fileElement.name ?? Path(path).lastComponent)
+        }
+        return Dependency(type: .framework, reference: path)
+    }
+
+    let targetSources = sources + headers + implicitHeaders + resources
+
+    let buildScripts = target.buildPhases
+        .compactMap { $0 as? PBXShellScriptBuildPhase }
+        .map(BuildScript.init)
+
+    let buildRules = target.buildRules.map(BuildRule.init)
+
+    return Target(name: target.name,
+                  type: target.productType ?? .application,
+                  platform: .iOS,
+                  productName: target.productName,
+                  settings: target.settings,
+                  sources: try optimizeSources(targetSources, sourceRoot: sourceRoot),
+                  dependencies: dependencies,
+                  postBuildScripts: buildScripts,
+                  buildRules: buildRules)
+}
+
+private func optimizeSources(_ sources: [TargetSource], sourceRoot: Path) throws -> [TargetSource] {
+    let allSourcePaths = sources.map { sourceRoot + Path($0.path) }
+    var merged = [TargetSource]()
+
+    let completed = try sources
+        .sorted { Path($0.path).components.count > Path($1.path).components.count }
+        .compactMap { targetSource -> TargetSource? in
+            let parent = (sourceRoot + Path(targetSource.path)).parent()
+
+            // skip when parent directory is already added
+            if merged.contains(where: { (sourceRoot + Path($0.path)) == parent }) {
+                return nil
+            }
+
+            let sameLevelFiles = try parent.children().filter {
+                // ingore files that will specified in build configs
+                $0.lastComponent != "Info.plist" &&
+                    $0.lastComponent != ".DS_Store" &&
+                    $0.extension != "modulemap" &&
+                    $0.extension != "entitlements"
+            }
+
+            // merge files into a directory if all its contents are in the target
+            if sameLevelFiles.allSatisfy({ allSourcePaths.contains($0) }) {
+                merged.append(TargetSource(path: try parent.relativePath(from: sourceRoot).string,
+                                           name: parent.lastComponent))
+                return nil
+            }
+            return targetSource
+    }
+
+    let result = merged.count > 0 ? try optimizeSources(completed + merged, sourceRoot: sourceRoot) : completed
+    return result.sorted { $0.path < $1.path }
+}
+
+private extension BuildScript {
+    init(buildPhase: PBXShellScriptBuildPhase) {
+        self.init(script: .script(buildPhase.shellScript ?? ""),
+                  name: buildPhase.name,
+                  inputFiles: buildPhase.inputPaths,
+                  outputFiles: buildPhase.outputPaths,
+                  inputFileLists: buildPhase.inputFileListPaths ?? [],
+                  outputFileLists: buildPhase.outputFileListPaths ?? [],
+                  shell: buildPhase.shellPath,
+                  runOnlyWhenInstalling: buildPhase.runOnlyForDeploymentPostprocessing,
+                  showEnvVars: buildPhase.showEnvVarsInLog)
+    }
+}
+
+private extension PBXProject {
+    var settingGroups: [String: Settings] {
+        return Dictionary(uniqueKeysWithValues: buildConfigurationList.buildConfigurations.map {
+            ($0.name, Settings(buildSettings: $0.buildSettings))
+        })
+    }
+}
+
+private extension PBXTarget {
+    var settings: Settings {
+        let configSettings = buildConfigurationList?.buildConfigurations.map {
+            ($0.name, Settings(buildSettings: $0.buildSettings))
+        }
+
+        return Settings(configSettings: configSettings.flatMap(Dictionary.init) ?? [:])
+    }
+}
+
+private extension AggregateTarget {
+    init(target: PBXAggregateTarget) {
+        let buildScripts = target.buildPhases
+            .compactMap { $0 as? PBXShellScriptBuildPhase }
+            .map(BuildScript.init)
+
+        self.init(
+            name: target.name,
+            targets: target.dependencies.compactMap { $0.target?.name },
+            settings: target.settings,
+            buildScripts: buildScripts)
+    }
+}
+
+private extension BuildRule {
+    init(buildRule: PBXBuildRule) {
+        let fileType: BuildRule.FileType
+        if let filePatterns = buildRule.filePatterns {
+            fileType = .pattern(filePatterns)
+        } else {
+            fileType = .type(buildRule.fileType)
+        }
+
+        let compilerSpec: BuildRule.Action
+        if buildRule.compilerSpec == "com.apple.compilers.proxy.script" {
+            compilerSpec = .script(buildRule.script ?? "")
+        } else {
+            compilerSpec = .compilerSpec(buildRule.compilerSpec)
+        }
+
+        self.init(fileType: fileType,
+                  action: compilerSpec,
+                  name: buildRule.name,
+                  outputFiles: buildRule.outputFiles,
+                  outputFilesCompilerFlags: buildRule.outputFilesCompilerFlags ?? [])
+    }
+}
+
+private extension TargetSource.HeaderVisibility {
+    init?(attribute: String?) {
+        guard let attribute = attribute else {
+            return nil
+        }
+        switch attribute {
+        case TargetSource.HeaderVisibility.private.settingName:
+            self = .private
+        case TargetSource.HeaderVisibility.public.settingName:
+            self = .public
+        case TargetSource.HeaderVisibility.project.settingName:
+            self = .project
+        default:
+            return nil
+        }
+    }
+}
+
+extension PBXGroup {
+    var allHeaderFiles: [PBXFileElement] {
+        return children.compactMap { file in
+            if let group = file as? PBXGroup {
+                return group.allHeaderFiles
+            }
+
+            if let path = file.path,
+                path.hasSuffix(".h") || path.hasSuffix(".hpp") {
+                return [file]
+            }
+
+            return nil
+        }.reduce([], { $0 + $1 })
+    }
+}

--- a/Tests/XcodeGenKitTests/ProjectSpecTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectSpecTests.swift
@@ -496,6 +496,9 @@ class ProjectSpecTests: XCTestCase {
                                    attributes: ["attributes": "bar"])
 
                 let json = proj.toJSONDictionary()
+
+                try expect(JSONSerialization.isValidJSONObject(json)).beTrue()
+
                 let restoredProj = try Project(basePath: Path.current, jsonDictionary: json)
 
                 // Examin some properties to make debugging easier

--- a/Tests/XcodeGenKitTests/SpecGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SpecGeneratorTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+import XcodeGenKit
+
+class SpecGeneratorTests: XCTestCase {
+    func testRemoveEmpty() {
+        let arr: [Any] = [[], [1, [2], []], [3]]
+        let removed: [Any] = arr.removeEmpty()
+
+        let dict: [String: Any?] = ["e": nil]
+        let removed2: [String: Any] = dict.removeEmpty()
+        XCTAssertEqual(removed2.count, 0)
+        let removed3: [String: Any] = dict.compactMapValues { $0 }
+        XCTAssertEqual(removed3.count, 0)
+    }
+}


### PR DESCRIPTION
Although it is not a complete PR, it is now operating to some extent. There are some issues and I would like to hear your feedback.

## Implementation status

- [x] Write Project to a yaml file
- [ ] Generate Project from XcodeProj
  - roughly done
  - some project settings are not treated yet
- [ ] Remove default values from yaml
- [ ] Change to proper command names and CLI improvements
- [ ] Fix to find C header files appropriate way

About the last item. As far as I know, C header files are not added to the build phase on the application target, so we have to find them from the group. Currently I am adding all header files in the group as sources, but if the group doesn't match the target it will cause problems. If you know anything about how to deal with this, please let me know.

## output example 

```bash
xcodegen generate-spec --project /path/to/project/Fireside.xcodeproj --spec  /path/to/project/project.yml
```

This produces below

<details>
<summary>project.yml</summary>

```yaml
attributes:
  LastUpgradeCheck: 1020
configs:
  Debug: debug
  Release: release
name: Fireside
options:
  groupSortPosition: bottom
  transitivelyLinkDependencies: false
settingGroups:
  Debug:
    ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: YES
    ALWAYS_SEARCH_USER_PATHS: NO
    CLANG_ANALYZER_NONNULL: YES
    CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: YES_AGGRESSIVE
    CLANG_CXX_LANGUAGE_STANDARD: gnu++14
    CLANG_CXX_LIBRARY: libc++
    CLANG_ENABLE_MODULES: YES
    CLANG_ENABLE_OBJC_ARC: YES
    CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING: YES
    CLANG_WARN_BOOL_CONVERSION: YES
    CLANG_WARN_COMMA: YES
    CLANG_WARN_CONSTANT_CONVERSION: YES
    CLANG_WARN_DIRECT_OBJC_ISA_USAGE: YES_ERROR
    CLANG_WARN_DOCUMENTATION_COMMENTS: YES
    CLANG_WARN_EMPTY_BODY: YES
    CLANG_WARN_ENUM_CONVERSION: YES
    CLANG_WARN_INFINITE_RECURSION: YES
    CLANG_WARN_INT_CONVERSION: YES
    CLANG_WARN_NON_LITERAL_NULL_CONVERSION: YES
    CLANG_WARN_OBJC_LITERAL_CONVERSION: YES
    CLANG_WARN_OBJC_ROOT_CLASS: YES_ERROR
    CLANG_WARN_RANGE_LOOP_ANALYSIS: YES
    CLANG_WARN_STRICT_PROTOTYPES: YES
    CLANG_WARN_SUSPICIOUS_MOVE: YES
    CLANG_WARN_UNGUARDED_AVAILABILITY: YES_AGGRESSIVE
    CLANG_WARN_UNREACHABLE_CODE: YES
    CLANG_WARN__DUPLICATE_METHOD_MATCH: YES
    COPY_PHASE_STRIP: NO
    DEBUG_INFORMATION_FORMAT: dwarf
    ENABLE_STRICT_OBJC_MSGSEND: YES
    ENABLE_TESTABILITY: YES
    GCC_C_LANGUAGE_STANDARD: gnu11
    GCC_DYNAMIC_NO_PIC: NO
    GCC_NO_COMMON_BLOCKS: YES
    GCC_OPTIMIZATION_LEVEL: 0
    GCC_PREPROCESSOR_DEFINITIONS:
    - $(inherited)
    - DEBUG=1
    GCC_WARN_64_TO_32_BIT_CONVERSION: YES
    GCC_WARN_ABOUT_RETURN_TYPE: YES_ERROR
    GCC_WARN_UNDECLARED_SELECTOR: YES
    GCC_WARN_UNINITIALIZED_AUTOS: YES_AGGRESSIVE
    GCC_WARN_UNUSED_FUNCTION: YES
    GCC_WARN_UNUSED_VARIABLE: YES
    MTL_ENABLE_DEBUG_INFO: YES
    ONLY_ACTIVE_ARCH: YES
    PRODUCT_NAME: $(TARGET_NAME)
    SDKROOT: iphoneos
    SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
    SWIFT_OPTIMIZATION_LEVEL: -Onone
    SWIFT_VERSION: 4.0
  Release:
    ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: YES
    ALWAYS_SEARCH_USER_PATHS: NO
    CLANG_ANALYZER_NONNULL: YES
    CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION: YES_AGGRESSIVE
    CLANG_CXX_LANGUAGE_STANDARD: gnu++14
    CLANG_CXX_LIBRARY: libc++
    CLANG_ENABLE_MODULES: YES
    CLANG_ENABLE_OBJC_ARC: YES
    CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING: YES
    CLANG_WARN_BOOL_CONVERSION: YES
    CLANG_WARN_COMMA: YES
    CLANG_WARN_CONSTANT_CONVERSION: YES
    CLANG_WARN_DIRECT_OBJC_ISA_USAGE: YES_ERROR
    CLANG_WARN_DOCUMENTATION_COMMENTS: YES
    CLANG_WARN_EMPTY_BODY: YES
    CLANG_WARN_ENUM_CONVERSION: YES
    CLANG_WARN_INFINITE_RECURSION: YES
    CLANG_WARN_INT_CONVERSION: YES
    CLANG_WARN_NON_LITERAL_NULL_CONVERSION: YES
    CLANG_WARN_OBJC_LITERAL_CONVERSION: YES
    CLANG_WARN_OBJC_ROOT_CLASS: YES_ERROR
    CLANG_WARN_RANGE_LOOP_ANALYSIS: YES
    CLANG_WARN_STRICT_PROTOTYPES: YES
    CLANG_WARN_SUSPICIOUS_MOVE: YES
    CLANG_WARN_UNGUARDED_AVAILABILITY: YES_AGGRESSIVE
    CLANG_WARN_UNREACHABLE_CODE: YES
    CLANG_WARN__DUPLICATE_METHOD_MATCH: YES
    COPY_PHASE_STRIP: NO
    DEBUG_INFORMATION_FORMAT: dwarf-with-dsym
    ENABLE_NS_ASSERTIONS: NO
    ENABLE_STRICT_OBJC_MSGSEND: YES
    GCC_C_LANGUAGE_STANDARD: gnu11
    GCC_NO_COMMON_BLOCKS: YES
    GCC_WARN_64_TO_32_BIT_CONVERSION: YES
    GCC_WARN_ABOUT_RETURN_TYPE: YES_ERROR
    GCC_WARN_UNDECLARED_SELECTOR: YES
    GCC_WARN_UNINITIALIZED_AUTOS: YES_AGGRESSIVE
    GCC_WARN_UNUSED_FUNCTION: YES
    GCC_WARN_UNUSED_VARIABLE: YES
    PRODUCT_NAME: $(TARGET_NAME)
    SDKROOT: iphoneos
    SWIFT_OPTIMIZATION_LEVEL: -Owholemodule
    SWIFT_VERSION: 4.0
    VALIDATE_PRODUCT: YES
targets:
  AppTests:
    platform: iOS
    settings:
      configs:
        Debug:
          ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
          BUNDLE_LOADER: $(TEST_HOST)
          INFOPLIST_FILE: AppTests/Info.plist
          IPHONEOS_DEPLOYMENT_TARGET: 10.0
          LD_RUNPATH_SEARCH_PATHS:
          - $(inherited)
          - '@executable_path/Frameworks'
          - '@loader_path/Frameworks'
          PRODUCT_BUNDLE_IDENTIFIER: com.covelline.AppTests
          SDKROOT: iphoneos
          TARGETED_DEVICE_FAMILY: 1,2
        Release:
          ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
          BUNDLE_LOADER: $(TEST_HOST)
          INFOPLIST_FILE: AppTests/Info.plist
          IPHONEOS_DEPLOYMENT_TARGET: 10.0
          LD_RUNPATH_SEARCH_PATHS:
          - $(inherited)
          - '@executable_path/Frameworks'
          - '@loader_path/Frameworks'
          PRODUCT_BUNDLE_IDENTIFIER: com.covelline.AppTests
          SDKROOT: iphoneos
          TARGETED_DEVICE_FAMILY: 1,2
    sources:
    - name: AppTests
      path: AppTests
    type: bundle.unit-test
  Fireside:
    platform: iOS
    settings:
      configs:
        Debug:
          ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
          CODE_SIGN_IDENTITY[sdk=iphoneos*]: iPhone Developer
          DEVELOPMENT_TEAM: K45ES832VB
          INFOPLIST_FILE: App/Info.plist
          IPHONEOS_DEPLOYMENT_TARGET: 10.0
          LD_RUNPATH_SEARCH_PATHS:
          - $(inherited)
          - '@executable_path/Frameworks'
          PRODUCT_BUNDLE_IDENTIFIER: com.covelline.fireside
          SDKROOT: iphoneos
          TARGETED_DEVICE_FAMILY: 1,2
        Release:
          ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
          CODE_SIGN_IDENTITY[sdk=iphoneos*]: iPhone Developer
          DEVELOPMENT_TEAM: K45ES832VB
          INFOPLIST_FILE: App/Info.plist
          IPHONEOS_DEPLOYMENT_TARGET: 10.0
          LD_RUNPATH_SEARCH_PATHS:
          - $(inherited)
          - '@executable_path/Frameworks'
          PRODUCT_BUNDLE_IDENTIFIER: com.covelline.fireside
          SDKROOT: iphoneos
          TARGETED_DEVICE_FAMILY: 1,2
    sources:
    - name: App
      path: App
    type: application
```
</details>