### PR TITLE
Use full path for XcodeProj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixed
 - Fixed resolving a relative path for `projectReference.path` [#740](https://github.com/yonaskolb/XcodeGen/pull/740) @kateinoigakukun
+- Fixed resolving relative path passed to `XcodeProj` [#751](https://github.com/yonaskolb/XcodeGen/pull/751) @PycKamil
 
 #### Internal
 - Update to SwiftCLI 6.0 and use the new property wrappers [#749](https://github.com/yonaskolb/XcodeGen/pull/749) @yonaskolb

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -1,6 +1,7 @@
 import Foundation
 import ProjectSpec
 import XcodeProj
+import PathKit
 
 private func suitableConfig(for type: ConfigType, in project: Project) -> Config {
     if let defaultConfig = Config.defaultConfigs.first(where: { $0.type == type }),
@@ -34,7 +35,7 @@ public class SchemeGenerator {
         if let cachedProject = projects[reference] {
             return cachedProject
         }
-        let pbxproj = try XcodeProj(pathString: reference.path).pbxproj
+        let pbxproj = try XcodeProj(path: project.basePath + Path(reference.path)).pbxproj
         projects[reference] = pbxproj
         return pbxproj
     }


### PR DESCRIPTION
This solves issue with relative project path reported with #729. It was partially fixed with #740 project reference is loaded correctly now, but when projects target is for example used in scheme, `XcodeProj` fails to read it, since the `../Project.xcodeproject` path is not recognised. This PR fix it by adding a base project path before passing it to it `XcodeProj`. 