### PR TITLE
Fixed unnecessary dependencies related to SwiftPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed missing headers for static framework targets [#705](https://github.com/yonaskolb/XcodeGen/pull/705) @wag-miles
 - Using more file types from XcodeProj for PBXFileReferences resulting in less project diffs [#715](https://github.com/yonaskolb/XcodeGen/pull/715) @yonaskolb
 - Fixed localized `*.intentdefinition` not being added to build source phases [#720](https://github.com/yonaskolb/XcodeGen/pull/720) @giginet
+- Fixed unnecessary dependencies related to SwiftPM [#726](https://github.com/yonaskolb/XcodeGen/pull/726) @tid-kijyun
 
 #### Changed
 - Deprecated `$old_form` variables in favor of `${new_form}` variables [#704](https://github.com/yonaskolb/XcodeGen/pull/704) @rcari

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -642,6 +642,11 @@ public class PBXProjGenerator {
                     )
                     targetFrameworkBuildFiles.append(buildFile)
                 }
+
+                let targetDependency = addObject(
+                    PBXTargetDependency(product: packageDependency)
+                )
+                dependencies.append(targetDependency)
             }
         }
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -641,12 +641,12 @@ public class PBXProjGenerator {
                         PBXBuildFile(product: packageDependency)
                     )
                     targetFrameworkBuildFiles.append(buildFile)
+                } else {
+                    let targetDependency = addObject(
+                        PBXTargetDependency(product: packageDependency)
+                    )
+                    dependencies.append(targetDependency)
                 }
-
-                let targetDependency = addObject(
-                    PBXTargetDependency(product: packageDependency)
-                )
-                dependencies.append(targetDependency)
             }
         }
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -642,11 +642,6 @@ public class PBXProjGenerator {
                     )
                     targetFrameworkBuildFiles.append(buildFile)
                 }
-
-                let targetDependency = addObject(
-                    PBXTargetDependency(product: packageDependency)
-                )
-                dependencies.append(targetDependency)
             }
         }
 

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				D85FFB99444DD260A72DDDA7 /* PBXTargetDependency */,
 			);
 			name = StaticLibrary;
 			packageProductDependencies = (
@@ -128,6 +129,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				E157C6348B8AD6A28C706801 /* PBXTargetDependency */,
 				078202CF7B08B66ACF7FEC23 /* PBXTargetDependency */,
 			);
 			name = App;
@@ -222,6 +224,14 @@
 			isa = PBXTargetDependency;
 			target = 3F8D94C4EFC431F646AAFB28 /* StaticLibrary */;
 			targetProxy = 29147E1DDAEB1AAC20CB0CF9 /* PBXContainerItemProxy */;
+		};
+		D85FFB99444DD260A72DDDA7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = AF233B61592982A7F6431FC6 /* Codability */;
+		};
+		E157C6348B8AD6A28C706801 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 16E6FE01D5BD99F78D4A17E2 /* Codability */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -129,7 +129,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				E157C6348B8AD6A28C706801 /* PBXTargetDependency */,
 				078202CF7B08B66ACF7FEC23 /* PBXTargetDependency */,
 			);
 			name = App;
@@ -228,10 +227,6 @@
 		D85FFB99444DD260A72DDDA7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = AF233B61592982A7F6431FC6 /* Codability */;
-		};
-		E157C6348B8AD6A28C706801 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 16E6FE01D5BD99F78D4A17E2 /* Codability */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -108,7 +108,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				D85FFB99444DD260A72DDDA7 /* PBXTargetDependency */,
 			);
 			name = StaticLibrary;
 			packageProductDependencies = (
@@ -129,7 +128,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				E157C6348B8AD6A28C706801 /* PBXTargetDependency */,
 				078202CF7B08B66ACF7FEC23 /* PBXTargetDependency */,
 			);
 			name = App;
@@ -224,14 +222,6 @@
 			isa = PBXTargetDependency;
 			target = 3F8D94C4EFC431F646AAFB28 /* StaticLibrary */;
 			targetProxy = 29147E1DDAEB1AAC20CB0CF9 /* PBXContainerItemProxy */;
-		};
-		D85FFB99444DD260A72DDDA7 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = AF233B61592982A7F6431FC6 /* Codability */;
-		};
-		E157C6348B8AD6A28C706801 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			productRef = 16E6FE01D5BD99F78D4A17E2 /* Codability */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
Removed unnecessary addition of `PBXTargetDependency` to `dependencies` in the `FBXNativeTarget section` for SwiftPM.

Xcode doesn't seem to require this dependency.
I checked that if I manually added a package using Xcode, it was not added.

Note: I found this issue because `pod install` failed.