### PR TITLE
Fixed issue when linking and embeding static frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Improve speed of metadata parsing and dependency resolution. [#803](https://github.com/yonaskolb/XcodeGen/pull/803) @michaeleisel
 - Improve support for iOS sticker packs and add support for `launchAutomaticallySubstyle` to run schemes. [#824](https://github.com/yonaskolb/XcodeGen/pull/824) @scelis
 
+#### Fixed
+- Fixed issue when linking and embeding static frameworks: they should be linked and NOT embed. [#820](https://github.com/yonaskolb/XcodeGen/pull/820) @acecilia
+
 ## 2.15.1
 
 #### Fixed

--- a/Sources/ProjectSpec/XCProjExtensions.swift
+++ b/Sources/ProjectSpec/XCProjExtensions.swift
@@ -52,6 +52,27 @@ extension PBXProductType {
             return false
         }
     }
+
+    /// Function to determine when a dependendency should be embedded into the target
+    public func shouldEmbed(_ dependencyType: PBXProductType) -> Bool {
+        switch dependencyType {
+        case .staticLibrary, .staticFramework:
+            // Some dependendencies should not be embed, independently of the target type
+            return false
+
+        default:
+            if isApp {
+                // If target is an app, all dependencies should be embed (except for the ones mentioned above)
+                return true
+            } else if isTest, [.framework, .bundle].contains(dependencyType) {
+                // If target is test, some dependencies should be embed (depending on their type)
+                return true
+            } else {
+                // If none of the above, do not embed the dependency
+                return false
+            }
+        }
+    }
 }
 
 extension Platform {

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -594,6 +594,7 @@ class ProjectGeneratorTests: XCTestCase {
                     "FrameworkE.framework",
                     "FrameworkF.framework",
                     "CarthageA.framework",
+                    "CarthageB.framework",
                     "CarthageC.framework",
                 ])
                 expectedEmbeddedFrameworks[iosFrameworkB.name] = Set([
@@ -623,10 +624,12 @@ class ProjectGeneratorTests: XCTestCase {
                     "FrameworkZ.framework",
                     "FrameworkX.framework",
                     "CarthageZ.framework",
+                    "FrameworkF.framework",
                     "FrameworkC.framework",
                     iosFrameworkB.filename,
                     "FrameworkD.framework",
                     "CarthageA.framework",
+                    "CarthageB.framework",
                     "CarthageD.framework",
                 ])
                 expectedEmbeddedFrameworks[appTest.name] = Set([
@@ -710,7 +713,7 @@ class ProjectGeneratorTests: XCTestCase {
                     if !expectedLinkedFiles.isEmpty {
                         let linkFrameworks = (frameworkPhases[0].files ?? [])
                             .compactMap { $0.file?.nameOrPath }
-                        try expect(Set(linkFrameworks)) == expectedLinkedFiles
+                        try expect(Array(Set(linkFrameworks)).sorted()) == Array(expectedLinkedFiles).sorted()
                     }
 
                     var expectedCopyFilesPhasesCount = 0


### PR DESCRIPTION
From what I understand, static frameworks are:

1. Linked as usual (to be able to use them)
2. Never embed, as their binary becomes part of the binary that depends on them

For example, given this (SwiftModule1, SwiftModule2 and SwiftModule3 are static frameworks; SnapKit is a dynamic one):

```
options:
  transitivelyLinkDependencies: true

targets:
  SwiftModule1:
    type: framework.static
    ...
    dependencies:
    - framework: SwiftModule2.framework
      implicit: true
      embed: false
    - framework: ../../Carthage/Build/iOS/SnapKit.framework
  SwiftModule1Tests:
    type: bundle.unit-test
    ...
    dependencies:
    - target: SwiftModule1
    - framework: SwiftModule3.framework
      implicit: true
      embed: false
      
```

In the target `SwiftModule1Tests`, when generating the xcode project you find that:
- Link binary with libraries: SnapKit, SwiftModule1, SwiftModule3
- Embed frameworks: SnapKit, SwiftModule1

I believe that is wrong, and instead it should be:
- Link binary with libraries: SnapKit, SwiftModule1, SwiftModule2, SwiftModule3
- Embed frameworks: SnapKit