### PR TITLE
Plist.path as Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Deprecated `$old_form` variables in favor of `${new_form}` variables [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari
 - Updated XcodeProj to 7.4.0 [#709](https://github.com/yonaskolb/XcodeGen/pull/709) [#715](https://github.com/yonaskolb/XcodeGen/pull/715) @yonaskolb
 - Updated to Swift 5.1 [#714](https://github.com/yonaskolb/XcodeGen/pull/714) @yonaskolb
-- Plist.path is Path, not String [#719](https://github.com/yonaskolb/XcodeGen/pull/719) @RomanPodymov
+- Changed `Plist.path` type from `String` to `Path` [#719](https://github.com/yonaskolb/XcodeGen/pull/719) @RomanPodymov
 
 ## 2.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Deprecated `$old_form` variables in favor of `${new_form}` variables [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari
 - Updated XcodeProj to 7.4.0 [#709](https://github.com/yonaskolb/XcodeGen/pull/709) [#715](https://github.com/yonaskolb/XcodeGen/pull/715) @yonaskolb
 - Updated to Swift 5.1 [#714](https://github.com/yonaskolb/XcodeGen/pull/714) @yonaskolb
+- Plist.path is Path, not String [#719](https://github.com/yonaskolb/XcodeGen/pull/719) @RomanPodymov
 
 ## 2.10.1
 

--- a/Sources/ProjectSpec/Plist.swift
+++ b/Sources/ProjectSpec/Plist.swift
@@ -1,12 +1,13 @@
 import Foundation
 import JSONUtilities
+import PathKit
 
 public struct Plist: Equatable {
 
-    public let path: String
+    public let path: Path
     public let properties: [String: Any]
 
-    public init(path: String, attributes: [String: Any] = [:]) {
+    public init(path: Path, attributes: [String: Any] = [:]) {
         self.path = path
         properties = attributes
     }
@@ -20,7 +21,8 @@ public struct Plist: Equatable {
 extension Plist: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
-        path = try jsonDictionary.json(atKeyPath: "path")
+        let pathString: String = try jsonDictionary.json(atKeyPath: "path")
+        path = Path(pathString)
         properties = jsonDictionary.json(atKeyPath: "properties") ?? [:]
     }
 }
@@ -28,7 +30,7 @@ extension Plist: JSONObjectConvertible {
 extension Plist: JSONEncodable {
     public func toJSONValue() -> Any {
         [
-            "path": path,
+            "path": path.string,
             "properties": properties,
         ]
     }

--- a/Sources/XcodeGenKit/FileWriter.swift
+++ b/Sources/XcodeGenKit/FileWriter.swift
@@ -31,12 +31,12 @@ public class FileWriter {
             // write Info.plist
             if let plist = target.info {
                 let properties = infoPlistGenerator.generateProperties(for: target).merged(plist.properties)
-                try writePlist(properties, path: plist.path)
+                try writePlist(properties, path: plist.path.string)
             }
 
             // write entitlements
             if let plist = target.entitlements {
-                try writePlist(plist.properties, path: plist.path)
+                try writePlist(plist.properties, path: plist.path.string)
             }
         }
     }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -856,13 +856,13 @@ public class PBXProjGenerator {
 
             // Set CODE_SIGN_ENTITLEMENTS
             if let entitlements = target.entitlements {
-                buildSettings["CODE_SIGN_ENTITLEMENTS"] = entitlements.path
+                buildSettings["CODE_SIGN_ENTITLEMENTS"] = entitlements.path.string
             }
 
             // Set INFOPLIST_FILE if not defined in settings
             if !project.targetHasBuildSetting("INFOPLIST_FILE", target: target, config: config) {
                 if let info = target.info {
-                    buildSettings["INFOPLIST_FILE"] = info.path
+                    buildSettings["INFOPLIST_FILE"] = info.path.string
                 } else if searchForPlist {
                     plistPath = getInfoPlist(target.sources)
                     searchForPlist = false

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -927,7 +927,7 @@ class ProjectGeneratorTests: XCTestCase {
 
                 let targetConfig = try unwrap(pbxProject.nativeTargets.first?.buildConfigurationList?.buildConfigurations.first)
 
-                try expect(targetConfig.buildSettings["INFOPLIST_FILE"] as? String) == plist.path
+                try expect(targetConfig.buildSettings["INFOPLIST_FILE"] as? String) == plist.path.string
 
                 let infoPlistFile = tempPath + plist.path
                 let data: Data = try infoPlistFile.read()
@@ -1037,7 +1037,7 @@ class ProjectGeneratorTests: XCTestCase {
 
                 let targetConfig = try unwrap(pbxProject.nativeTargets.first?.buildConfigurationList?.buildConfigurations.first)
 
-                try expect(targetConfig.buildSettings["INFOPLIST_FILE"] as? String) == plist.path
+                try expect(targetConfig.buildSettings["INFOPLIST_FILE"] as? String) == plist.path.string
 
                 let infoPlistFile = tempPath + plist.path
                 let data: Data = try infoPlistFile.read()


### PR DESCRIPTION
Hello.
Thank you for XcodeGen.
In this pull request I modified `Plist.path` type. Now it is `Path`, not `String`.