### PR TITLE
Bugfix: settings override on occasion (v. 2.14.0)

### DIFF
--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -81,7 +81,7 @@ extension Project {
         buildSettings += settings.buildSettings
 
         for (configVariant, settings) in settings.configSettings {
-            let isPartialMatch = config.name.lowercased().contains(configVariant.lowercased())
+            let isPartialMatch = config.name.lowercased().split(separator: " ").contains(Substring(configVariant.lowercased()))
             if isPartialMatch {
                 let exactConfig = getConfig(configVariant)
                 let matchesExactlyToOtherConfig = exactConfig != nil && exactConfig?.name != config.name

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -223,6 +223,33 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(buildSettings["SETTING3"]).beNil()
             }
 
+            $0.it("doesn't mix up config settings for partially matching names") {
+                let project = Project(
+                    name: "test",
+                    configs: [
+                        Config(name: "Rod Release", type: .release),
+                        Config(name: "Prod Release", type: .release),
+                        Config(name: "Preprod Release", type: .release),
+                    ],
+                    settings: Settings(configSettings: [
+                        "Prod": ["SETTING1": "VALUE2"],
+                        "Rod": ["SETTING1": "VALUE1"],
+                        "Preprod": ["SETTING1": "VALUE3"],
+                    ])
+                )
+
+                var buildSettings = project.getProjectBuildSettings(config: project.configs[0])
+                try expect(buildSettings["SETTING1"] as? String) == "VALUE1"
+
+                // Rod settings shouldn't override Prod
+                buildSettings = project.getProjectBuildSettings(config: project.configs[1])
+                try expect(buildSettings["SETTING1"] as? String) == "VALUE2"
+
+                // Prod or Rod settings shouldn't override Preprod
+                buildSettings = project.getProjectBuildSettings(config: project.configs[2])
+                try expect(buildSettings["SETTING1"] as? String) == "VALUE3"
+            }
+
             $0.it("sets project SDKROOT if there is only a single platform") {
                 var project = Project(
                     name: "test",


### PR DESCRIPTION
**Problem**
On our project we have to use build configurations with prefixed names (e. g. **Test** and **ABTest**), and it leads to a situation, when **ABTest** build settings are overridden with **Test** ones.

**Solution**
Updated `getBuildSettings` function of `Project` to take this edge case into consideration.

**Unit testing note**
As `getBuildSettings` result depends on `settings.configSettings` enumeration order, which is undefined, sometimes this function works correctly even without a provided fix. So, added unit test case may not fail on old implementation from time to time. 