### PR TITLE
Adding two Xcodegen external examples

### DIFF
--- a/Docs/Examples.md
+++ b/Docs/Examples.md
@@ -5,4 +5,5 @@ These are a bunch of real world examples of XcodeGen project specs. Feel free to
 - [num42/RxUserDefaults](https://github.com/num42/RxUserDefaults/blob/master/project.yml)
 - [toshi0383/Bitrise-iOS](https://github.com/toshi0383/Bitrise-iOS/blob/master/project.yml)
 - [johndpope/swift-models](https://github.com/johndpope/swift-models/tree/stable/Inference)
-
+- [atelier-socle/AppRepositoryTemplate](https://github.com/atelier-socle/AppRepositoryTemplate/blob/master/project.yml)
+- [atelier-socle/FrameworkRepositoryTemplate](https://github.com/atelier-socle/FrameworkRepositoryTemplate/blob/master/project.yml)


### PR DESCRIPTION
Thanks for this great tool, I ended using it to make two repositories templates which is based on Xcodegen for the `xcodeproj` generation (one to generate frameworks, and the other to generate apps). I do think this examples can be really useful for users :)