### PR TITLE
Add missing onlyGenerateCoverageForSpecifiedTargets

### DIFF
--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -204,6 +204,7 @@ public class SchemeGenerator {
             shouldUseLaunchSchemeArgsEnv: scheme.test?.shouldUseLaunchSchemeArgsEnv ?? true,
             codeCoverageEnabled: scheme.test?.gatherCoverageData ?? Scheme.Test.gatherCoverageDataDefault,
             codeCoverageTargets: coverageBuildableTargets,
+            onlyGenerateCoverageForSpecifiedTargets: !coverageBuildableTargets.isEmpty,
             disableMainThreadChecker: scheme.test?.disableMainThreadChecker ?? Scheme.Test.disableMainThreadCheckerDefault,
             commandlineArguments: testCommandLineArgs,
             environmentVariables: testVariables,


### PR DESCRIPTION
Add missing `onlyGenerateCoverageForSpecifiedTargets` which enables specific target coverage

Fix https://github.com/yonaskolb/XcodeGen/issues/699