### PR TITLE
Support optional include

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -64,12 +64,14 @@ An include can be provided via a string (the path) or an object of the form:
 
 - [x] **path**: **String** - The path to the included file.
 - [ ] **relativePaths**: **Bool** - Dictates whether the included spec specifies paths relative to itself (the default) or the root spec file.
+- [ ] **optional**: **Bool** - Dictates whether ignoring failure loading (e.g. the path is not exist). Defaults to false.
 
 ```yaml
 include:
   - includedFile.yml
   - path: path/to/includedFile.yml
     relativePaths: false
+    optional: true
 ```
 
 By default specs are merged additively. That is for every value:

--- a/Tests/Fixtures/optional_include/non_optional_include.yml
+++ b/Tests/Fixtures/optional_include/non_optional_include.yml
@@ -1,0 +1,10 @@
+include:
+  - path: not_exist.yml
+    optional: false
+name: NonOptionalInclude
+targets:
+  IncludedTarget:
+    type: application
+    platform: iOS
+    sources:
+      - template

--- a/Tests/Fixtures/optional_include/optional_include.yml
+++ b/Tests/Fixtures/optional_include/optional_include.yml
@@ -1,0 +1,10 @@
+include:
+  - path: not_exist.yml
+    optional: true
+name: OptionalInclude
+targets:
+  IncludedTarget:
+    type: application
+    platform: iOS
+    sources:
+      - template

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -41,6 +41,25 @@ class SpecLoadingTests: XCTestCase {
                     Target(name: "NewTarget", type: .application, platform: .iOS, sources: ["template", "target"]),
                 ]
             }
+            
+            $0.context("with optional include for non exist subspecs") {
+                $0.it("ignore subspecs") {
+                    let path = fixturePath + "optional_include/optional_include.yml"
+                    let project = try XCTUnwrap(loadSpec(path: path))
+                    
+                    try expect(project.name) == "OptionalInclude"
+                    try expect(project.targets) == [
+                        Target(name: "IncludedTarget", type: .application, platform: .iOS, sources: ["template"]),
+                    ]
+                }
+            }
+            
+            $0.context("with non optional include for non exist subspecs") {
+                $0.it("failed to load specs") {
+                    let path = fixturePath + "optional_include/non_optional_include.yml"
+                    XCTAssertThrowsError(try loadSpec(path: path), "failed to load specs")
+                }
+            }
 
             $0.it("expands directories") {
                 let path = fixturePath + "paths_test.yml"

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -57,7 +57,10 @@ class SpecLoadingTests: XCTestCase {
             $0.context("with non optional include for non exist subspecs") {
                 $0.it("failed to load specs") {
                     let path = fixturePath + "optional_include/non_optional_include.yml"
-                    XCTAssertThrowsError(try loadSpec(path: path), "failed to load specs")
+                    XCTAssertThrowsError(try loadSpec(path: path), "failed to load specs") { error in
+                        let failure = error as! FailureType
+                        XCTAssertTrue(failure.reason.contains("No such file or directory"))
+                    }
                 }
             }
 


### PR DESCRIPTION
# Motivation

I want to add targets dynamically. including subspecs help me in the situation.
The included spec is automatically generated and if not exists ignore adding targets.

# Description

I added `optional` option to `Include`.
This value indicates whether ignoring failure loading (e.g. the path does not exist).

```yaml
include:
  - path: not_exist.yml
    optional: true
name: OptionalInclude
targets:
  IncludedTarget:
    type: application
    platform: iOS
    sources:
      - template
```
