### PR TITLE
Don't add framework dependency's directory to FRAMEWORK_SEARCH_PATHS if it is implicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixed
 - Fixed resolving a relative path for `projectReference.path` [#740](https://github.com/yonaskolb/XcodeGen/pull/740) @kateinoigakukun
+- Don't add framework dependency's directory to `FRAMEWORK_SEARCH_PATHS` if it is implicit [#744](https://github.com/yonaskolb/XcodeGen/pull/744) @ikesyo @yutailang0119
 
 #### Internal
 - Update to SwiftCLI 6.0 and use the new property wrappers [#749](https://github.com/yonaskolb/XcodeGen/pull/749) @yonaskolb

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -534,8 +534,10 @@ public class PBXProjGenerator {
                 }
 
             case .framework:
-                let buildPath = Path(dependency.reference).parent().string.quoted
-                frameworkBuildPaths.insert(buildPath)
+                if !dependency.implicit {
+                    let buildPath = Path(dependency.reference).parent().string.quoted
+                    frameworkBuildPaths.insert(buildPath)
+                }
 
                 let fileReference: PBXFileElement
                 if dependency.implicit {


### PR DESCRIPTION
Because we assume the dependency is in `BUILT_PRODUCTS_DIR`. Adding `.` to `FRAMEWORK_SEARCH_PATHS` should be avoided.

/cc @yutailang0119

Refs:
- #224
- https://github.com/yonaskolb/XcodeGen/issues/570#issuecomment-517543767