### PR TITLE
Add scheme actions to build step for TargetScheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 - Prefix static library target filenames with 'lib' to match Xcode. [#831](https://github.com/yonaskolb/XcodeGen/pull/831) @ileitch
 - Fixed duplicate addition of carthage static frameworks. [#829](https://github.com/yonaskolb/XcodeGen/pull/829) @funzin
 
+#### Fixed
+- Set `preActions` and `postActions` on the `build` action of a TargetScheme instead of the other actions. [#823](https://github.com/yonaskolb/XcodeGen/pull/823) @brentleyjones
+
 ## 2.15.1
 
 #### Fixed

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -602,8 +602,8 @@ This is a convenience used to automatically generate schemes for a target based 
 - [ ] **region**: **String** - a String that indicates the region used for running and testing. This defaults to nil
 - [ ] **commandLineArguments**: **[String:Bool]** - a dictionary from the argument name (`String`) to if it is enabled (`Bool`). These arguments will be added to the Test, Profile and Run scheme actions
 - [ ] **environmentVariables**: **[[Environment Variable](#environment-variable)]** or **[String:String]** - environment variables for Run, Test and Profile scheme actions. When passing a dictionary, every key-value entry maps to a corresponding variable that is enabled.
-- [ ] **preActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *before* all actions
-- [ ] **postActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *after* all actions
+- [ ] **preActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *before* the build action
+- [ ] **postActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *after* the build action
 
 For example, the spec below would create 3 schemes called:
 

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -314,13 +314,13 @@ extension Scheme {
             name: name,
             build: .init(
                 targets: Scheme.buildTargets(for: target, project: project),
-                buildImplicitDependencies: targetScheme.buildImplicitDependencies
+                buildImplicitDependencies: targetScheme.buildImplicitDependencies,
+                preActions: targetScheme.preActions,
+                postActions: targetScheme.postActions
             ),
             run: .init(
                 config: debugConfig,
                 commandLineArguments: targetScheme.commandLineArguments,
-                preActions: targetScheme.preActions,
-                postActions: targetScheme.postActions,
                 environmentVariables: targetScheme.environmentVariables,
                 disableMainThreadChecker: targetScheme.disableMainThreadChecker,
                 stopOnEveryMainThreadCheckerIssue: targetScheme.stopOnEveryMainThreadCheckerIssue,
@@ -333,8 +333,6 @@ extension Scheme {
                 disableMainThreadChecker: targetScheme.disableMainThreadChecker,
                 commandLineArguments: targetScheme.commandLineArguments,
                 targets: targetScheme.testTargets,
-                preActions: targetScheme.preActions,
-                postActions: targetScheme.postActions,
                 environmentVariables: targetScheme.environmentVariables,
                 language: targetScheme.language,
                 region: targetScheme.region
@@ -342,17 +340,13 @@ extension Scheme {
             profile: .init(
                 config: releaseConfig,
                 commandLineArguments: targetScheme.commandLineArguments,
-                preActions: targetScheme.preActions,
-                postActions: targetScheme.postActions,
                 environmentVariables: targetScheme.environmentVariables
             ),
             analyze: .init(
                 config: debugConfig
             ),
             archive: .init(
-                config: releaseConfig,
-                preActions: targetScheme.preActions,
-                postActions: targetScheme.postActions
+                config: releaseConfig
             )
         )
     }

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -257,14 +257,13 @@ class SchemeGeneratorTests: XCTestCase {
 
                 let xcscheme = try unwrap(xcodeProject.sharedData?.schemes.first)
 
-                try expect(xcscheme.launchAction?.preActions.count) == 1
-                try expect(xcscheme.launchAction?.preActions.first?.title) == "Run"
-                try expect(xcscheme.launchAction?.preActions.first?.scriptText) == "do"
+                try expect(xcscheme.buildAction?.preActions.count) == 1
+                try expect(xcscheme.buildAction?.preActions.first?.title) == "Run"
+                try expect(xcscheme.buildAction?.preActions.first?.scriptText) == "do"
+                try expect(xcscheme.buildAction?.postActions.first?.environmentBuildable?.blueprintName) == "MyApp"
 
-                try expect(xcscheme.testAction?.postActions.count) == 1
-                try expect(xcscheme.testAction?.postActions.first?.title) == "Run2"
-                try expect(xcscheme.testAction?.postActions.first?.scriptText) == "post"
-                try expect(xcscheme.testAction?.postActions.first?.environmentBuildable?.blueprintName) == "MyApp"
+                try expect(xcscheme.launchAction?.preActions.count) == 0
+                try expect(xcscheme.testAction?.postActions.count) == 0
             }
 
             $0.it("generates scheme using external project file") {


### PR DESCRIPTION
We say in the documentation that the preActions and postActions of a TargetScheme are applied to _all_ steps. They weren't being applied to the build step though.