### PR TITLE
Add support On Demand Resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Added
 - Support for language and region settings on a target basis [#728](https://github.com/yonaskolb/XcodeGen/pull/728) @FranzBusch
 - Added option to generate only Info.plist files with `--only-plists` [#739](https://github.com/yonaskolb/XcodeGen/pull/739) @namolnad
+- Support for On Demand Resources tags [#753](https://github.com/yonaskolb/XcodeGen/pull/753) @sipao
 
 #### Fixed
 - Fixed resolving a relative path for `projectReference.path` [#740](https://github.com/yonaskolb/XcodeGen/pull/740) @kateinoigakukun

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -342,6 +342,7 @@ A source can be provided via a string (the path) or an object of the form:
 	- `private`
 	- `project`
 - [ ] **attributes**: **[String]** - Additional settings attributes that will be applied to any build files.
+- [ ] **resourceTags**: **[String]** - Additional On Demand Resource Tags that will be applied to any build files. this also add to project attribute's  knownAssetTags
 
 ```yaml
 targets:
@@ -370,6 +371,8 @@ targets:
             subpath: include/$(PRODUCT_NAME)
       - path: Resources
         type: folder
+      - path: Path/To/File.asset
+        resourceTags: [tag1, tag2]
 ```
 
 ### Dependency

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -342,7 +342,7 @@ A source can be provided via a string (the path) or an object of the form:
 	- `private`
 	- `project`
 - [ ] **attributes**: **[String]** - Additional settings attributes that will be applied to any build files.
-- [ ] **resourceTags**: **[String]** - Additional On Demand Resource Tags that will be applied to any build files. this also add to project attribute's  knownAssetTags
+- [ ] **resourceTags**: **[String]** - On Demand Resource Tags that will be applied to any resources. This also adds to the project attribute's knownAssetTags
 
 ```yaml
 targets:

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -19,6 +19,7 @@ public struct TargetSource: Equatable {
     public var headerVisibility: HeaderVisibility?
     public var createIntermediateGroups: Bool?
     public var attributes: [String]
+    public var resourceTags: [String]
 
     public enum HeaderVisibility: String {
         case `public`
@@ -134,7 +135,8 @@ public struct TargetSource: Equatable {
         buildPhase: BuildPhase? = nil,
         headerVisibility: HeaderVisibility? = nil,
         createIntermediateGroups: Bool? = nil,
-        attributes: [String] = []
+        attributes: [String] = [],
+        resourceTags: [String] = []
     ) {
         self.path = path
         self.name = name
@@ -148,6 +150,7 @@ public struct TargetSource: Equatable {
         self.headerVisibility = headerVisibility
         self.createIntermediateGroups = createIntermediateGroups
         self.attributes = attributes
+        self.resourceTags = resourceTags
     }
 }
 
@@ -192,6 +195,7 @@ extension TargetSource: JSONObjectConvertible {
 
         createIntermediateGroups = jsonDictionary.json(atKeyPath: "createIntermediateGroups")
         attributes = jsonDictionary.json(atKeyPath: "attributes") ?? []
+        resourceTags = jsonDictionary.json(atKeyPath: "resourceTags") ?? []
     }
 }
 

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -211,6 +211,7 @@ extension TargetSource: JSONEncodable {
             "type": type?.rawValue,
             "buildPhase": buildPhase?.toJSONValue(),
             "createIntermediateGroups": createIntermediateGroups,
+            "resourceTags": resourceTags,
         ]
 
         if optional != TargetSource.optionalDefault {

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -233,8 +233,15 @@ public class PBXProjGenerator {
             .sorted { $0.nameOrPath.localizedStandardCompare($1.nameOrPath) == .orderedAscending }
             .map { $0 }
 
+        let assetTags = Array(Set(project.targets
+            .map { target in
+                target.sources.map { $0.resourceTags }.flatMap { $0 }
+            }.flatMap { $0 }
+        ))
+        
         let projectAttributes: [String: Any] = ["LastUpgradeCheck": project.xcodeVersion]
             .merged(project.attributes)
+            .merged(["knownAssetTags" : assetTags])
 
         let knownRegions = sourceGenerator.knownRegions
         pbxProject.knownRegions = (knownRegions.isEmpty ? ["en"] : knownRegions).union(["Base"]).sorted()

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -233,11 +233,11 @@ public class PBXProjGenerator {
             .sorted { $0.nameOrPath.localizedStandardCompare($1.nameOrPath) == .orderedAscending }
             .map { $0 }
 
-        let assetTags = Array(Set(project.targets
+        let assetTags = Set(project.targets
             .map { target in
                 target.sources.map { $0.resourceTags }.flatMap { $0 }
             }.flatMap { $0 }
-        ))
+        ).sorted()
         
         let projectAttributes: [String: Any] = ["LastUpgradeCheck": project.xcodeVersion]
             .merged(project.attributes)

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -239,10 +239,13 @@ public class PBXProjGenerator {
             }.flatMap { $0 }
         ).sorted()
         
-        let projectAttributes: [String: Any] = ["LastUpgradeCheck": project.xcodeVersion]
+        var projectAttributes: [String: Any] = ["LastUpgradeCheck": project.xcodeVersion]
             .merged(project.attributes)
-            .merged(["knownAssetTags" : assetTags])
-
+        
+        if !assetTags.isEmpty {
+            projectAttributes["knownAssetTags"] = assetTags
+        }
+        
         let knownRegions = sourceGenerator.knownRegions
         pbxProject.knownRegions = (knownRegions.isEmpty ? ["en"] : knownRegions).union(["Base"]).sorted()
         pbxProject.packages = packageReferences.sorted { $0.key < $1.key }.map { $1 }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -85,7 +85,6 @@ class SourceGenerator {
         let fileReference = fileReference ?? fileReferencesByPath[path.string.lowercased()]!
         var settings: [String: Any] = [:]
         var attributes: [String] = targetSource.attributes
-        let resourceTags: [String] = targetSource.resourceTags
         var chosenBuildPhase: TargetSource.BuildPhase?
 
         let headerVisibility = targetSource.headerVisibility ?? .public
@@ -126,8 +125,8 @@ class SourceGenerator {
             settings["ATTRIBUTES"] = attributes
         }
         
-        if !resourceTags.isEmpty {
-            settings["ASSET_TAGS"] = resourceTags
+        if !targetSource.resourceTags.isEmpty {
+            settings["ASSET_TAGS"] = targetSource.resourceTags
         }
 
         let buildFile = PBXBuildFile(file: fileReference, settings: settings.isEmpty ? nil : settings)

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -85,6 +85,7 @@ class SourceGenerator {
         let fileReference = fileReference ?? fileReferencesByPath[path.string.lowercased()]!
         var settings: [String: Any] = [:]
         var attributes: [String] = targetSource.attributes
+        let resourceTags: [String] = targetSource.resourceTags
         var chosenBuildPhase: TargetSource.BuildPhase?
 
         let headerVisibility = targetSource.headerVisibility ?? .public
@@ -123,6 +124,10 @@ class SourceGenerator {
 
         if !attributes.isEmpty {
             settings["ATTRIBUTES"] = attributes
+        }
+        
+        if !resourceTags.isEmpty {
+            settings["ASSET_TAGS"] = resourceTags
         }
 
         let buildFile = PBXBuildFile(file: fileReference, settings: settings.isEmpty ? nil : settings)

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -125,7 +125,7 @@ class SourceGenerator {
             settings["ATTRIBUTES"] = attributes
         }
         
-        if !targetSource.resourceTags.isEmpty {
+        if chosenBuildPhase == .resources && !targetSource.resourceTags.isEmpty {
             settings["ASSET_TAGS"] = targetSource.resourceTags
         }
 

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		7C8FF0B857E390417134C10F /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7F658343A505B824321E086B /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 2E1E747C7BC434ADB80CC269 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
 		803B7CE086CFBA409F9D1ED7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 108BB29172D27BE3BD1E7F35 /* Assets.xcassets */; };
+		818D448D4DDD6649B5B26098 /* example.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 28360ECA4D727FAA58557A81 /* example.mp4 */; settings = {ASSET_TAGS = (tag1, tag2, ); }; };
 		900CFAD929CAEE3861127627 /* MyBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B5068D64404C61A67A18458 /* MyBundle.bundle */; };
 		95DD9941E1529FD2AE1A191D /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359F /* StaticLibrary_ObjC.h */; };
 		96B55C0F660235FE6BDD8869 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -467,6 +468,7 @@
 		1D0C79A8C750EC0DE748C463 /* StaticLibrary_ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticLibrary_ObjC.m; sourceTree = "<group>"; };
 		22237B8EBD9E6BE8EBC8735F /* XPC Service.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = "XPC Service.xpc"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2233774B86539B1574D206B0 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		28360ECA4D727FAA58557A81 /* example.mp4 */ = {isa = PBXFileReference; path = example.mp4; sourceTree = "<group>"; };
 		2A5F527F2590C14956518174 /* FrameworkFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkFile.swift; sourceTree = "<group>"; };
 		2E1E747C7BC434ADB80CC269 /* Headers */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Headers; sourceTree = SOURCE_ROOT; };
 		33F6DCDC37D2E66543D4965D /* App_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -851,6 +853,7 @@
 		9EDF27BB8A57733E6639D36D /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				28360ECA4D727FAA58557A81 /* example.mp4 */,
 				7B5068D64404C61A67A18458 /* MyBundle.bundle */,
 			);
 			path = Resources;
@@ -1591,6 +1594,10 @@
 						TestTargetID = 0867B0DACEF28C11442DE8F7;
 					};
 				};
+				knownAssetTags = (
+					tag1,
+					tag2,
+				);
 			};
 			buildConfigurationList = D91E14E36EC0B415578456F2 /* Build configuration list for PBXProject "Project" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -1685,6 +1692,7 @@
 				900CFAD929CAEE3861127627 /* MyBundle.bundle in Resources */,
 				C88598A49087A212990F4E8B /* ResourceFolder in Resources */,
 				E8A135F768448632F8D77C8F /* StandaloneAssets.xcassets in Resources */,
+				818D448D4DDD6649B5B26098 /* example.mp4 in Resources */,
 				2C7C03B45571A13D472D6B23 /* iMessageApp.app in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -86,6 +86,11 @@ targets:
           copyFiles:
             destination: productsDirectory
             subpath: include/$(PRODUCT_NAME)
+      - path: Resources/example.mp4
+        buildPhase: resources
+        resourceTags:
+          - tag1
+          - tag2
     settings:
       INFOPLIST_FILE: App_iOS/Info.plist
       PRODUCT_BUNDLE_IDENTIFIER: com.project.app

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -348,6 +348,7 @@ class SpecLoadingTests: XCTestCase {
                     ["path": "sourceWithFileType", "type": "file"],
                     ["path": "sourceWithGroupType", "type": "group"],
                     ["path": "sourceWithFolderType", "type": "folder"],
+                    ["path": "sourceWithResourceTags", "resourceTags": ["tag1", "tag2"]],
                 ]
                 var targetDictionary2 = validTarget
                 targetDictionary2["sources"] = "source3"
@@ -364,6 +365,7 @@ class SpecLoadingTests: XCTestCase {
                     TargetSource(path: "sourceWithFileType", type: .file),
                     TargetSource(path: "sourceWithGroupType", type: .group),
                     TargetSource(path: "sourceWithFolderType", type: .folder),
+                    TargetSource(path: "sourceWithResourceTags", resourceTags: ["tag1", "tag2"]),
                 ]
 
                 try expect(target1.sources) == target1SourcesExpect

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -928,6 +928,74 @@ class SourceGeneratorTests: XCTestCase {
                         try expect(resourcesBuildPhase.files?.compactMap { $0.file?.nameOrPath }) == ["Intents.intentdefinition"]
                     }
                 }
+                
+                $0.it("generates resource tags") {
+                    let directories = """
+                    A:
+                        - resourceFile.mp4
+                        - resourceFile2.mp4
+                        - sourceFile.swift
+                    """
+                    try createDirectories(directories)
+                    
+                    let target = Target(
+                        name: "Test",
+                        type: .application,
+                        platform: .iOS,
+                        sources: [
+                            TargetSource(path: "A/resourceFile.mp4", buildPhase: .resources, resourceTags: ["tag1", "tag2"]),
+                            TargetSource(path: "A/resourceFile2.mp4", buildPhase: .resources, resourceTags: ["tag2", "tag3"]),
+                            TargetSource(path: "A/sourceFile.swift", buildPhase: .sources, resourceTags: ["tag1", "tag2"]),
+                        ]
+                    )
+                    
+                    let project = Project(basePath: directoryPath,
+                                          name: "Test",
+                                          targets: [target])
+                    
+                    let pbxProj = try project.generatePbxProj()
+                    
+                    let resourceFileReference = try unwrap(pbxProj.getFileReference(
+                        paths: ["A", "resourceFile.mp4"],
+                        names: ["A", "resourceFile.mp4"]
+                    ))
+                    
+                    let resourceFileReference2 = try unwrap(pbxProj.getFileReference(
+                        paths: ["A", "resourceFile2.mp4"],
+                        names: ["A", "resourceFile2.mp4"]
+                    ))
+                    
+                    let sourceFileReference = try unwrap(pbxProj.getFileReference(
+                        paths: ["A", "sourceFile.swift"],
+                        names: ["A", "sourceFile.swift"]
+                    ))
+                    
+                    try pbxProj.expectFile(paths: ["A", "resourceFile.mp4"],  buildPhase: .resources)
+                    try pbxProj.expectFile(paths: ["A", "resourceFile2.mp4"], buildPhase: .resources)
+                    try pbxProj.expectFile(paths: ["A", "sourceFile.swift"], buildPhase: .sources)
+                    
+                    let resourceBuildFile  = try unwrap(pbxProj.buildFiles.first(where: { $0.file == resourceFileReference }))
+                    let resourceBuildFile2 = try unwrap(pbxProj.buildFiles.first(where: { $0.file == resourceFileReference2 }))
+                    let sourceBuildFile = try unwrap(pbxProj.buildFiles.first(where: { $0.file == sourceFileReference }))
+                    
+                    if (resourceBuildFile.settings! as NSDictionary) != (["ASSET_TAGS": ["tag1", "tag2"]] as NSDictionary) {
+                        throw failure("File does not contain tag1 and tag2 ASSET_TAGS")
+                    }
+                    
+                    if (resourceBuildFile2.settings! as NSDictionary) != (["ASSET_TAGS": ["tag2", "tag3"]] as NSDictionary) {
+                        throw failure("File does not contain tag2 and tag3 ASSET_TAGS")
+                    }
+                    
+                    if sourceBuildFile.settings != nil {
+                        throw failure("File that buildPhase is source contain settings")
+                    }
+                    
+                    if !pbxProj.rootObject!.attributes.keys.contains("knownAssetTags") {
+                        throw failure("PBXProject does not contain knownAssetTags")
+                    }
+                    
+                    try expect((pbxProj.rootObject!.attributes["knownAssetTags"] as! [String])) == ["tag1", "tag2", "tag3"]
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves #750

```
sources:
  - path: example.mp4
    resourceTags: ["example", "movie"]
```

If the file exists directly under `Foo` and `Foo` is specified in the sources, need to use excluded.

```
sources:
  - path: Foo
    excludes:
      - "example.mp4"
  - path: Foo/example.mp4
    resourceTags: ["example", "movie"]
```