### PR TITLE
Don't generate CFBundleExecutable for targets of type bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Fixed
 - Add base localisation by default even if no base localised files were found. Fixes warning in Xcode 11 [#685](https://github.com/yonaskolb/XcodeGen/pull/685) @yonaskolb
+- Don't generate CFBundleExecutable for target of type `bundle` @FranzBusch
 
 ## 2.9.0
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -203,10 +203,10 @@ Settings are merged in the following order: groups, base, configs.
   - `TEST_TARGET_NAME`: for ui tests that target an application
   - `TEST_HOST`: for unit tests that target an application
 - [ ] **dependencies**: **[[Dependency](#dependency)]** - Dependencies for the target
-- [ ] **info**: **[Plist](#plist)** - If defined, this will generate and write an `Info.plist` to the specified path and use it by setting the `INFOPLIST_FILE` build setting for every configuration, unless `INFOPLIST_FILE` is already defined in  **settings** for this configuration. The following properties are generated automatically, the rest will have to be provided.
+- [ ] **info**: **[Plist](#plist)** - If defined, this will generate and write an `Info.plist` to the specified path and use it by setting the `INFOPLIST_FILE` build setting for every configuration, unless `INFOPLIST_FILE` is already defined in  **settings** for this configuration. The following properties are generated automatically if appropriate, the rest will have to be provided.
   - `CFBundleIdentifier`
   - `CFBundleInfoDictionaryVersion`
-  - `CFBundleExecutable`
+  - `CFBundleExecutable` **Not generated for targets of type bundle**
   - `CFBundleName`
   - `CFBundleDevelopmentRegion`
   - `CFBundleShortVersionString`

--- a/Sources/XcodeGenKit/FileWriter.swift
+++ b/Sources/XcodeGenKit/FileWriter.swift
@@ -30,7 +30,7 @@ public class FileWriter {
         for target in project.targets {
             // write Info.plist
             if let plist = target.info {
-                let properties = infoPlistGenerator.generateProperties(target: target).merged(plist.properties)
+                let properties = infoPlistGenerator.generateProperties(for: target).merged(plist.properties)
                 try writePlist(properties, path: plist.path)
             }
 

--- a/Sources/XcodeGenKit/InfoPlistGenerator.swift
+++ b/Sources/XcodeGenKit/InfoPlistGenerator.swift
@@ -8,7 +8,7 @@ public class InfoPlistGenerator {
      Default info plist attributes taken from:
      /Applications/Xcode.app/Contents/Developer/Library/Xcode/Templates/Project Templates/Base/Base_DefinitionsInfoPlist.xctemplate/TemplateInfo.plist
      */
-    private func generateDefaultInfoPlist(target: Target) -> [String: Any] {
+    private func generateDefaultInfoPlist(for target: Target) -> [String: Any] {
         var dictionary: [String: Any] = [:]
         dictionary["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
         dictionary["CFBundleInfoDictionaryVersion"] = "6.0"
@@ -26,8 +26,8 @@ public class InfoPlistGenerator {
         return dictionary
     }
 
-    public func generateProperties(target: Target) -> [String: Any] {
-        var targetInfoPlist = generateDefaultInfoPlist(target: target)
+    public func generateProperties(for target: Target) -> [String: Any] {
+        var targetInfoPlist = generateDefaultInfoPlist(for: target)
         switch target.type {
         case .uiTestBundle,
              .unitTestBundle:

--- a/Sources/XcodeGenKit/InfoPlistGenerator.swift
+++ b/Sources/XcodeGenKit/InfoPlistGenerator.swift
@@ -8,20 +8,26 @@ public class InfoPlistGenerator {
      Default info plist attributes taken from:
      /Applications/Xcode.app/Contents/Developer/Library/Xcode/Templates/Project Templates/Base/Base_DefinitionsInfoPlist.xctemplate/TemplateInfo.plist
      */
-    var defaultInfoPlist: [String: Any] = {
+    private func generateDefaultInfoPlist(target: Target) -> [String: Any] {
         var dictionary: [String: Any] = [:]
         dictionary["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
         dictionary["CFBundleInfoDictionaryVersion"] = "6.0"
-        dictionary["CFBundleExecutable"] = "$(EXECUTABLE_NAME)"
+
         dictionary["CFBundleName"] = "$(PRODUCT_NAME)"
         dictionary["CFBundleDevelopmentRegion"] = "$(DEVELOPMENT_LANGUAGE)"
         dictionary["CFBundleShortVersionString"] = "1.0"
         dictionary["CFBundleVersion"] = "1"
+
+        // Bundles should not contain any CFBundleExecutable otherwise they will be rejected when uploading.
+        if target.type != .bundle {
+            dictionary["CFBundleExecutable"] = "$(EXECUTABLE_NAME)"
+        }
+
         return dictionary
-    }()
+    }
 
     public func generateProperties(target: Target) -> [String: Any] {
-        var targetInfoPlist = defaultInfoPlist
+        var targetInfoPlist = generateDefaultInfoPlist(target: target)
         switch target.type {
         case .uiTestBundle,
              .unitTestBundle:

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -971,16 +971,17 @@ class ProjectGeneratorTests: XCTestCase {
                 let infoPlistFile = tempPath + plist.path
                 let data: Data = try infoPlistFile.read()
                 let infoPlist = try PropertyListSerialization.propertyList(from: data, options: [], format: nil) as! [String: Any]
-                var expectedInfoPlist: [String: Any] = [:]
-                expectedInfoPlist["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
-                expectedInfoPlist["CFBundleInfoDictionaryVersion"] = "6.0"
-                expectedInfoPlist["CFBundleExecutable"] = "$(EXECUTABLE_NAME)"
-                expectedInfoPlist["CFBundleName"] = "$(PRODUCT_NAME)"
-                expectedInfoPlist["CFBundleDevelopmentRegion"] = "$(DEVELOPMENT_LANGUAGE)"
-                expectedInfoPlist["CFBundleShortVersionString"] = "1.0"
-                expectedInfoPlist["CFBundleVersion"] = "1"
-                expectedInfoPlist["CFBundlePackageType"] = "APPL"
-                expectedInfoPlist["UISupportedInterfaceOrientations"] = ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationLandscapeLeft"]
+                let expectedInfoPlist: [String: Any] = [
+                    "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+                    "CFBundleInfoDictionaryVersion": "6.0",
+                    "CFBundleName": "$(PRODUCT_NAME)",
+                    "CFBundleExecutable": "$(EXECUTABLE_NAME)",
+                    "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+                    "CFBundleShortVersionString": "1.0",
+                    "CFBundleVersion": "1",
+                    "CFBundlePackageType": "APPL",
+                    "UISupportedInterfaceOrientations": ["UIInterfaceOrientationPortrait", "UIInterfaceOrientationLandscapeLeft"]
+                ]
 
                 try expect(NSDictionary(dictionary: expectedInfoPlist).isEqual(to: infoPlist)).beTrue()
             }
@@ -1020,14 +1021,15 @@ class ProjectGeneratorTests: XCTestCase {
                 let infoPlistFile = tempPath + plist.path
                 let data: Data = try infoPlistFile.read()
                 let infoPlist = try PropertyListSerialization.propertyList(from: data, options: [], format: nil) as! [String: Any]
-                var expectedInfoPlist: [String: Any] = [:]
-                expectedInfoPlist["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
-                expectedInfoPlist["CFBundleInfoDictionaryVersion"] = "6.0"
-                expectedInfoPlist["CFBundleName"] = "$(PRODUCT_NAME)"
-                expectedInfoPlist["CFBundleDevelopmentRegion"] = "$(DEVELOPMENT_LANGUAGE)"
-                expectedInfoPlist["CFBundleShortVersionString"] = "1.0"
-                expectedInfoPlist["CFBundleVersion"] = "1"
-                expectedInfoPlist["CFBundlePackageType"] = "BNDL"
+                let expectedInfoPlist: [String: Any] = [
+                    "CFBundleIdentifier": "$(PRODUCT_BUNDLE_IDENTIFIER)",
+                    "CFBundleInfoDictionaryVersion": "6.0",
+                    "CFBundleName": "$(PRODUCT_NAME)",
+                    "CFBundleDevelopmentRegion": "$(DEVELOPMENT_LANGUAGE)",
+                    "CFBundleShortVersionString": "1.0",
+                    "CFBundleVersion": "1",
+                    "CFBundlePackageType": "BNDL"
+                ]
 
                 try expect(NSDictionary(dictionary: expectedInfoPlist).isEqual(to: infoPlist)).beTrue()
             }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1002,6 +1002,35 @@ class ProjectGeneratorTests: XCTestCase {
                 // generated plist should not be in buildsettings
                 try expect(targetConfig.buildSettings["INFOPLIST_FILE"] as? String) == predefinedPlistPath
             }
+
+            $0.it("generate info.plist doesn't generate CFBundleExecutable for targets with type bundle") {
+                let plist = Plist(path: "Info.plist", attributes: [:])
+                let tempPath = Path.temporary + "info"
+                let project = Project(basePath: tempPath, name: "", targets: [Target(name: "", type: .bundle, platform: .iOS, info: plist)])
+                let pbxProject = try project.generatePbxProj()
+                let writer = FileWriter(project: project)
+                try writer.writePlists()
+
+                guard let targetConfig = pbxProject.nativeTargets.first?.buildConfigurationList?.buildConfigurations.first else {
+                    throw failure("Couldn't find Target config")
+                }
+
+                try expect(targetConfig.buildSettings["INFOPLIST_FILE"] as? String) == plist.path
+
+                let infoPlistFile = tempPath + plist.path
+                let data: Data = try infoPlistFile.read()
+                let infoPlist = try PropertyListSerialization.propertyList(from: data, options: [], format: nil) as! [String: Any]
+                var expectedInfoPlist: [String: Any] = [:]
+                expectedInfoPlist["CFBundleIdentifier"] = "$(PRODUCT_BUNDLE_IDENTIFIER)"
+                expectedInfoPlist["CFBundleInfoDictionaryVersion"] = "6.0"
+                expectedInfoPlist["CFBundleName"] = "$(PRODUCT_NAME)"
+                expectedInfoPlist["CFBundleDevelopmentRegion"] = "$(DEVELOPMENT_LANGUAGE)"
+                expectedInfoPlist["CFBundleShortVersionString"] = "1.0"
+                expectedInfoPlist["CFBundleVersion"] = "1"
+                expectedInfoPlist["CFBundlePackageType"] = "BNDL"
+
+                try expect(NSDictionary(dictionary: expectedInfoPlist).isEqual(to: infoPlist)).beTrue()
+            }
         }
     }
 }


### PR DESCRIPTION
When declaring a target like this

```
  BundleTarget:
    platform: iOS
    type: bundle
    info:
      path: some/path/Info.plist
    sources: [some/path/sources]
```

The generated Info.plist file contains a key `CFBundleExecutable` by default. This key indicates that the bundle has a executable. When uploading an application with such a bundle that contains the Info.plist AppStore connect will decline the binary since a bundle by default doesn't contain any executable but rather only resources. Therefore, I suggest we do not generate the `CFBundleExecutable` by default for targets of type `bundle`.