### PR TITLE
Update to SwiftCLI 6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Added
 - Support for language and region settings on a target basis [#728](https://github.com/yonaskolb/XcodeGen/pull/728) @FranzBusch
 
+#### Internal
+- Update to SwiftCLI 6.0 and use the new property wrappers [#749](https://github.com/yonaskolb/XcodeGen/pull/749) @yonaskolb
+
 ## 2.11.0
 
 #### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI.git",
         "state": {
           "branch": null,
-          "revision": "ba2268e67c07b9f9cfbc0801385e6238b36255eb",
-          "version": "5.3.2"
+          "revision": "c72c4564f8c0a24700a59824880536aca45a4cae",
+          "version": "6.0.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .package(url: "https://github.com/kylef/Spectre.git", from: "0.9.0"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "3.0.0"),
         .package(url: "https://github.com/tuist/XcodeProj.git", from: "7.4.0"),
-        .package(url: "https://github.com/jakeheis/SwiftCLI.git", .upToNextMinor(from: "5.3.2")),
+        .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.0"),
     ],
     targets: [
         .target(name: "XcodeGen", dependencies: [

--- a/Sources/XcodeGenCLI/Arguments.swift
+++ b/Sources/XcodeGenCLI/Arguments.swift
@@ -4,7 +4,7 @@ import SwiftCLI
 
 extension Path: ConvertibleFromString {
 
-    public static func convert(from: String) -> Path? {
-        Path(from)
+    public init?(input: String) {
+        self.init(input)
     }
 }

--- a/Sources/XcodeGenCLI/Commands/DumpCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/DumpCommand.swift
@@ -6,19 +6,11 @@ import Yams
 
 class DumpCommand: ProjectCommand {
 
-    private let dumpType = Key<DumpType>(
-        "--type",
-        "-t",
-        description: """
-        The type of dump to output. Either \(DumpType.allCases.map { "\"\($0.rawValue)\"" }.joined(separator: ", ")). Defaults to \(DumpType.defaultValue.rawValue). The "parsed" types parse the project into swift and then back again.
-        """
-    )
+    @Key("--type", "-t", description: "The type of dump to output. Either \(DumpType.allCases.map { "\"\($0.rawValue)\"" }.joined(separator: ", ")). Defaults to \(DumpType.defaultValue.rawValue). The \"parsed\" types parse the project into swift and then back again.")
+    private var dumpType: DumpType?
 
-    private let file = Key<Path>(
-        "--file",
-        "-f",
-        description: "The path of a file to write to. If not supplied will output to stdout"
-    )
+    @Key("--file", "-f", description: "The path of a file to write to. If not supplied will output to stdout")
+    private var file: Path?
 
     init(version: Version) {
         super.init(version: version,
@@ -27,7 +19,7 @@ class DumpCommand: ProjectCommand {
     }
 
     override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
-        let type = dumpType.value ?? .defaultValue
+        let type = dumpType ?? .defaultValue
 
         let output: String
         switch type {
@@ -49,7 +41,7 @@ class DumpCommand: ProjectCommand {
             output = project.debugDescription
         }
 
-        if let file = file.value {
+        if let file = file {
             try file.parent().mkpath()
             try file.write(output)
         } else {

--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -7,30 +7,17 @@ import XcodeProj
 
 class GenerateCommand: ProjectCommand {
 
-    let quiet = Flag(
-        "-q",
-        "--quiet",
-        description: "Suppress all informational and success output",
-        defaultValue: false
-    )
+    @Flag("-q", "--quiet", description: "Suppress all informational and success output")
+    var quiet: Bool
 
-    let useCache = Flag(
-        "-c",
-        "--use-cache",
-        description: "Use a cache for the xcodegen spec. This will prevent unnecessarily generating the project if nothing has changed",
-        defaultValue: false
-    )
+    @Flag("-c", "--use-cache", description: "Use a cache for the xcodegen spec. This will prevent unnecessarily generating the project if nothing has changed")
+    var useCache: Bool
 
-    let cacheFilePath = Key<Path>(
-        "--cache-path",
-        description: "Where the cache file will be loaded from and save to. Defaults to ~/.xcodegen/cache/{SPEC_PATH_HASH}"
-    )
+    @Key("--cache-path", description: "Where the cache file will be loaded from and save to. Defaults to ~/.xcodegen/cache/{SPEC_PATH_HASH}")
+    var cacheFilePath: Path?
 
-    let projectDirectory = Key<Path>(
-        "-p",
-        "--project",
-        description: "The path to the directory where the project should be generated. Defaults to the directory the spec is in. The filename is defined in the project spec"
-    )
+    @Key("-p", "--project", description: "The path to the directory where the project should be generated. Defaults to the directory the spec is in. The filename is defined in the project spec")
+    var projectDirectory: Path?
 
     init(version: Version) {
         super.init(version: version,
@@ -40,7 +27,7 @@ class GenerateCommand: ProjectCommand {
 
     override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
 
-        let projectDirectory = self.projectDirectory.value?.absolute() ?? projectSpecPath.parent()
+        let projectDirectory = self.projectDirectory?.absolute() ?? projectSpecPath.parent()
 
         // validate project dictionary
         do {
@@ -51,12 +38,12 @@ class GenerateCommand: ProjectCommand {
 
         let projectPath = projectDirectory + "\(project.name).xcodeproj"
 
-        let cacheFilePath = self.cacheFilePath.value ??
+        let cacheFilePath = self.cacheFilePath ??
             Path("~/.xcodegen/cache/\(projectSpecPath.absolute().string.md5)").absolute()
         var cacheFile: CacheFile?
 
         // read cache
-        if useCache.value || self.cacheFilePath.value != nil {
+        if useCache || self.cacheFilePath != nil {
             do {
                 cacheFile = try specLoader.generateCacheFile()
             } catch {
@@ -129,19 +116,19 @@ class GenerateCommand: ProjectCommand {
     }
 
     func info(_ string: String) {
-        if !quiet.value {
+        if !quiet {
             stdout.print(string)
         }
     }
 
     func warning(_ string: String) {
-        if !quiet.value {
+        if !quiet {
             stdout.print(string.yellow)
         }
     }
 
     func success(_ string: String) {
-        if !quiet.value {
+        if !quiet {
             stdout.print(string.green)
         }
     }

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -11,18 +11,11 @@ class ProjectCommand: Command {
     let name: String
     let shortDescription: String
 
-    let spec = Key<Path>(
-        "-s",
-        "--spec",
-        description: "The path to the project spec file. Defaults to project.yml"
-    )
+    @Key("-s", "--spec", description: "The path to the project spec file. Defaults to project.yml")
+    var spec: Path?
 
-    let disableEnvExpansion = Flag(
-        "-n",
-        "--no-env",
-        description: "Disable environment variable expansions",
-        defaultValue: false
-    )
+    @Flag("-n", "--no-env", description: "Disable environment variable expansions")
+    var disableEnvExpansion: Bool
 
     init(version: Version, name: String, shortDescription: String) {
         self.version = version
@@ -32,7 +25,7 @@ class ProjectCommand: Command {
 
     func execute() throws {
 
-        let projectSpecPath = (spec.value ?? "project.yml").absolute()
+        let projectSpecPath = (spec ?? "project.yml").absolute()
 
         if !projectSpecPath.exists {
             throw GenerationError.missingProjectSpec(projectSpecPath)
@@ -41,7 +34,7 @@ class ProjectCommand: Command {
         let specLoader = SpecLoader(version: version)
         let project: Project
 
-        let variables: [String: String] = disableEnvExpansion.value ? [:] : ProcessInfo.processInfo.environment
+        let variables: [String: String] = disableEnvExpansion ? [:] : ProcessInfo.processInfo.environment
 
         do {
             project = try specLoader.loadProject(path: projectSpecPath, variables: variables)


### PR DESCRIPTION
This uses the new property wrappers introduced in SwiftCLI 6.0
```swift
@Key("-s", "--spec", description: "The path to the project spec file. Defaults to project.yml")
var spec: Path?
```