### PR TITLE
Prefer default Debug and Release configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed resolving a relative path for `projectReference.path` [#740](https://github.com/yonaskolb/XcodeGen/pull/740) @kateinoigakukun
 - Don't add framework dependency's directory to `FRAMEWORK_SEARCH_PATHS` if it is implicit [#744](https://github.com/yonaskolb/XcodeGen/pull/744) @ikesyo @yutailang0119
 - Fixed resolving relative path passed to `XcodeProj` [#751](https://github.com/yonaskolb/XcodeGen/pull/751) @PycKamil
+- Prefer configurations named "Debug" or "Release" for default scheme build configurations [#752](https://github.com/yonaskolb/XcodeGen/pull/752) @john-flanagan
 
 #### Internal
 - Update to SwiftCLI 6.0 and use the new property wrappers [#749](https://github.com/yonaskolb/XcodeGen/pull/749) @yonaskolb

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -17,11 +17,11 @@ public class SchemeGenerator {
     let pbxProj: PBXProj
 
     var defaultDebugConfig: Config {
-        project.configs.first { $0.type == .debug }!
+        suitableConfig(for: .debug, in: project)
     }
 
     var defaultReleaseConfig: Config {
-        project.configs.first { $0.type == .release }!
+        suitableConfig(for: .release, in: project)
     }
 
     public init(project: Project, pbxProj: PBXProj) {


### PR DESCRIPTION
The default schemes generated for a target is using the `suitableConfig` helper function to prefer configs named "Debug" or "Release" over the alphabetically first scheme of the matching type:

https://github.com/yonaskolb/XcodeGen/blob/480477a7e8863e1585596c417cd6ce34513b9ef2/Sources/XcodeGenKit/SchemeGenerator.swift#L57-L58

but `generateScheme(_: Scheme)` was using the computed `default<ConfigType>Config` properties which only took into account the sorting order for top level schemes.

https://github.com/yonaskolb/XcodeGen/blob/480477a7e8863e1585596c417cd6ce34513b9ef2/Sources/XcodeGenKit/SchemeGenerator.swift#L244-L250

This change uses the same `suitableConfig` function to back the `default<ConfigType>Config` properties so that top level schemes and target schemes will have the same default config behavior.