### PR TITLE
Improving variable expansion runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Next Version
 
+#### Added
+- Added `--no-env` option to disable environment variables expansion [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari
+
+#### Fixed
+- Improved variable expansion runtime [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari
+
+#### Changed
+- Deprecated `$old_form` variables in favor of `${new_form}` variables [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari
+
 ## 2.10.1
 
 #### Fixed

--- a/Sources/ProjectSpec/SpecFile.swift
+++ b/Sources/ProjectSpec/SpecFile.swift
@@ -147,12 +147,14 @@ extension Dictionary where Key == String, Value: Any {
     func expand(variables: [String:String]) -> JSONDictionary {
         var expanded: JSONDictionary = self
 
-        for (key, value) in self {
-            let newKey = expand(variables: variables, in: key)
-            if newKey != key {
-                expanded.removeValue(forKey: key)
+        if !variables.isEmpty {
+            for (key, value) in self {
+                let newKey = expand(variables: variables, in: key)
+                if newKey != key {
+                    expanded.removeValue(forKey: key)
+                }
+                expanded[newKey] = expand(variables: variables, in: value)
             }
-            expanded[newKey] = expand(variables: variables, in: value)
         }
 
         return expanded

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -45,13 +45,8 @@ public class SpecLoader {
 private extension Dictionary where Key == String, Value: Any {
 
     func validateWarnings() throws {
-        var errors: [SpecValidationError.ValidationError] = []
-        if hasValueContaining("$target_name") {
-            errors.append(.deprecatedUsageOfPlaceholder(placeholderName: "target_name"))
-        }
-        if hasValueContaining("$platform") {
-            errors.append(.deprecatedUsageOfPlaceholder(placeholderName: "platform"))
-        }
+        let errors: [SpecValidationError.ValidationError] = []
+
         if !errors.isEmpty {
             throw SpecValidationError(errors: errors)
         }

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -30,7 +30,6 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case missingDefaultConfig(configName: String)
         case invalidPerConfigSettings
         case invalidProjectReference(scheme: String, reference: String)
-        case deprecatedUsageOfPlaceholder(placeholderName: String)
 
         public var description: String {
             switch self {
@@ -76,8 +75,6 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Settings that are for a specific config must go in \"configs\". \"base\" can be used for common settings"
             case let .invalidProjectReference(scheme, project):
                 return "Scheme \(scheme.quoted) has invalid project reference \(project.quoted)"
-            case let .deprecatedUsageOfPlaceholder(placeholderName: placeholderName):
-                return "Usage of $\(placeholderName) is deprecated and will stop working in an upcoming version. Use ${\(placeholderName)} instead."
             }
         }
     }

--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -148,8 +148,7 @@ extension Target {
                 for platform in platforms {
                     var platformTarget = target
 
-                    platformTarget = platformTarget.replaceString("$platform", with: platform) // Will be removed in upcoming version
-                    platformTarget = platformTarget.replaceString("${platform}", with: platform)
+                    platformTarget = platformTarget.expand(variables: ["platform": platform])
 
                     platformTarget["platform"] = platform
                     let platformSuffix = platformTarget["platformSuffix"] as? String ?? "_\(platform)"

--- a/Sources/ProjectSpec/Template.swift
+++ b/Sources/ProjectSpec/Template.swift
@@ -61,12 +61,10 @@ private func resolveTemplates(jsonDictionary: JSONDictionary, templateStructure:
                 }
             }
             reference = reference.merged(onto: mergedDictionary)
-            reference = reference.replaceString("$\(templateStructure.nameToReplace)", with: referenceName) // Will be removed in upcoming version
-            reference = reference.replaceString("${\(templateStructure.nameToReplace)}", with: referenceName)
+            reference = reference.expand(variables: [templateStructure.nameToReplace: referenceName])
+
             if let templateAttributes = reference["templateAttributes"] as? [String: String] {
-                for (templateAttribute, value) in templateAttributes {
-                    reference = reference.replaceString("${\(templateAttribute)}", with: value)
-                }
+                reference = reference.expand(variables: templateAttributes)
             }
         }
         baseDictionary[referenceName] = reference

--- a/Sources/ProjectSpec/Yaml.swift
+++ b/Sources/ProjectSpec/Yaml.swift
@@ -16,3 +16,8 @@ public func loadYamlDictionary(path: Path) throws -> [String: Any] {
     }
     return yaml as? [String: Any] ?? [:]
 }
+
+public func dumpYamlDictionary(_ dictionary: [String: Any], path: Path) throws {
+    let string: String = try Yams.dump(object: dictionary)
+    try path.write(string)
+}

--- a/Sources/XcodeGenCLI/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/GenerateCommand.swift
@@ -17,6 +17,13 @@ class GenerateCommand: Command {
         defaultValue: false
     )
 
+    let disableEnvExpansion = Flag(
+        "-n",
+        "--no-env",
+        description: "Disable environment variables expansions",
+        defaultValue: false
+    )
+
     let useCache = Flag(
         "-c",
         "--use-cache",
@@ -56,9 +63,11 @@ class GenerateCommand: Command {
         let specLoader = SpecLoader(version: version)
         let project: Project
 
+        let variables: [String: String] = disableEnvExpansion.value ? [:] : ProcessInfo.processInfo.environment
+
         // load project spec
         do {
-            project = try specLoader.loadProject(path: projectSpecPath, variables: ProcessInfo.processInfo.environment)
+            project = try specLoader.loadProject(path: projectSpecPath, variables: variables)
             info("Loaded project:\n  \(project.debugDescription.replacingOccurrences(of: "\n", with: "\n  "))")
         } catch {
             throw GenerationError.projectSpecParsingError(error)

--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -9,6 +9,17 @@ class GeneratedPerformanceTests: XCTestCase {
 
     let basePath = Path.temporary + "XcodeGenPeformanceTests"
 
+    func testLoading() throws {
+        let project = try Project.testProject(basePath: basePath)
+        let specPath = basePath + "project.yaml"
+        try dumpYamlDictionary(project.toJSONDictionary(), path: specPath)
+
+        measure {
+            let spec = try! SpecFile(path: specPath)
+            _ = spec.resolvedDictionary(variables: ProcessInfo.processInfo.environment)
+        }
+    }
+
     func testGeneration() throws {
         let project = try Project.testProject(basePath: basePath)
         measure {

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -256,7 +256,7 @@ class SpecLoadingTests: XCTestCase {
                     "templates": [
                         "Framework": [
                             "type": "framework",
-                            "sources": ["$target_name/$platform/Sources"],
+                            "sources": ["${target_name}/${platform}/Sources"],
                         ],
                     ],
                     "targets": [
@@ -274,10 +274,6 @@ class SpecLoadingTests: XCTestCase {
                 } catch {
                     throw failure("\(error)")
                 }
-                try expectError(SpecValidationError(errors: [
-                    .deprecatedUsageOfPlaceholder(placeholderName: "target_name"),
-                    .deprecatedUsageOfPlaceholder(placeholderName: "platform"),
-                ])) { try specLoader.validateProjectDictionaryWarnings() }
             }
 
             $0.it("successfully validates warnings for new placeholder usage") {
@@ -429,7 +425,7 @@ class SpecLoadingTests: XCTestCase {
                     "deploymentTarget": ["iOS": 9.0, "tvOS": "10.0"],
                     "type": "framework",
                     "sources": ["Framework", "Framework ${platform}"],
-                    "settings": ["SETTING": "value_$platform"],
+                    "settings": ["SETTING": "value_${platform}"],
                 ]
 
                 let project = try getProjectSpec(["targets": ["Framework": targetDictionary]])
@@ -473,7 +469,7 @@ class SpecLoadingTests: XCTestCase {
                             "platform": "tvOS",
                             "deploymentTarget": "1.1.0",
                             "configFiles": [
-                                "debug": "Configs/$target_name/debug.xcconfig",
+                                "debug": "Configs/${target_name}/debug.xcconfig",
                                 "release": "Configs/${target_name}/release.xcconfig",
                             ],
                             "sources": ["${source}"],
@@ -513,7 +509,7 @@ class SpecLoadingTests: XCTestCase {
                         "temp2": [
                             "platform": "tvOS",
                             "deploymentTarget": "1.1.0",
-                            "configFiles": ["debug": "Configs/$target_name/debug.xcconfig"],
+                            "configFiles": ["debug": "Configs/${target_name}/debug.xcconfig"],
                             "templates": ["temp", "temp1"],
                             "sources": ["templateSource"],
                         ],
@@ -618,7 +614,7 @@ class SpecLoadingTests: XCTestCase {
                         "temp2": [
                             "platform": "tvOS",
                             "deploymentTarget": "1.1.0",
-                            "configFiles": ["debug": "Configs/$target_name/debug.xcconfig"],
+                            "configFiles": ["debug": "Configs/${target_name}/debug.xcconfig"],
                             "templates": ["temp", "temp1"],
                             "sources": ["templateSource"],
                         ],
@@ -662,7 +658,7 @@ class SpecLoadingTests: XCTestCase {
                         "Framework": [
                             "type": "framework",
                             "platform": ["iOS", "tvOS"],
-                            "templates": ["$platform"],
+                            "templates": ["${platform}"],
                         ],
                     ],
                     "targetTemplates": [
@@ -880,7 +876,7 @@ class SpecLoadingTests: XCTestCase {
                             "platform": "tvOS",
                             "deploymentTarget": "1.1.0",
                             "configFiles": [
-                                "debug": "Configs/$target_name/debug.xcconfig",
+                                "debug": "Configs/${target_name}/debug.xcconfig",
                                 "release": "Configs/${target_name}/release.xcconfig",
                             ],
                             "sources": ["${source}"],


### PR DESCRIPTION
The current implementation of variable expansion is O(n x m) with n being the
number of strings in the project spec and m being the number of project variables.

This implementation is now O(n).

Also, this effectively deprecates the support for $legacy_variables in favor of the
${new_variables} making this whole patch possible.

A large project we use saw generation time divided by two after applying this patch.

@yonaskolb 