### PR TITLE
Add support for language and region settings for target schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Added
+- Support for language and region settings on a target basis [#728](https://github.com/yonaskolb/XcodeGen/pull/728) @FranzBusch
+
 ## 2.11.0
 
 #### Added

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -586,6 +586,8 @@ This is a convenience used to automatically generate schemes for a target based 
 - [ ] **testTargets**: **[[Test Target](#test-target)]** - a list of test targets that should be included in the scheme. These will be added to the build targets and the test entries. Each entry can either be a simple string, or a [Test Target](#test-target)
 - [ ] **gatherCoverageData**: **Bool** - a boolean that indicates if this scheme should gather coverage data. This defaults to false
 - [ ] **disableMainThreadChecker**: **Bool** - a boolean that indicates if this scheme should disable disable the Main Thread Checker. This defaults to false
+- [ ] **language**: **String** - a String that indicates the language used for running and testing. This defaults to nil
+- [ ] **region**: **String** - a String that indicates the region used for running and testing. This defaults to nil
 - [ ] **commandLineArguments**: **[String:Bool]** - a dictionary from the argument name (`String`) to if it is enabled (`Bool`). These arguments will be added to the Test, Profile and Run scheme actions
 - [ ] **environmentVariables**: **[[Environment Variable](#environment-variable)]** or **[String:String]** - environment variables for Run, Test and Profile scheme actions. When passing a dictionary, every key-value entry maps to a corresponding variable that is enabled.
 - [ ] **preActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *before* all actions

--- a/Sources/ProjectSpec/TargetScheme.swift
+++ b/Sources/ProjectSpec/TargetScheme.swift
@@ -9,6 +9,8 @@ public struct TargetScheme: Equatable {
     public var testTargets: [Scheme.Test.TestTarget]
     public var configVariants: [String]
     public var gatherCoverageData: Bool
+    public var language: String?
+    public var region: String?
     public var disableMainThreadChecker: Bool
     public var commandLineArguments: [String: Bool]
     public var environmentVariables: [XCScheme.EnvironmentVariable]
@@ -19,6 +21,8 @@ public struct TargetScheme: Equatable {
         testTargets: [Scheme.Test.TestTarget] = [],
         configVariants: [String] = [],
         gatherCoverageData: Bool = gatherCoverageDataDefault,
+        language: String? = nil,
+        region: String? = nil,
         disableMainThreadChecker: Bool = disableMainThreadCheckerDefault,
         commandLineArguments: [String: Bool] = [:],
         environmentVariables: [XCScheme.EnvironmentVariable] = [],
@@ -28,6 +32,8 @@ public struct TargetScheme: Equatable {
         self.testTargets = testTargets
         self.configVariants = configVariants
         self.gatherCoverageData = gatherCoverageData
+        self.language = language
+        self.region = region
         self.disableMainThreadChecker = disableMainThreadChecker
         self.commandLineArguments = commandLineArguments
         self.environmentVariables = environmentVariables
@@ -54,6 +60,8 @@ extension TargetScheme: JSONObjectConvertible {
         }
         configVariants = jsonDictionary.json(atKeyPath: "configVariants") ?? []
         gatherCoverageData = jsonDictionary.json(atKeyPath: "gatherCoverageData") ?? TargetScheme.gatherCoverageDataDefault
+        language = jsonDictionary.json(atKeyPath: "language")
+        region = jsonDictionary.json(atKeyPath: "region")
         disableMainThreadChecker = jsonDictionary.json(atKeyPath: "disableMainThreadChecker") ?? TargetScheme.disableMainThreadCheckerDefault
         commandLineArguments = jsonDictionary.json(atKeyPath: "commandLineArguments") ?? [:]
         environmentVariables = try XCScheme.EnvironmentVariable.parseAll(jsonDictionary: jsonDictionary)
@@ -79,6 +87,14 @@ extension TargetScheme: JSONEncodable {
 
         if disableMainThreadChecker != TargetScheme.disableMainThreadCheckerDefault {
             dict["disableMainThreadChecker"] = disableMainThreadChecker
+        }
+
+        if let language = language {
+            dict["language"] = language
+        }
+
+        if let region = region {
+            dict["region"] = region
         }
 
         return dict

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -56,7 +56,7 @@ public class SchemeGenerator {
                     let debugConfig = suitableConfig(for: .debug, in: project)
                     let releaseConfig = suitableConfig(for: .release, in: project)
 
-                    let scheme = Scheme(
+                    let scheme = Scheme.init(
                         name: schemeName,
                         target: target,
                         targetScheme: targetScheme,
@@ -288,7 +288,9 @@ extension Scheme {
                 preActions: targetScheme.preActions,
                 postActions: targetScheme.postActions,
                 environmentVariables: targetScheme.environmentVariables,
-                disableMainThreadChecker: targetScheme.disableMainThreadChecker
+                disableMainThreadChecker: targetScheme.disableMainThreadChecker,
+                language: targetScheme.language,
+                region: targetScheme.region
             ),
             test: .init(
                 config: debugConfig,
@@ -298,7 +300,9 @@ extension Scheme {
                 targets: targetScheme.testTargets,
                 preActions: targetScheme.preActions,
                 postActions: targetScheme.postActions,
-                environmentVariables: targetScheme.environmentVariables
+                environmentVariables: targetScheme.environmentVariables,
+                language: targetScheme.language,
+                region: targetScheme.region
             ),
             profile: .init(
                 config: releaseConfig,

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -700,6 +700,8 @@ class SpecLoadingTests: XCTestCase {
                         "ENV1": true,
                     ],
                     "gatherCoverageData": true,
+                    "language": "en",
+                    "region": "US",
                     "disableMainThreadChecker": true,
                     "environmentVariables": [
                         "TEST_VAR": "TEST_VAL",
@@ -724,6 +726,8 @@ class SpecLoadingTests: XCTestCase {
                     testTargets: ["t1", "t2"],
                     configVariants: ["dev", "app-store"],
                     gatherCoverageData: true,
+                    language: "en",
+                    region: "US",
                     disableMainThreadChecker: true,
                     commandLineArguments: ["ENV1": true],
                     environmentVariables: [XCScheme.EnvironmentVariable(variable: "TEST_VAR", value: "TEST_VAL", enabled: true)],


### PR DESCRIPTION
In Xcode it is possible to set the language and region that is used during running and testing the application. At the moment, this is only possible to set in `XcodeGen` for schemes but not for target schemes. This PR adds support to configure language and region on a target basis.

I opted to use the passed language and region for both the run and test action. Is this okay @yonaskolb? We can also separate this but this would require to add more parameters or change the `TargetScheme` API.