### PR TITLE
[WIP] Invalid resourcetags source to be throw error.

### DIFF
--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -185,6 +185,9 @@ extension Project {
                 if !source.optional && !sourcePath.exists {
                     errors.append(.invalidTargetSource(target: target.name, source: sourcePath.string))
                 }
+                if !source.resourceTags.isEmpty && source.buildPhase != .resources {
+                    errors.append(.invalidResourceTagBuildPhase(target: target.name, source: sourcePath.string))
+                }
             }
         }
 

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -32,6 +32,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidPerConfigSettings
         case invalidProjectReference(scheme: String, reference: String)
         case invalidProjectReferencePath(ProjectReference)
+        case invalidResourceTagBuildPhase(target: String, source: String)
 
         public var description: String {
             switch self {
@@ -79,6 +80,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Scheme \(scheme.quoted) has invalid project reference \(project.quoted)"
             case let .invalidProjectReferencePath(reference):
                 return "Project reference \(reference.name) has a project file path that doesn't exist \"\(reference.path)\""
+            case let .invalidResourceTagBuildPhase(target, source):
+                return "Target \(target.quoted) has a resourceTags \(source.quoted) which must have \"resources\" build pahse."
             }
         }
     }

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -136,7 +136,12 @@ class ProjectSpecTests: XCTestCase {
                     platform: .iOS,
                     settings: invalidSettings,
                     configFiles: ["invalidConfig": "invalidConfigFile"],
-                    sources: ["invalidSource"],
+                    sources: [
+                        "invalidSource",
+                        .init(path: "invalidSourceResourceTags",
+                              buildPhase: .headers,
+                              resourceTags: ["Tag1"])
+                    ],
                     dependencies: [
                         Dependency(type: .target, reference: "invalidDependency"),
                         Dependency(type: .package(product: nil), reference: "invalidPackage"),
@@ -160,6 +165,8 @@ class ProjectSpecTests: XCTestCase {
 
                 try expectValidationError(project, .missingConfigForTargetScheme(target: "target1", configType: .debug))
                 try expectValidationError(project, .missingConfigForTargetScheme(target: "target1", configType: .release))
+                
+                try expectValidationError(project, .invalidResourceTagBuildPhase(target: "target1", source: "invalidSourceResourceTags"))
 
                 project.targets[0].scheme?.configVariants = ["invalidVariant"]
                 try expectValidationError(project, .invalidTargetSchemeConfigVariant(target: "target1", configVariant: "invalidVariant", configType: .debug))

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -987,7 +987,6 @@ class SourceGeneratorTests: XCTestCase {
                         sources: [
                             TargetSource(path: "A/resourceFile.mp4", buildPhase: .resources, resourceTags: ["tag1", "tag2"]),
                             TargetSource(path: "A/resourceFile2.mp4", buildPhase: .resources, resourceTags: ["tag2", "tag3"]),
-                            TargetSource(path: "A/sourceFile.swift", buildPhase: .sources, resourceTags: ["tag1", "tag2"]),
                         ]
                     )
                     
@@ -1007,18 +1006,11 @@ class SourceGeneratorTests: XCTestCase {
                         names: ["A", "resourceFile2.mp4"]
                     ))
                     
-                    let sourceFileReference = try unwrap(pbxProj.getFileReference(
-                        paths: ["A", "sourceFile.swift"],
-                        names: ["A", "sourceFile.swift"]
-                    ))
-                    
                     try pbxProj.expectFile(paths: ["A", "resourceFile.mp4"],  buildPhase: .resources)
                     try pbxProj.expectFile(paths: ["A", "resourceFile2.mp4"], buildPhase: .resources)
-                    try pbxProj.expectFile(paths: ["A", "sourceFile.swift"], buildPhase: .sources)
                     
                     let resourceBuildFile  = try unwrap(pbxProj.buildFiles.first(where: { $0.file == resourceFileReference }))
                     let resourceBuildFile2 = try unwrap(pbxProj.buildFiles.first(where: { $0.file == resourceFileReference2 }))
-                    let sourceBuildFile = try unwrap(pbxProj.buildFiles.first(where: { $0.file == sourceFileReference }))
                     
                     if (resourceBuildFile.settings! as NSDictionary) != (["ASSET_TAGS": ["tag1", "tag2"]] as NSDictionary) {
                         throw failure("File does not contain tag1 and tag2 ASSET_TAGS")
@@ -1026,10 +1018,6 @@ class SourceGeneratorTests: XCTestCase {
                     
                     if (resourceBuildFile2.settings! as NSDictionary) != (["ASSET_TAGS": ["tag2", "tag3"]] as NSDictionary) {
                         throw failure("File does not contain tag2 and tag3 ASSET_TAGS")
-                    }
-                    
-                    if sourceBuildFile.settings != nil {
-                        throw failure("File that buildPhase is source contain settings")
                     }
                     
                     if !pbxProj.rootObject!.attributes.keys.contains("knownAssetTags") {


### PR DESCRIPTION
The `resourceTags` cannot be used in BuildPhase other than resource.
A incorrect spec should fail before generation.

https://github.com/yonaskolb/XcodeGen/blob/59ab2239227811f2607a4981c8d304219ca5f47d/Sources/XcodeGenKit/SourceGenerator.swift#L134