### PR TITLE
Add option to generate only plist files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Added
 - Support for language and region settings on a target basis [#728](https://github.com/yonaskolb/XcodeGen/pull/728) @FranzBusch
+- Added option to generate only Info.plist files with `--only-plists` [#739](https://github.com/yonaskolb/XcodeGen/pull/739) @namolnad
 
 #### Fixed
 - Fixed resolving a relative path for `projectReference.path` [#740](https://github.com/yonaskolb/XcodeGen/pull/740) @kateinoigakukun

--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -19,6 +19,9 @@ class GenerateCommand: ProjectCommand {
     @Key("-p", "--project", description: "The path to the directory where the project should be generated. Defaults to the directory the spec is in. The filename is defined in the project spec")
     var projectDirectory: Path?
 
+    @Flag("--only-plists", description: "Generate only plist files")
+    var onlyPlists: Bool
+
     init(version: Version) {
         super.init(version: version,
                    name: "generate",
@@ -81,6 +84,9 @@ class GenerateCommand: ProjectCommand {
         let fileWriter = FileWriter(project: project)
         do {
             try fileWriter.writePlists()
+            if onlyPlists {
+                return
+            }
         } catch {
             throw GenerationError.writingError(error)
         }


### PR DESCRIPTION
At Instacart we use XcodeGen in conjunction with Bazel. For one of our CI testing steps, we need only to generate the Plist files, and not the project in its entirety. This adds the option to exit early from the project generation command, after only generating the plist files.