### PR TITLE
Skip inserting build path when the path is the current path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Next Version
 
 #### Fixed
-- Set `defaultConfigurationName` for every target which is defined in a project. [#787](https://github.com/yonaskolb/XcodeGen/pull/787)
+- Set `defaultConfigurationName` for every target which is defined in a project. [#787](https://github.com/yonaskolb/XcodeGen/pull/787) @ken0nek
 - Set `TEST_TARGET_NAME` only when a project has UITest bundle. [#792](https://github.com/yonaskolb/XcodeGen/pull/792) @ken0nek
+- Skip inserting the build path when the path to be added is the current path. [#790](https://github.com/yonaskolb/XcodeGen/pull/790) @ken0nek
 
 ## 2.13.1
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -693,8 +693,10 @@ public class PBXProjGenerator {
 
             case .framework:
                 if !dependency.implicit {
-                    let buildPath = Path(dependency.reference).parent().string.quoted
-                    frameworkBuildPaths.insert(buildPath)
+                    if Path(dependency.reference).parent().absolute() != Path.current {
+                        let buildPath = Path(dependency.reference).parent().string.quoted
+                        frameworkBuildPaths.insert(buildPath)
+                    }
                 }
 
                 let fileReference: PBXFileElement


### PR DESCRIPTION
I think we don't have to add the current path to `FRAMEWORK_SEARCH_PATH`.

```diff
-                               FRAMEWORK_SEARCH_PATHS = (
-                                       "$(inherited)",
-                                       "\".\"",
-                               );
```