### PR TITLE
Fixing link directive on dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Fixed
 - Add Base to knownRegions even if one doesn't exist [#694](https://github.com/yonaskolb/XcodeGen/pull/694) @bryansum
 - Fixed missing `onlyGenerateCoverageForSpecifiedTargets` issue [#700](https://github.com/yonaskolb/XcodeGen/pull/700) @kateinoigakukun
+- Fixed regression on dependencies `link` flag [#703](https://github.com/yonaskolb/XcodeGen/pull/703) @rcari
 
 ## 2.10.0
 
@@ -46,9 +47,9 @@
 #### Added
 - Added support for Swift Package dependencies [#624](https://github.com/yonaskolb/XcodeGen/pull/624) @yonaskolb
 - Added `includes` to `sources` for a Target. This follows the same glob-style as `excludes` but functions as a way to only include files that match a specified pattern. Useful if you only want a certain file type, for example specifying `**/*.swift`. [#637](https://github.com/yonaskolb/XcodeGen/pull/637) @bclymer
-- Support `dylib` SDK. [#650](https://github.com/yonaskolb/XcodeGen/pull/650) @kateinoigakukun 
-- Added `language` and `region` options for `run` and `test` scheme [#654](https://github.com/yonaskolb/XcodeGen/pull/654) @kateinoigakukun 
-- Added `debugEnabled` option for `run` and `test` scheme [#657](https://github.com/yonaskolb/XcodeGen/pull/657) @kateinoigakukun 
+- Support `dylib` SDK. [#650](https://github.com/yonaskolb/XcodeGen/pull/650) @kateinoigakukun
+- Added `language` and `region` options for `run` and `test` scheme [#654](https://github.com/yonaskolb/XcodeGen/pull/654) @kateinoigakukun
+- Added `debugEnabled` option for `run` and `test` scheme [#657](https://github.com/yonaskolb/XcodeGen/pull/657) @kateinoigakukun
 
 #### Fixed
 - Expand template variable in Array of Any [#651](https://github.com/yonaskolb/XcodeGen/pull/651) @kateinoigakukun

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -478,8 +478,8 @@ public class PBXProjGenerator {
 
                 let dependecyLinkage = dependencyTarget.defaultLinkage
                 let link = dependency.link ??
-                    (dependecyLinkage == .dynamic && target.type != .staticLibrary) ||
-                    (dependecyLinkage == .static && target.type.isExecutable)
+                    ((dependecyLinkage == .dynamic && target.type != .staticLibrary) ||
+                    (dependecyLinkage == .static && target.type.isExecutable))
 
                 if link {
                     let dependencyFile = targetFileReferences[dependencyTarget.name]!


### PR DESCRIPTION
PR #624 introduced a bug with operator priorities discarding false link settings
for dependencies when the target is an executable and the dependency a static
library.
Important parentheses were removed in a refactoring, causing the issue as the `??` operator has a higher priority than the `||` operator.