### PR TITLE
Fix #784 Swift Package Manager (Embed & Sign) for dynamic packages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Added
+- Support Swift Package Manager (Embed & Sign/Embed Without Signing) for dynamic packages. [#788](https://github.com/yonaskolb/XcodeGen/pull/788)
+
 #### Fixed
 - Set `defaultConfigurationName` for every target which is defined in a project. [#787](https://github.com/yonaskolb/XcodeGen/pull/787)
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -821,7 +821,7 @@ public class PBXProjGenerator {
                     dependencies.append(targetDependency)
                 }
                 
-                if embed {
+                if dependency.embed == true {
                     let embedFile = addObject(
                         PBXBuildFile(product: packageDependency,
                                      settings: getEmbedSettings(dependency: dependency, codeSign: dependency.codeSign ?? true))

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -820,6 +820,14 @@ public class PBXProjGenerator {
                     )
                     dependencies.append(targetDependency)
                 }
+                
+                if embed {
+                    let embedFile = addObject(
+                        PBXBuildFile(product: packageDependency,
+                                     settings: getEmbedSettings(dependency: dependency, codeSign: dependency.codeSign ?? true))
+                    )
+                    copyFrameworksReferences.append(embedFile)
+                }
             case .bundle:
                 // Static and dynamic libraries can't copy resources
                 guard target.type != .staticLibrary && target.type != .dynamicLibrary else { break }

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -8,9 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		2DA7998902987953B119E4CE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F7EFEE613987D1E1258A60 /* AppDelegate.swift */; };
+		3986ED6965842721C46C0452 /* SwiftRoaring in Frameworks */ = {isa = PBXBuildFile; productRef = 836BDD793C9003A2E7BD17F0 /* SwiftRoaring */; };
+		3F5D08B766861EB128ED491C /* SwiftRoaring in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 836BDD793C9003A2E7BD17F0 /* SwiftRoaring */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		578E78BC3627CF48FB2CE129 /* App.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = A9601593D0AD02931266A4E5 /* App.xctestplan */; };
 		78E2E1F9F271C0C4CDA04BD9 /* StaticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F7AFEF8ECCC678519EA643C /* StaticLibrary.a */; };
 		9C4AD0711D706FD3ED0E436D /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C17B77601A9D1B7895AB42 /* StaticLibrary.swift */; };
+		B89EA0F3859878A1DCF7BAFD /* Codability in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 16E6FE01D5BD99F78D4A17E2 /* Codability */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE46CBA5671B951B546C8673 /* Codability in Frameworks */ = {isa = PBXBuildFile; productRef = 16E6FE01D5BD99F78D4A17E2 /* Codability */; };
 		E368431019ABC696E4FFC0CF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E22B8BCC18A29EFE1DE3BE4 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
@@ -24,6 +27,21 @@
 			remoteInfo = StaticLibrary;
 		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		528B26CADD32E3F39B813BEE /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				B89EA0F3859878A1DCF7BAFD /* Codability in Embed Frameworks */,
+				3F5D08B766861EB128ED491C /* SwiftRoaring in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		097F2DB5622B591E21BC3C73 /* App.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -42,6 +60,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE46CBA5671B951B546C8673 /* Codability in Frameworks */,
+				3986ED6965842721C46C0452 /* SwiftRoaring in Frameworks */,
 				78E2E1F9F271C0C4CDA04BD9 /* StaticLibrary.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -109,10 +128,12 @@
 			);
 			dependencies = (
 				D85FFB99444DD260A72DDDA7 /* PBXTargetDependency */,
+				DDD17C561AD5065DF4FA4072 /* PBXTargetDependency */,
 			);
 			name = StaticLibrary;
 			packageProductDependencies = (
 				AF233B61592982A7F6431FC6 /* Codability */,
+				CBF8EB1FEC788CBD14D88FB4 /* SwiftRoaring */,
 			);
 			productName = StaticLibrary;
 			productReference = 3F7AFEF8ECCC678519EA643C /* StaticLibrary.a */;
@@ -125,6 +146,7 @@
 				460F52476B5219D2CDA494C2 /* Sources */,
 				F77D37B94534F63D9B461F30 /* Resources */,
 				796E7DE873F16699BD82FFEA /* Frameworks */,
+				528B26CADD32E3F39B813BEE /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -134,6 +156,7 @@
 			name = App;
 			packageProductDependencies = (
 				16E6FE01D5BD99F78D4A17E2 /* Codability */,
+				836BDD793C9003A2E7BD17F0 /* SwiftRoaring */,
 			);
 			productName = App;
 			productReference = 097F2DB5622B591E21BC3C73 /* App.app */;
@@ -160,6 +183,7 @@
 			mainGroup = 218F6C96DF9E182F526258CF;
 			packageReferences = (
 				5BA91390AE78D2EE15C60091 /* XCRemoteSwiftPackageReference "Codability" */,
+				E3887F3CB2C069E70D98092F /* XCRemoteSwiftPackageReference "SwiftRoaring" */,
 			);
 			projectDirPath = "";
 			projectRoot = "";
@@ -229,6 +253,10 @@
 		D85FFB99444DD260A72DDDA7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = AF233B61592982A7F6431FC6 /* Codability */;
+		};
+		DDD17C561AD5065DF4FA4072 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = CBF8EB1FEC788CBD14D88FB4 /* SwiftRoaring */;
 		};
 /* End PBXTargetDependency section */
 
@@ -448,6 +476,14 @@
 				minimumVersion = 0.2.1;
 			};
 		};
+		E3887F3CB2C069E70D98092F /* XCRemoteSwiftPackageReference "SwiftRoaring" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/piotte13/SwiftRoaring";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.4;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -456,10 +492,20 @@
 			package = 5BA91390AE78D2EE15C60091 /* XCRemoteSwiftPackageReference "Codability" */;
 			productName = Codability;
 		};
+		836BDD793C9003A2E7BD17F0 /* SwiftRoaring */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E3887F3CB2C069E70D98092F /* XCRemoteSwiftPackageReference "SwiftRoaring" */;
+			productName = SwiftRoaring;
+		};
 		AF233B61592982A7F6431FC6 /* Codability */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5BA91390AE78D2EE15C60091 /* XCRemoteSwiftPackageReference "Codability" */;
 			productName = Codability;
+		};
+		CBF8EB1FEC788CBD14D88FB4 /* SwiftRoaring */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E3887F3CB2C069E70D98092F /* XCRemoteSwiftPackageReference "SwiftRoaring" */;
+			productName = SwiftRoaring;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -8,12 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		2DA7998902987953B119E4CE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F7EFEE613987D1E1258A60 /* AppDelegate.swift */; };
-		3986ED6965842721C46C0452 /* SwiftRoaring in Frameworks */ = {isa = PBXBuildFile; productRef = 836BDD793C9003A2E7BD17F0 /* SwiftRoaring */; };
-		3F5D08B766861EB128ED491C /* SwiftRoaring in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 836BDD793C9003A2E7BD17F0 /* SwiftRoaring */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3986ED6965842721C46C0452 /* SwiftRoaringDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */; };
 		578E78BC3627CF48FB2CE129 /* App.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = A9601593D0AD02931266A4E5 /* App.xctestplan */; };
 		78E2E1F9F271C0C4CDA04BD9 /* StaticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F7AFEF8ECCC678519EA643C /* StaticLibrary.a */; };
 		9C4AD0711D706FD3ED0E436D /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C17B77601A9D1B7895AB42 /* StaticLibrary.swift */; };
-		B89EA0F3859878A1DCF7BAFD /* Codability in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 16E6FE01D5BD99F78D4A17E2 /* Codability */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B89EA0F3859878A1DCF7BAFD /* SwiftRoaringDynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE46CBA5671B951B546C8673 /* Codability in Frameworks */ = {isa = PBXBuildFile; productRef = 16E6FE01D5BD99F78D4A17E2 /* Codability */; };
 		E368431019ABC696E4FFC0CF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E22B8BCC18A29EFE1DE3BE4 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
@@ -35,8 +34,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				B89EA0F3859878A1DCF7BAFD /* Codability in Embed Frameworks */,
-				3F5D08B766861EB128ED491C /* SwiftRoaring in Embed Frameworks */,
+				B89EA0F3859878A1DCF7BAFD /* SwiftRoaringDynamic in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -60,7 +58,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE46CBA5671B951B546C8673 /* Codability in Frameworks */,
-				3986ED6965842721C46C0452 /* SwiftRoaring in Frameworks */,
+				3986ED6965842721C46C0452 /* SwiftRoaringDynamic in Frameworks */,
 				78E2E1F9F271C0C4CDA04BD9 /* StaticLibrary.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -133,7 +131,7 @@
 			name = StaticLibrary;
 			packageProductDependencies = (
 				AF233B61592982A7F6431FC6 /* Codability */,
-				CBF8EB1FEC788CBD14D88FB4 /* SwiftRoaring */,
+				C816AEB28ED71C3C47F31B98 /* SwiftRoaringDynamic */,
 			);
 			productName = StaticLibrary;
 			productReference = 3F7AFEF8ECCC678519EA643C /* StaticLibrary.a */;
@@ -156,7 +154,7 @@
 			name = App;
 			packageProductDependencies = (
 				16E6FE01D5BD99F78D4A17E2 /* Codability */,
-				836BDD793C9003A2E7BD17F0 /* SwiftRoaring */,
+				DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */,
 			);
 			productName = App;
 			productReference = 097F2DB5622B591E21BC3C73 /* App.app */;
@@ -256,7 +254,7 @@
 		};
 		DDD17C561AD5065DF4FA4072 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = CBF8EB1FEC788CBD14D88FB4 /* SwiftRoaring */;
+			productRef = C816AEB28ED71C3C47F31B98 /* SwiftRoaringDynamic */;
 		};
 /* End PBXTargetDependency section */
 
@@ -492,20 +490,20 @@
 			package = 5BA91390AE78D2EE15C60091 /* XCRemoteSwiftPackageReference "Codability" */;
 			productName = Codability;
 		};
-		836BDD793C9003A2E7BD17F0 /* SwiftRoaring */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E3887F3CB2C069E70D98092F /* XCRemoteSwiftPackageReference "SwiftRoaring" */;
-			productName = SwiftRoaring;
-		};
 		AF233B61592982A7F6431FC6 /* Codability */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5BA91390AE78D2EE15C60091 /* XCRemoteSwiftPackageReference "Codability" */;
 			productName = Codability;
 		};
-		CBF8EB1FEC788CBD14D88FB4 /* SwiftRoaring */ = {
+		C816AEB28ED71C3C47F31B98 /* SwiftRoaringDynamic */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = E3887F3CB2C069E70D98092F /* XCRemoteSwiftPackageReference "SwiftRoaring" */;
-			productName = SwiftRoaring;
+			productName = SwiftRoaringDynamic;
+		};
+		DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E3887F3CB2C069E70D98092F /* XCRemoteSwiftPackageReference "SwiftRoaring" */;
+			productName = SwiftRoaringDynamic;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -47,15 +47,6 @@
         }
       },
       {
-        "package": "Shell",
-        "repositoryURL": "https://github.com/tuist/Shell",
-        "state": {
-          "branch": null,
-          "revision": "d38121f89401db902b0d0bfc30b987e2c84c254e",
-          "version": "2.0.3"
-        }
-      },
-      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {
@@ -69,17 +60,35 @@
         "repositoryURL": "https://github.com/jakeheis/SwiftCLI.git",
         "state": {
           "branch": null,
-          "revision": "5318c37d3cacc8780f50b87a8840a6774320ebdf",
-          "version": "5.2.2"
+          "revision": "c72c4564f8c0a24700a59824880536aca45a4cae",
+          "version": "6.0.1"
+        }
+      },
+      {
+        "package": "SwiftRoaring",
+        "repositoryURL": "https://github.com/piotte13/SwiftRoaring",
+        "state": {
+          "branch": null,
+          "revision": "9104cf3f35e7a38c9fb633084c7adb63a9f27f8b",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "package": "Version",
+        "repositoryURL": "https://github.com/mxcl/Version",
+        "state": {
+          "branch": null,
+          "revision": "a94b48f36763c05629fc102837398505032dead9",
+          "version": "2.0.0"
         }
       },
       {
         "package": "XcodeProj",
-        "repositoryURL": "https://github.com/tuist/xcodeproj.git",
+        "repositoryURL": "https://github.com/tuist/XcodeProj.git",
         "state": {
           "branch": null,
-          "revision": "aefcbf59cea5b0831837ed2f385e6dfd80d82cc9",
-          "version": "7.1.0"
+          "revision": "f32704e01d2752bdc17cde3963bee4256c1f4df4",
+          "version": "7.8.0"
         }
       },
       {

--- a/Tests/Fixtures/SPM/project.yml
+++ b/Tests/Fixtures/SPM/project.yml
@@ -3,6 +3,9 @@ packages:
   Codability:
     url: https://github.com/yonaskolb/Codability
     majorVersion: 0.2.1
+  SwiftRoaring:
+    url: https://github.com/piotte13/SwiftRoaring
+    majorVersion: 1.0.4
 localPackages:
  - ../../.. #XcodeGen itself
 targets:
@@ -13,6 +16,7 @@ targets:
     scheme: {}
     dependencies:
       - package: Codability
+      - package: SwiftRoaring
       - target: StaticLibrary
   StaticLibrary:
     type: library.static
@@ -20,3 +24,4 @@ targets:
     sources: StaticLibrary
     dependencies:
       - package: Codability
+      - package: SwiftRoaring

--- a/Tests/Fixtures/SPM/project.yml
+++ b/Tests/Fixtures/SPM/project.yml
@@ -17,6 +17,8 @@ targets:
     dependencies:
       - package: Codability
       - package: SwiftRoaring
+        product: SwiftRoaringDynamic
+        embed: true
       - target: StaticLibrary
   StaticLibrary:
     type: library.static
@@ -25,3 +27,4 @@ targets:
     dependencies:
       - package: Codability
       - package: SwiftRoaring
+        product: SwiftRoaringDynamic


### PR DESCRIPTION
Swift Package Manager dynamic dependencies declared like:

```swift
.library(name: "MyLib", type: .dynamic, targets: ["MyLib"])
```

Are embedded (**Embed & Sign** or **Embed Without Signing** if `codeSign: false`) when you declare `embed: true` in package dependency definition:

![Captura de pantalla 2020-02-19 a las 16 35 06](https://user-images.githubusercontent.com/297950/74848318-d7f9cb00-5337-11ea-861a-854259f0c7f8.jpg)

And included here:

![Captura de pantalla 2020-02-19 a las 16 35 34](https://user-images.githubusercontent.com/297950/74848408-eea02200-5337-11ea-998a-b36b9e9f9084.jpg)