### PR TITLE
Add spec validation for scheme test targets and tweak docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Fixed
+- Validate scheme test action and test coverage target references before generating. [#775](https://github.com/yonaskolb/XcodeGen/pull/775) @liamnichols
+
 ## 2.13.0
 
 #### Added

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -714,8 +714,8 @@ Schemes allows for more control than the convenience [Target Scheme](#target-sch
 
 ```yaml
 targets:
-  myTarget: all
-  myTarget2: [test, run]
+  MyTarget: all
+  FooLib/FooTarget: [test, run]
 parallelizeBuild: true
 buildImplicitDependencies: true
 ```

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -16,7 +16,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidTargetConfigFile(target: String, configFile: String, config: String)
         case invalidTargetSchemeConfigVariant(target: String, configVariant: String, configType: ConfigType)
         case invalidTargetSchemeTest(target: String, testTarget: String)
-        case invalidSchemeTarget(scheme: String, target: String)
+        case invalidSchemeTarget(scheme: String, target: String, action: String)
         case invalidSchemeConfig(scheme: String, config: String)
         case invalidSwiftPackage(name: String, target: String)
         case invalidLocalPackage(String)
@@ -50,8 +50,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Target \(target.quoted) scheme has invalid test \(test.quoted)"
             case let .invalidConfigFile(configFile, config):
                 return "Invalid config file \(configFile.quoted) for config \(config.quoted)"
-            case let .invalidSchemeTarget(scheme, target):
-                return "Scheme \(scheme.quoted) has invalid build target \(target.quoted)"
+            case let .invalidSchemeTarget(scheme, target, action):
+                return "Scheme \(scheme.quoted) has invalid \(action) target \(target.quoted)"
             case let .invalidSchemeConfig(scheme, config):
                 return "Scheme \(scheme.quoted) has invalid build configuration \(config.quoted)"
             case let .invalidBuildSettingConfig(config):

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -209,12 +209,15 @@ class ProjectSpecTests: XCTestCase {
                     name: "scheme1",
                     build: .init(targets: [.init(target: "invalidTarget")]),
                     run: .init(config: "debugInvalid"),
+                    test: .init(config: "testInvalid", coverageTargets: ["SubProject/Yams"], targets: [.init(targetReference: "invalidTarget")]),
                     archive: .init(config: "releaseInvalid")
                 )]
 
-                try expectValidationError(project, .invalidSchemeTarget(scheme: "scheme1", target: "invalidTarget"))
+                try expectValidationError(project, .invalidSchemeTarget(scheme: "scheme1", target: "invalidTarget", action: "build"))
                 try expectValidationError(project, .invalidSchemeConfig(scheme: "scheme1", config: "debugInvalid"))
                 try expectValidationError(project, .invalidSchemeConfig(scheme: "scheme1", config: "releaseInvalid"))
+                try expectValidationError(project, .invalidSchemeTarget(scheme: "scheme1", target: "invalidTarget", action: "test"))
+                try expectValidationError(project, .invalidProjectReference(scheme: "scheme1", reference: "SubProject"))
             }
 
             $0.it("fails with invalid project reference in scheme") {


### PR DESCRIPTION
As we roll out XcodeGen on our project, I got stumped for a little while when trying to create a Scheme definition that includes targets from a referenced project (and not a target defined in the spec).

It wasn't immediately obvious to me that I needed to use the `ProjectName/TargetName` syntax for this to work since in Xcode, the GUI doesn't expose the fact that it does this for you.. After I figured that out, I decided to update the docs to include the `FooLib/FooTarget` example previously used in the document to hopefully help anybody facing a similar situation in the future. 

After I made the changes and run the generator, I then hit a thrown exception with a different error that threw me off again until I debugged slightly to realise that the SpecValidation wasn't checking target references defined in the Test action (I'd only updated the build action)... To help make this a bit more obvious, I've expanded the validator to check the test actions target references as well as coverage target references in a similar way to how the build targets were being validated. 

Thanks again for the great work so far! 🚀 