### PR TITLE
Resolve auto-generated INFOPLIST_FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Fixed
 - Add base localisation by default even if no base localised files were found. Fixes warning in Xcode 11 [#685](https://github.com/yonaskolb/XcodeGen/pull/685) @yonaskolb
 - Don't generate CFBundleExecutable in default generated Info.plist for `bundle` target types [#689](https://github.com/yonaskolb/XcodeGen/pull/689) @FranzBusch
+- Fixed resolving relative paths with custom project destination [#681](https://github.com/yonaskolb/XcodeGen/pull/681) @giginet
+- Fixed resolving relative paths for Info.plist [#683](https://github.com/yonaskolb/XcodeGen/pull/683)
+
 
 ## 2.9.0
 
@@ -16,7 +19,6 @@
 - Add `rcproject` files to sources build phase instead of resources [#669](https://github.com/yonaskolb/XcodeGen/pull/669) @Qusic
 - Prefer default configuration names for generated schemes [#673](https://github.com/yonaskolb/XcodeGen/pull/673) @giginet
 - Fixed some resource files being placed to "Recovered References" group [#679](https://github.com/yonaskolb/XcodeGen/pull/679) @nivanchikov
-- Fixed resolving relative paths with custom project destination [#681](https://github.com/yonaskolb/XcodeGen/pull/681) @giginet
 
 #### Internal
 - Updated to SwiftCLI 5.3.2 [#667](https://github.com/yonaskolb/XcodeGen/pull/667) @giginet

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -9,6 +9,7 @@ public class PBXProjGenerator {
     let project: Project
 
     let pbxProj: PBXProj
+    let projectDirectory: Path?
     let carthageResolver: CarthageDependencyResolver
 
     var sourceGenerator: SourceGenerator!
@@ -28,6 +29,7 @@ public class PBXProjGenerator {
         self.project = project
         carthageResolver = CarthageDependencyResolver(project: project)
         pbxProj = PBXProj(rootObject: nil, objectVersion: project.objectVersion)
+        self.projectDirectory = projectDirectory
         sourceGenerator = SourceGenerator(project: project,
                                           pbxProj: pbxProj,
                                           projectDirectory: projectDirectory)
@@ -861,7 +863,7 @@ public class PBXProjGenerator {
                     searchForPlist = false
                 }
                 if let plistPath = plistPath {
-                    buildSettings["INFOPLIST_FILE"] = (try? plistPath.relativePath(from: project.basePath)) ?? plistPath
+                    buildSettings["INFOPLIST_FILE"] = (try? plistPath.relativePath(from: projectDirectory ?? project.basePath)) ?? plistPath
                 }
             }
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1066,6 +1066,18 @@ class ProjectGeneratorTests: XCTestCase {
                     let group = generatedProject.pbxproj.groups.first(where: { $0.nameOrPath == groupName })
                     try expect(group?.path) == "TestProject/App_iOS"
                 }
+                
+                $0.it("generate Info.plist") {
+                    let destinationPath = fixturePath
+                    let project = Project(name: "test", targets: [frameworkWithSources])
+                    let generator = ProjectGenerator(project: project)
+                    let generatedProject = try generator.generateXcodeProject(to: destinationPath)
+                    let plists = generatedProject.pbxproj.buildConfigurations.compactMap { $0.buildSettings["INFOPLIST_FILE"] as? Path }
+                    try expect(plists.count) == 2
+                    for plist in plists {
+                        try expect(plist) == "TestProject/App_iOS/Info.plist"
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
# Motivation and Context

~This PR relied on #681. Please review first #681 before this.~

In the same situation as #681, Info.plist paths are also wrong.

```console
$ xcodegen -p ./GeneratedProjects
```

`INFOPLIST_PATH` was relative path from the project spec.

https://github.com/yonaskolb/XcodeGen/pull/681#issue-325748881

# Description

Use related path for auto-generated `INFOPLIST_FILE` settings and added tests.