### PR TITLE
Fix typo on Carthage from Usage.md

### DIFF
--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -122,7 +122,7 @@ By default these all have to be listed if you want to link and use them:
 ```yml
 targets:
   App:
-    frameworks:
+    dependencies:
       - carthage: ReactiveCocoa
       - carthage: ReactiveMapKit 
 ```
@@ -134,7 +134,7 @@ options:
   findCarthageFrameworks: true
 targets:
   App:
-    frameworks:
+    dependencies:
       - carthage: ReactiveCocoa # will find ReactiveMapKit as well
       - carthage: OtherCarthageDependency
         findFrameworks: false # disables the global option


### PR DESCRIPTION
I guess this is not `frameworks` but `dependencies` when using carthage dependencies.