### PR TITLE
Bugfix: Consider folders with dot in it when generating projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixed
 - Fixed issue when linking and embeding static frameworks: they should be linked and NOT embed. [#820](https://github.com/yonaskolb/XcodeGen/pull/820) @acecilia
+- Fixed issue when generating projects for paths with a dot in the folder for swift sources. [#826](https://github.com/yonaskolb/XcodeGen/pull/826)
 
 ## 2.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 #### Fixed
 - Fixed issue when linking and embeding static frameworks: they should be linked and NOT embed. [#820](https://github.com/yonaskolb/XcodeGen/pull/820) @acecilia
-- Fixed issue when generating projects for paths with a dot in the folder for swift sources. [#826](https://github.com/yonaskolb/XcodeGen/pull/826)
+- Fixed issue when generating projects for paths with a dot in the folder for swift sources. [#826](https://github.com/yonaskolb/XcodeGen/pull/826) @asifmohd
 
 ## 2.15.1
 

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -413,12 +413,14 @@ class SourceGenerator {
         let children = try getSourceChildren(targetSource: targetSource, dirPath: path, excludePaths: excludePaths, includePaths: includePaths)
 
         let createIntermediateGroups = targetSource.createIntermediateGroups ?? project.options.createIntermediateGroups
+        let directoryExtensionsToSkip = ["lproj", "bundle", "xcassets", "xcdatamodeld"]
 
         let directories = children
-            .filter { $0.isDirectory && $0.extension != "lproj" && $0.extension != "xcassets" && $0.extension != "bundle" && $0.extension != "xcdatamodeld" }
+            .filter { $0.isDirectory && !directoryExtensionsToSkip.contains($0.extension ?? "") }
 
+        let whitelistedDirectoryExtensionsForFilePath = ["xcdatamodeld", "xcdatamodel" , "xcassets" , "intentdefinition"]
         let filePaths = children
-            .filter { $0.isFile || $0.extension != nil && $0.extension != "lproj" && ($0.extension == "xcdatamodeld" || $0.extension == "xcdatamodel" || $0.extension == "xcassets" || $0.extension == "intentdefinition" || !$0.isDirectory) }
+            .filter { $0.isFile || $0.extension != nil && $0.extension != "lproj" && (whitelistedDirectoryExtensionsForFilePath.contains($0.extension ?? "") || !$0.isDirectory) }
 
         let localisedDirectories = children
             .filter { $0.extension == "lproj" }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -415,10 +415,10 @@ class SourceGenerator {
         let createIntermediateGroups = targetSource.createIntermediateGroups ?? project.options.createIntermediateGroups
 
         let directories = children
-            .filter { $0.isDirectory && $0.extension != "lproj" && $0.extension != "xcassets" && $0.extension != "bundle" }
+            .filter { $0.isDirectory && $0.extension != "lproj" && $0.extension != "xcassets" && $0.extension != "bundle" && $0.extension != "xcdatamodeld" }
 
         let filePaths = children
-            .filter { $0.isFile || $0.extension != nil && $0.extension != "lproj" && !$0.isDirectory }
+            .filter { $0.isFile || $0.extension != nil && $0.extension != "lproj" && ($0.extension == "xcdatamodeld" || $0.extension == "xcdatamodel" || $0.extension == "xcassets" || $0.extension == "intentdefinition" || !$0.isDirectory) }
 
         let localisedDirectories = children
             .filter { $0.extension == "lproj" }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -415,10 +415,10 @@ class SourceGenerator {
         let createIntermediateGroups = targetSource.createIntermediateGroups ?? project.options.createIntermediateGroups
 
         let directories = children
-            .filter { $0.isDirectory && $0.extension == nil && $0.extension != "lproj" }
+            .filter { $0.isDirectory && $0.extension != "lproj" && $0.extension != "xcassets" && $0.extension != "bundle" }
 
         let filePaths = children
-            .filter { $0.isFile || $0.extension != nil && $0.extension != "lproj" }
+            .filter { $0.isFile || $0.extension != nil && $0.extension != "lproj" && !$0.isDirectory }
 
         let localisedDirectories = children
             .filter { $0.extension == "lproj" }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -418,7 +418,7 @@ class SourceGenerator {
         let directories = children
             .filter { $0.isDirectory && !directoryExtensionsToSkip.contains($0.extension ?? "") }
 
-        let whitelistedDirectoryExtensionsForFilePath = ["xcdatamodeld", "xcdatamodel" , "xcassets" , "intentdefinition"]
+        let whitelistedDirectoryExtensionsForFilePath = ["xcdatamodeld", "xcdatamodel" , "xcassets"]
         let filePaths = children
             .filter { $0.isFile || $0.extension != nil && $0.extension != "lproj" && (whitelistedDirectoryExtensionsForFilePath.contains($0.extension ?? "") || !$0.isDirectory) }
 

--- a/Tests/Fixtures/TestProject/App_iOS/FolderWithDot2.0/SwiftFileInDotPath.swift
+++ b/Tests/Fixtures/TestProject/App_iOS/FolderWithDot2.0/SwiftFileInDotPath.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension String {
+  func printHelloWorld() {
+    print("Hello World!")
+  }
+}

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		7F658343A505B824321E086B /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 2E1E747C7BC434ADB80CC269 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
 		803B7CE086CFBA409F9D1ED7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 108BB29172D27BE3BD1E7F35 /* Assets.xcassets */; };
 		818D448D4DDD6649B5B26098 /* example.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 28360ECA4D727FAA58557A81 /* example.mp4 */; settings = {ASSET_TAGS = (tag1, tag2, ); }; };
+		87927928A8A3460166ACB819 /* SwiftFileInDotPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F430AABE04B7499B458D9DB /* SwiftFileInDotPath.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		900CFAD929CAEE3861127627 /* MyBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B5068D64404C61A67A18458 /* MyBundle.bundle */; };
 		95DD9941E1529FD2AE1A191D /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359F /* StaticLibrary_ObjC.h */; };
 		96B55C0F660235FE6BDD8869 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -488,6 +489,7 @@
 		28360ECA4D727FAA58557A81 /* example.mp4 */ = {isa = PBXFileReference; path = example.mp4; sourceTree = "<group>"; };
 		2A5F527F2590C14956518174 /* FrameworkFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkFile.swift; sourceTree = "<group>"; };
 		2E1E747C7BC434ADB80CC269 /* Headers */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Headers; sourceTree = SOURCE_ROOT; };
+		2F430AABE04B7499B458D9DB /* SwiftFileInDotPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFileInDotPath.swift; sourceTree = "<group>"; };
 		33F6DCDC37D2E66543D4965D /* App_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		34F13B632328979093CE6056 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3571E41E19A5AB8AAAB04109 /* StandaloneAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = StandaloneAssets.xcassets; sourceTree = "<group>"; };
@@ -688,6 +690,7 @@
 		1F2DE413CF2CB54988158172 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				2F80635127D17ECB7748067B /* FolderWithDot2.0 */,
 				F0D48A913C087D049C8EDDD7 /* App.entitlements */,
 				7F1A2F579A6F79C62DDA0571 /* AppDelegate.swift */,
 				3797E591F302ECC0AA2FC607 /* Assets.xcassets */,
@@ -760,6 +763,14 @@
 				F2950763C4C568CC85021D18 /* module.modulemap */,
 			);
 			path = Module;
+			sourceTree = "<group>";
+		};
+		2F80635127D17ECB7748067B /* FolderWithDot2.0 */ = {
+			isa = PBXGroup;
+			children = (
+				2F430AABE04B7499B458D9DB /* SwiftFileInDotPath.swift */,
+			);
+			path = FolderWithDot2.0;
 			sourceTree = "<group>";
 		};
 		3F2E22B7AB20FA42CD205C2A /* CopyFiles */ = {
@@ -2025,6 +2036,7 @@
 				F788A3FA1CE6489BC257C1C3 /* Model.xcdatamodeld in Sources */,
 				58C18019E71E372F635A3FB4 /* MoreUnder.swift in Sources */,
 				5D10822B0E7C33DD6979F656 /* Standalone.swift in Sources */,
+				87927928A8A3460166ACB819 /* SwiftFileInDotPath.swift in Sources */,
 				2730C6D0A35AED4ADD6EDF17 /* ViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -405,6 +405,8 @@ class SourceGeneratorTests: XCTestCase {
                       - c.jpg
                     - D2.0:
                       - d.swift
+                    - E.bundle:
+                      - e.json
                 """
                 try createDirectories(directories)
 
@@ -413,6 +415,7 @@ class SourceGeneratorTests: XCTestCase {
                     "Sources/A/B/b.swift",
                     "Sources/A/D2.0/d.swift",
                     "Sources/A/Assets.xcassets",
+                    "Sources/A/E.bundle/e.json",
                     "Sources/A/B/c.jpg",
                 ])
                 let project = Project(basePath: directoryPath, name: "Test", targets: [target])
@@ -423,6 +426,7 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFile(paths: ["Sources/A/D2.0", "d.swift"], names: ["D2.0", "d.swift"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["Sources/A/B", "c.jpg"], names: ["B", "c.jpg"], buildPhase: .resources)
                 try pbxProj.expectFile(paths: ["Sources/A", "Assets.xcassets"], names: ["A", "Assets.xcassets"], buildPhase: .resources)
+                try pbxProj.expectFile(paths: ["Sources/A/E.bundle", "e.json"], names: ["E.bundle", "e.json"], buildPhase: .resources)
             }
 
             $0.it("generates shared sources") {

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -62,6 +62,8 @@ class SourceGeneratorTests: XCTestCase {
                     - a.swift
                     - B:
                       - b.swift
+                    - C2.0:
+                      - c.swift
                 """
                 try createDirectories(directories)
 
@@ -71,6 +73,7 @@ class SourceGeneratorTests: XCTestCase {
                 let pbxProj = try project.generatePbxProj()
                 try pbxProj.expectFile(paths: ["Sources", "A", "a.swift"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["Sources", "A", "B", "b.swift"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: ["Sources", "A", "C2.0", "c.swift"], buildPhase: .sources)
             }
 
             $0.it("supports frameworks in sources") {
@@ -400,12 +403,15 @@ class SourceGeneratorTests: XCTestCase {
                     - B:
                       - b.swift
                       - c.jpg
+                    - D2.0:
+                      - d.swift
                 """
                 try createDirectories(directories)
 
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: [
                     "Sources/A/a.swift",
                     "Sources/A/B/b.swift",
+                    "Sources/A/D2.0/d.swift",
                     "Sources/A/Assets.xcassets",
                     "Sources/A/B/c.jpg",
                 ])
@@ -414,6 +420,7 @@ class SourceGeneratorTests: XCTestCase {
                 let pbxProj = try project.generatePbxProj()
                 try pbxProj.expectFile(paths: ["Sources/A", "a.swift"], names: ["A", "a.swift"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["Sources/A/B", "b.swift"], names: ["B", "b.swift"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: ["Sources/A/D2.0", "d.swift"], names: ["D2.0", "d.swift"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["Sources/A/B", "c.jpg"], names: ["B", "c.jpg"], buildPhase: .resources)
                 try pbxProj.expectFile(paths: ["Sources/A", "Assets.xcassets"], names: ["A", "Assets.xcassets"], buildPhase: .resources)
             }


### PR DESCRIPTION
Fixes #825 

Folders which would have a dot in it, would be added to Copy Bundle Resources even though it contained swift files

- This PR, updates the if checks for directories and file path in `SourceGenerator.swift`.
- I have added tests for the same
- Have updated the TestProject fixture as well