### PR TITLE
Set `TEST_TARGET_NAME` only when a project has UITest bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 #### Fixed
 - Set `defaultConfigurationName` for every target which is defined in a project. [#787](https://github.com/yonaskolb/XcodeGen/pull/787)
+- Set `TEST_TARGET_NAME` only when a project has UITest bundle. [#792](https://github.com/yonaskolb/XcodeGen/pull/792) @ken0nek
 
 ## 2.13.1
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -1083,7 +1083,7 @@ public class PBXProjGenerator {
             }
 
             // automatically set test target name
-            if target.type == .uiTestBundle || target.type == .unitTestBundle,
+            if target.type == .uiTestBundle,
                 !project.targetHasBuildSetting("TEST_TARGET_NAME", target: target, config: config) {
                 for dependency in target.dependencies {
                     if dependency.type == .target,

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -1618,14 +1618,8 @@
 					0867B0DACEF28C11442DE8F7 = {
 						ProvisioningStyle = Automatic;
 					};
-					71E2BDAC4B8E8FC2BBF75C55 = {
-						TestTargetID = 020A320BB3736FCDE6CC4E70;
-					};
 					BF3693DCA6182D7AEC410AFC = {
 						CUSTOM = value;
-					};
-					DC2F16BAA6E13B44AB62F888 = {
-						TestTargetID = 0867B0DACEF28C11442DE8F7;
 					};
 					F674B2CFC4738EEC49BAD0DA = {
 						TestTargetID = 0867B0DACEF28C11442DE8F7;
@@ -2619,7 +2613,6 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Staging Release";
 		};
@@ -2665,7 +2658,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
-				TEST_TARGET_NAME = App_macOS;
 			};
 			name = "Test Release";
 		};
@@ -2993,7 +2985,6 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Staging Debug";
 		};
@@ -3015,7 +3006,6 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Test Debug";
 		};
@@ -3213,7 +3203,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
-				TEST_TARGET_NAME = App_macOS;
 			};
 			name = "Test Debug";
 		};
@@ -3389,7 +3378,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
-				TEST_TARGET_NAME = App_macOS;
 			};
 			name = "Production Debug";
 		};
@@ -3411,7 +3399,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
-				TEST_TARGET_NAME = App_macOS;
 			};
 			name = "Production Release";
 		};
@@ -4011,7 +3998,6 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Test Release";
 		};
@@ -4888,7 +4874,6 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Production Release";
 		};
@@ -5116,7 +5101,6 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
-				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Production Debug";
 		};
@@ -5692,7 +5676,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
-				TEST_TARGET_NAME = App_macOS;
 			};
 			name = "Staging Release";
 		};
@@ -5874,7 +5857,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
 				SDKROOT = macosx;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
-				TEST_TARGET_NAME = App_macOS;
 			};
 			name = "Staging Debug";
 		};


### PR DESCRIPTION
`TEST_TARGET_NAME` is only for UITest and I think we don't have to set this if we just have UnitTest.

ref: https://github.com/yonaskolb/XcodeGen/pull/452