### PR TITLE
Add dump command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Added
 - Add Carthage static framework dependencies support. [#688](https://github.com/yonaskolb/XcodeGen/pull/688) @giginet
+- Added `xcodegen dump` command [#710](https://github.com/yonaskolb/XcodeGen/pull/710) @yonaskolb
 - Added `--no-env` option to disable environment variables expansion [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Options:
 - **--use-cache**: Used to prevent unnecessarily generating the project. If this is set, then a cache file will be written to when a project is generated. If `xcodegen` is later run but the spec and all the files it contains are the same, the project won't be generated.
 - **--cache-path**: A custom path to use for your cache file. This defaults to `~/.xcodegen/cache/{PROJECT_SPEC_PATH_HASH}`
 
-Use `xcodegen help` to see more detailed usage information.
+There are other commands as well. Use `xcodegen help` to see more detailed usage information.
 
 ## Editing
 ```shell

--- a/Sources/ProjectSpec/SpecFile.swift
+++ b/Sources/ProjectSpec/SpecFile.swift
@@ -144,7 +144,7 @@ extension Dictionary where Key == String, Value: Any {
         return merged
     }
 
-    func expand(variables: [String:String]) -> JSONDictionary {
+    func expand(variables: [String: String]) -> JSONDictionary {
         var expanded: JSONDictionary = self
 
         if !variables.isEmpty {
@@ -189,8 +189,7 @@ extension Dictionary where Key == String, Value: Any {
                 index = result.endIndex
             } else if substring[index] == "$"
                 && substring[substring.index(index, offsetBy: 1)] == "{"
-                && substring[substring.index(index, offsetBy: 2)] != "}"
-            {
+                && substring[substring.index(index, offsetBy: 2)] != "}" {
                 // This is the start of a variable expansion...
                 let variableStart = index
                 if let variableEnd = substring.firstIndex(of: "}") {

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -7,7 +7,7 @@ import Yams
 public class SpecLoader {
 
     var project: Project!
-    private var projectDictionary: [String: Any]?
+    public private(set) var projectDictionary: [String: Any]?
     let version: Version
 
     public init(version: Version) {

--- a/Sources/XcodeGenCLI/Commands/DumpCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/DumpCommand.swift
@@ -10,11 +10,13 @@ class DumpCommand: ProjectCommand {
     override var shortDescription: String { "Dumps the project spec to stdout" }
 
     private let dumpType = Key<DumpType>("--type", "-t", description: """
-    The type of dump to output. Either "json", "yaml", "summary", "swift-dump", "parsed-json", or "parsed-yaml". Defaults to summary. The "parsed" types parse the project into swift and then back again and can be used for testing.
+    The type of dump to output. Either "json", "yaml", "summary", "swift-dump", "parsed-json", or "parsed-yaml". Defaults to yaml. The "parsed" types parse the project into swift and then back again and can be used for testing.
     """)
 
+    private let file = Key<Path>("--file", "-f", description: "The path of a file to write to. If not supplied will output to stdout")
+
     override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
-        let type = dumpType.value ?? .summary
+        let type = dumpType.value ?? .yaml
 
         let output: String
         switch type {
@@ -36,7 +38,12 @@ class DumpCommand: ProjectCommand {
             output = project.debugDescription
         }
 
-        stdout.print(output)
+        if let file = file.value {
+            try file.parent().mkpath()
+            try file.write(output)
+        } else {
+            stdout.print(output)
+        }
     }
 }
 

--- a/Sources/XcodeGenCLI/Commands/DumpCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/DumpCommand.swift
@@ -1,0 +1,50 @@
+import Foundation
+import SwiftCLI
+import PathKit
+import ProjectSpec
+import Yams
+
+class DumpCommand: ProjectCommand {
+
+    override var name: String { "dump" }
+    override var shortDescription: String { "Dumps the project spec to stdout" }
+
+    private let dumpType = Key<DumpType>("--type", "-t", description: """
+    The type of dump to output. Either "json", "yaml", "summary", "swift-dump", "parsed-json", or "parsed-yaml". Defaults to summary. The "parsed" types parse the project into swift and then back again and can be used for testing.
+    """)
+
+    override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
+        let type = dumpType.value ?? .summary
+
+        let output: String
+        switch type {
+        case .swiftDump:
+            var string = ""
+            dump(project, to: &string)
+            output = string
+        case .json:
+            let data = try JSONSerialization.data(withJSONObject: specLoader.projectDictionary!, options: .prettyPrinted)
+            output = String(data: data, encoding: .utf8)!
+        case .yaml:
+            output = try Yams.dump(object: specLoader.projectDictionary!)
+        case .parsedJSON:
+            let data = try JSONSerialization.data(withJSONObject: project.toJSONDictionary(), options: .prettyPrinted)
+            output = String(data: data, encoding: .utf8)!
+        case .parsedYaml:
+            output = try Yams.dump(object: project.toJSONDictionary())
+        case .summary:
+            output = project.debugDescription
+        }
+
+        stdout.print(output)
+    }
+}
+
+fileprivate enum DumpType: String, ConvertibleFromString {
+    case swiftDump = "swift-dump"
+    case json
+    case yaml
+    case parsedJSON = "parsed-json"
+    case parsedYaml = "parsed-yaml"
+    case summary
+}

--- a/Sources/XcodeGenCLI/Commands/DumpCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/DumpCommand.swift
@@ -9,11 +9,19 @@ class DumpCommand: ProjectCommand {
     override var name: String { "dump" }
     override var shortDescription: String { "Dumps the project spec to stdout" }
 
-    private let dumpType = Key<DumpType>("--type", "-t", description: """
-    The type of dump to output. Either "json", "yaml", "summary", "swift-dump", "parsed-json", or "parsed-yaml". Defaults to yaml. The "parsed" types parse the project into swift and then back again and can be used for testing.
-    """)
+    private let dumpType = Key<DumpType>(
+        "--type",
+        "-t",
+        description: """
+        The type of dump to output. Either "json", "yaml", "summary", "swift-dump", "parsed-json", or "parsed-yaml". Defaults to yaml. The "parsed" types parse the project into swift and then back again and can be used for testing.
+        """
+    )
 
-    private let file = Key<Path>("--file", "-f", description: "The path of a file to write to. If not supplied will output to stdout")
+    private let file = Key<Path>(
+        "--file",
+        "-f",
+        description: "The path of a file to write to. If not supplied will output to stdout"
+    )
 
     override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
         let type = dumpType.value ?? .yaml
@@ -47,7 +55,7 @@ class DumpCommand: ProjectCommand {
     }
 }
 
-fileprivate enum DumpType: String, ConvertibleFromString {
+private enum DumpType: String, ConvertibleFromString {
     case swiftDump = "swift-dump"
     case json
     case yaml

--- a/Sources/XcodeGenCLI/Commands/DumpCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/DumpCommand.swift
@@ -6,14 +6,11 @@ import Yams
 
 class DumpCommand: ProjectCommand {
 
-    override var name: String { "dump" }
-    override var shortDescription: String { "Dumps the project spec to stdout" }
-
     private let dumpType = Key<DumpType>(
         "--type",
         "-t",
         description: """
-        The type of dump to output. Either "json", "yaml", "summary", "swift-dump", "parsed-json", or "parsed-yaml". Defaults to yaml. The "parsed" types parse the project into swift and then back again and can be used for testing.
+        The type of dump to output. Either \(DumpType.allCases.map { "\"\($0.rawValue)\"" }.joined(separator: ", ")). Defaults to \(DumpType.defaultValue.rawValue). The "parsed" types parse the project into swift and then back again.
         """
     )
 
@@ -23,8 +20,15 @@ class DumpCommand: ProjectCommand {
         description: "The path of a file to write to. If not supplied will output to stdout"
     )
 
+    init(version: Version) {
+        super.init(version: version,
+                   name: "dump",
+                   shortDescription: "Dumps the resolved project spec to stdout or a file"
+        )
+    }
+
     override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
-        let type = dumpType.value ?? .yaml
+        let type = dumpType.value ?? .defaultValue
 
         let output: String
         switch type {
@@ -55,11 +59,13 @@ class DumpCommand: ProjectCommand {
     }
 }
 
-private enum DumpType: String, ConvertibleFromString {
+private enum DumpType: String, ConvertibleFromString, CaseIterable {
     case swiftDump = "swift-dump"
     case json
     case yaml
     case parsedJSON = "parsed-json"
     case parsedYaml = "parsed-yaml"
     case summary
+
+    static var defaultValue: DumpType { .yaml }
 }

--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -5,22 +5,15 @@ import SwiftCLI
 import XcodeGenKit
 import XcodeProj
 
-class GenerateCommand: Command {
+class GenerateCommand: ProjectCommand {
 
-    let name: String = "generate"
-    let shortDescription: String = "Generate an Xcode project from a spec"
+    override var name: String { "generate" }
+    override var shortDescription: String { "Generate an Xcode project from a spec" }
 
     let quiet = Flag(
         "-q",
         "--quiet",
         description: "Suppress all informational and success output",
-        defaultValue: false
-    )
-
-    let disableEnvExpansion = Flag(
-        "-n",
-        "--no-env",
-        description: "Disable environment variables expansions",
         defaultValue: false
     )
 
@@ -36,41 +29,11 @@ class GenerateCommand: Command {
         description: "Where the cache file will be loaded from and save to. Defaults to ~/.xcodegen/cache/{SPEC_PATH_HASH}"
     )
 
-    let spec = Key<Path>(
-        "-s",
-        "--spec",
-        description: "The path to the project spec file. Defaults to project.yml"
-    )
-
     let projectDirectory = Key<Path>("-p", "--project", description: "The path to the directory where the project should be generated. Defaults to the directory the spec is in. The filename is defined in the project spec")
 
-    let version: Version
-
-    init(version: Version) {
-        self.version = version
-    }
-
-    func execute() throws {
-
-        let projectSpecPath = (spec.value ?? "project.yml").absolute()
+    override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
 
         let projectDirectory = self.projectDirectory.value?.absolute() ?? projectSpecPath.parent()
-
-        if !projectSpecPath.exists {
-            throw GenerationError.missingProjectSpec(projectSpecPath)
-        }
-
-        let specLoader = SpecLoader(version: version)
-        let project: Project
-
-        let variables: [String: String] = disableEnvExpansion.value ? [:] : ProcessInfo.processInfo.environment
-
-        // load project spec
-        do {
-            project = try specLoader.loadProject(path: projectSpecPath, variables: variables)
-        } catch {
-            throw GenerationError.projectSpecParsingError(error)
-        }
 
         // validate project dictionary
         do {

--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -29,7 +29,11 @@ class GenerateCommand: ProjectCommand {
         description: "Where the cache file will be loaded from and save to. Defaults to ~/.xcodegen/cache/{SPEC_PATH_HASH}"
     )
 
-    let projectDirectory = Key<Path>("-p", "--project", description: "The path to the directory where the project should be generated. Defaults to the directory the spec is in. The filename is defined in the project spec")
+    let projectDirectory = Key<Path>(
+        "-p",
+        "--project",
+        description: "The path to the directory where the project should be generated. Defaults to the directory the spec is in. The filename is defined in the project spec"
+    )
 
     override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
 

--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -7,9 +7,6 @@ import XcodeProj
 
 class GenerateCommand: ProjectCommand {
 
-    override var name: String { "generate" }
-    override var shortDescription: String { "Generate an Xcode project from a spec" }
-
     let quiet = Flag(
         "-q",
         "--quiet",
@@ -34,6 +31,13 @@ class GenerateCommand: ProjectCommand {
         "--project",
         description: "The path to the directory where the project should be generated. Defaults to the directory the spec is in. The filename is defined in the project spec"
     )
+
+    init(version: Version) {
+        super.init(version: version,
+                   name: "generate",
+                   shortDescription: "Generate an Xcode project from a spec"
+        )
+    }
 
     override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
 

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -50,7 +50,5 @@ class ProjectCommand: Command {
         try execute(specLoader: specLoader, projectSpecPath: projectSpecPath, project: project)
     }
 
-    func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
-
-    }
+    func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {}
 }

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -1,0 +1,56 @@
+import Foundation
+import SwiftCLI
+import ProjectSpec
+import XcodeGenKit
+import PathKit
+import Core
+
+class ProjectCommand: Command {
+
+    let version: Version
+    var name: String { "ProjectCommand" }
+    var shortDescription: String { "" }
+
+    let spec = Key<Path>(
+        "-s",
+        "--spec",
+        description: "The path to the project spec file. Defaults to project.yml"
+    )
+
+    let disableEnvExpansion = Flag(
+        "-n",
+        "--no-env",
+        description: "Disable environment variable expansions",
+        defaultValue: false
+    )
+
+    init(version: Version) {
+        self.version = version
+    }
+
+    func execute() throws {
+
+        let projectSpecPath = (spec.value ?? "project.yml").absolute()
+
+        if !projectSpecPath.exists {
+            throw GenerationError.missingProjectSpec(projectSpecPath)
+        }
+
+        let specLoader = SpecLoader(version: version)
+        let project: Project
+
+        let variables: [String: String] = disableEnvExpansion.value ? [:] : ProcessInfo.processInfo.environment
+
+        do {
+            project = try specLoader.loadProject(path: projectSpecPath, variables: variables)
+        } catch {
+            throw GenerationError.projectSpecParsingError(error)
+        }
+
+        try execute(specLoader: specLoader, projectSpecPath: projectSpecPath, project: project)
+    }
+
+    func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
+
+    }
+}

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -8,8 +8,8 @@ import Core
 class ProjectCommand: Command {
 
     let version: Version
-    var name: String { "ProjectCommand" }
-    var shortDescription: String { "" }
+    let name: String
+    let shortDescription: String
 
     let spec = Key<Path>(
         "-s",
@@ -24,8 +24,10 @@ class ProjectCommand: Command {
         defaultValue: false
     )
 
-    init(version: Version) {
+    init(version: Version, name: String, shortDescription: String) {
         self.version = version
+        self.name = name
+        self.shortDescription = shortDescription
     }
 
     func execute() throws {

--- a/Sources/XcodeGenCLI/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/GenerateCommand.swift
@@ -68,7 +68,6 @@ class GenerateCommand: Command {
         // load project spec
         do {
             project = try specLoader.loadProject(path: projectSpecPath, variables: variables)
-            info("Loaded project:\n  \(project.debugDescription.replacingOccurrences(of: "\n", with: "\n  "))")
         } catch {
             throw GenerationError.projectSpecParsingError(error)
         }

--- a/Sources/XcodeGenCLI/XcodeGenCLI.swift
+++ b/Sources/XcodeGenCLI/XcodeGenCLI.swift
@@ -12,7 +12,10 @@ public class XcodeGenCLI {
             name: "xcodegen",
             version: version.string,
             description: "Generates Xcode projects",
-            commands: [generateCommand]
+            commands: [
+                generateCommand,
+                DumpCommand(version: version)
+            ]
         )
         cli.parser.routeBehavior = .searchWithFallback(generateCommand)
     }

--- a/Sources/XcodeGenCLI/XcodeGenCLI.swift
+++ b/Sources/XcodeGenCLI/XcodeGenCLI.swift
@@ -14,7 +14,7 @@ public class XcodeGenCLI {
             description: "Generates Xcode projects",
             commands: [
                 generateCommand,
-                DumpCommand(version: version)
+                DumpCommand(version: version),
             ]
         )
         cli.parser.routeBehavior = .searchWithFallback(generateCommand)

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -479,7 +479,7 @@ public class PBXProjGenerator {
                 let dependecyLinkage = dependencyTarget.defaultLinkage
                 let link = dependency.link ??
                     ((dependecyLinkage == .dynamic && target.type != .staticLibrary) ||
-                    (dependecyLinkage == .static && target.type.isExecutable))
+                        (dependecyLinkage == .static && target.type.isExecutable))
 
                 if link {
                     let dependencyFile = targetFileReferences[dependencyTarget.name]!


### PR DESCRIPTION
Added a new dump command
```
xcodegen dump
```

This can be used to output the spec in the following formats with `--type`:
- `yaml`
- `json`
- `parsed-yaml` (parsed into swift and then back to yaml)
- `parsed-json` (parsed into swift and then back to json)
- `summary` (the old output of generate, which has been removed)
- `swift-dump` (parsed into swift and then a `dump()` on that

This is useful for:
- migrating to different formats
- integrating with other tooling
- checking the way `include` and variable expansion is evaluated
- combining specs from multiple `include`
- testing 2 way parsing

There are opportunities to output graphs of dependencies as well but that will go into a seperate `xcodegen graph` command