### PR TITLE
Avoid copying ObjC interface header when SWIFT_INSTALL_OBJC_HEADER=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Fixed
+- Avoid copying ObjC interface header when SWIFT_INSTALL_OBJC_HEADER=false. [#805](https://github.com/yonaskolb/XcodeGen/pull/805) @kateinoigakukun
+
 ## 2.14.0
 
 #### Added

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -940,9 +940,11 @@ public class PBXProjGenerator {
         }
 
         let swiftObjCInterfaceHeader = project.getCombinedBuildSetting("SWIFT_OBJC_INTERFACE_HEADER_NAME", target: target, config: project.configs[0]) as? String
+        let swiftInstallObjCHeader = project.getCombinedBuildSetting("SWIFT_INSTALL_OBJC_HEADER", target: target, config: project.configs[0]) as? Bool
 
         if target.type == .staticLibrary
             && swiftObjCInterfaceHeader != ""
+            && swiftInstallObjCHeader != false
             && sourceFiles.contains(where: { $0.buildPhase == .sources && $0.path.extension == "swift" }) {
 
             let inputPaths = ["$(DERIVED_SOURCES_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)"]

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -822,11 +822,19 @@ class ProjectGeneratorTests: XCTestCase {
                     sources: [TargetSource(path: "StaticLibrary_Swift/StaticLibrary.swift")],
                     dependencies: []
                 )
-                let swiftStaticLibraryWithoutHeader = Target(
-                    name: "swiftStaticLibraryWithoutHeader",
+                let swiftStaticLibraryWithoutHeader1 = Target(
+                    name: "swiftStaticLibraryWithoutHeader1",
                     type: .staticLibrary,
                     platform: .iOS,
                     settings: Settings(buildSettings: ["SWIFT_OBJC_INTERFACE_HEADER_NAME": ""]),
+                    sources: [TargetSource(path: "StaticLibrary_Swift/StaticLibrary.swift")],
+                    dependencies: []
+                )
+                let swiftStaticLibraryWithoutHeader2 = Target(
+                    name: "swiftStaticLibraryWithoutHeader2",
+                    type: .staticLibrary,
+                    platform: .iOS,
+                    settings: Settings(buildSettings: ["SWIFT_INSTALL_OBJC_HEADER": false]),
                     sources: [TargetSource(path: "StaticLibrary_Swift/StaticLibrary.swift")],
                     dependencies: []
                 )
@@ -838,7 +846,7 @@ class ProjectGeneratorTests: XCTestCase {
                     dependencies: []
                 )
 
-                let targets = [swiftStaticLibraryWithHeader, swiftStaticLibraryWithoutHeader, objCStaticLibrary]
+                let targets = [swiftStaticLibraryWithHeader, swiftStaticLibraryWithoutHeader1, swiftStaticLibraryWithoutHeader2, objCStaticLibrary]
 
                 let project = Project(
                     basePath: fixturePath + "TestProject",
@@ -866,7 +874,8 @@ class ProjectGeneratorTests: XCTestCase {
                 )
 
                 try expect(scriptBuildPhases(target: swiftStaticLibraryWithHeader)) == [expectedScriptPhase]
-                try expect(scriptBuildPhases(target: swiftStaticLibraryWithoutHeader)) == []
+                try expect(scriptBuildPhases(target: swiftStaticLibraryWithoutHeader1)) == []
+                try expect(scriptBuildPhases(target: swiftStaticLibraryWithoutHeader2)) == []
                 try expect(scriptBuildPhases(target: objCStaticLibrary)) == []
             }
 


### PR DESCRIPTION
As same as `SWIFT_OBJC_INTERFACE_HEADER_NAME`, we should avoid copying ObjC interface header when `SWIFT_INSTALL_OBJC_HEADER` is false