### PR TITLE
Add Base to knownRegions even if one doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Fixed
+- Add Base to knownRegions even if one doesn't exist [#694](https://github.com/yonaskolb/XcodeGen/pull/694) @bryansum
+
 ## 2.10.0
 
 #### Added

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -224,8 +224,8 @@ public class PBXProjGenerator {
         let projectAttributes: [String: Any] = ["LastUpgradeCheck": project.xcodeVersion]
             .merged(project.attributes)
 
-        let knownRegions = sourceGenerator.knownRegions.sorted()
-        pbxProject.knownRegions = knownRegions.isEmpty ? ["en"] : knownRegions
+        let knownRegions = sourceGenerator.knownRegions
+        pbxProject.knownRegions = (knownRegions.isEmpty ? ["en"] : knownRegions).union(["Base"]).sorted()
         pbxProject.packages = packageReferences.sorted { $0.key < $1.key }.map { $1 }
 
         let allTargets: [PBXTarget] = targetObjects.valueArray + targetAggregateObjects.valueArray

--- a/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				Base,
 				en,
 			);
 			mainGroup = 293D0FF827366B513839236A;

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				Base,
 				en,
 			);
 			mainGroup = 218F6C96DF9E182F526258CF;

--- a/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				Base,
 				en,
 			);
 			mainGroup = 2D08B11F4EE060D112B7BCA1;


### PR DESCRIPTION
Addendum to https://github.com/yonaskolb/XcodeGen/pull/685 in the case there's   
no `Base.lproj` folder but one for the development language -- in this case      
XcodeGen generates a `knownRegions` result of only `en`, which leads to warnings 
in Xcode 11. Adding `Base` by default in this case silences Xcode.