### PR TITLE
Revert "Add Base to known regions even if one doesn't exist"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Version
 
 #### Fixed
+- Revert "Add Base to known regions even if one doesn't exist" [#791](https://github.com/yonaskolb/XcodeGen/pull/792) @bryansum
 - Set `defaultConfigurationName` for every target which is defined in a project. [#787](https://github.com/yonaskolb/XcodeGen/pull/787)
 - Set `TEST_TARGET_NAME` only when a project has UITest bundle. [#792](https://github.com/yonaskolb/XcodeGen/pull/792) @ken0nek
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -288,9 +288,10 @@ public class PBXProjGenerator {
         if !assetTags.isEmpty {
             projectAttributes["knownAssetTags"] = assetTags
         }
-        
-        let knownRegions = sourceGenerator.knownRegions
-        pbxProject.knownRegions = (knownRegions.isEmpty ? ["en"] : knownRegions).union(["Base"]).sorted()
+
+        let knownRegions = sourceGenerator.knownRegions.sorted()
+        pbxProject.knownRegions = knownRegions.isEmpty ? ["en"] : knownRegions
+
         pbxProject.packages = packageReferences.sorted { $0.key < $1.key }.map { $1 }
 
         let allTargets: [PBXTarget] = targetObjects.valueArray + targetAggregateObjects.valueArray

--- a/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
@@ -321,7 +321,6 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				Base,
 				en,
 			);
 			mainGroup = 293D0FF827366B513839236A;

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -154,7 +154,6 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				Base,
 				en,
 			);
 			mainGroup = 218F6C96DF9E182F526258CF;

--- a/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
@@ -87,7 +87,6 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				Base,
 				en,
 			);
 			mainGroup = 4E8CFA4275C972686621210C;

--- a/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
@@ -59,7 +59,6 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				Base,
 				en,
 			);
 			mainGroup = 2D08B11F4EE060D112B7BCA1;


### PR DESCRIPTION
This reverts commit 98472a3d882b0a1bf421532d1a652907d543eb0c as this was agreed that we should not silence this "Enable Base internationalization" Xcode warning by default. 

To reproduce warning:
* create a new project in Xcode 11.0
* remove base internationalization
* open project in any of 11.1, 11.3.1, 11.4 beta 2

To silence this warning after this change for those without a Base.lproj folder, run

```sh
export SRC="."
mkdir -p $SRC/Base.lproj
touch $SRC/Base.lproj/.gitkeep
```

which will force xcodegen to detect base internationalization and thus remove the warning.