### PR TITLE
Fix handling of SWIFT_INSTALL_OBJC_HEADER when its value is YES/NO.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@
 - Fixed issue when generating projects for paths with a dot in the folder for swift sources. [#826](https://github.com/yonaskolb/XcodeGen/pull/826) @asifmohd
 - Prefix static library target filenames with 'lib' to match Xcode. [#831](https://github.com/yonaskolb/XcodeGen/pull/831) @ileitch
 - Fixed duplicate addition of carthage static frameworks. [#829](https://github.com/yonaskolb/XcodeGen/pull/829) @funzin
-
-#### Fixed
+- Fix handling of SWIFT_INSTALL_OBJC_HEADER when its value is YES/NO. [#827](https://github.com/yonaskolb/XcodeGen/pull/827) @ileitch
 - Set `preActions` and `postActions` on the `build` action of a TargetScheme instead of the other actions. [#823](https://github.com/yonaskolb/XcodeGen/pull/823) @brentleyjones
 
 ## 2.15.1

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -941,7 +941,15 @@ public class PBXProjGenerator {
         }
 
         let swiftObjCInterfaceHeader = project.getCombinedBuildSetting("SWIFT_OBJC_INTERFACE_HEADER_NAME", target: target, config: project.configs[0]) as? String
-        let swiftInstallObjCHeader = project.getCombinedBuildSetting("SWIFT_INSTALL_OBJC_HEADER", target: target, config: project.configs[0]) as? Bool
+        let swiftInstallObjCHeaderValue = project.getCombinedBuildSetting("SWIFT_INSTALL_OBJC_HEADER", target: target, config: project.configs[0])
+
+        var swiftInstallObjCHeader = true // Xcode default
+
+        if let boolValue = swiftInstallObjCHeaderValue as? Bool {
+            swiftInstallObjCHeader = boolValue
+        } else if let stringValue = swiftInstallObjCHeaderValue as? String {
+            swiftInstallObjCHeader = stringValue == "YES"
+        }
 
         if target.type == .staticLibrary
             && swiftObjCInterfaceHeader != ""

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -941,19 +941,11 @@ public class PBXProjGenerator {
         }
 
         let swiftObjCInterfaceHeader = project.getCombinedBuildSetting("SWIFT_OBJC_INTERFACE_HEADER_NAME", target: target, config: project.configs[0]) as? String
-        let swiftInstallObjCHeaderValue = project.getCombinedBuildSetting("SWIFT_INSTALL_OBJC_HEADER", target: target, config: project.configs[0])
-
-        var swiftInstallObjCHeader = true // Xcode default
-
-        if let boolValue = swiftInstallObjCHeaderValue as? Bool {
-            swiftInstallObjCHeader = boolValue
-        } else if let stringValue = swiftInstallObjCHeaderValue as? String {
-            swiftInstallObjCHeader = stringValue == "YES"
-        }
+        let swiftInstallObjCHeader = project.getBoolBuildSetting("SWIFT_INSTALL_OBJC_HEADER", target: target, config: project.configs[0]) ?? true // Xcode default
 
         if target.type == .staticLibrary
             && swiftObjCInterfaceHeader != ""
-            && swiftInstallObjCHeader != false
+            && swiftInstallObjCHeader
             && sourceFiles.contains(where: { $0.buildPhase == .sources && $0.path.extension == "swift" }) {
 
             let inputPaths = ["$(DERIVED_SOURCES_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)"]

--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -114,6 +114,18 @@ extension Project {
         return nil
     }
 
+    public func getBoolBuildSetting(_ setting: String, target: ProjectTarget, config: Config) -> Bool? {
+        guard let value = getCombinedBuildSetting(setting, target: target, config: config) else { return nil }
+
+        if let boolValue = value as? Bool {
+            return boolValue
+        } else if let stringValue = value as? String {
+            return stringValue == "YES"
+        }
+
+        return nil
+    }
+
     public func targetHasBuildSetting(_ setting: String, target: Target, config: Config) -> Bool {
         getCombinedBuildSetting(setting, target: target, config: config) != nil
     }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -841,6 +841,14 @@ class ProjectGeneratorTests: XCTestCase {
                     sources: [TargetSource(path: "StaticLibrary_Swift/StaticLibrary.swift")],
                     dependencies: []
                 )
+                let swiftStaticLibraryWithoutHeader3 = Target(
+                    name: "swiftStaticLibraryWithoutHeader3",
+                    type: .staticLibrary,
+                    platform: .iOS,
+                    settings: Settings(buildSettings: ["SWIFT_INSTALL_OBJC_HEADER": "NO"]),
+                    sources: [TargetSource(path: "StaticLibrary_Swift/StaticLibrary.swift")],
+                    dependencies: []
+                )
                 let objCStaticLibrary = Target(
                     name: "objCStaticLibrary",
                     type: .staticLibrary,
@@ -849,7 +857,7 @@ class ProjectGeneratorTests: XCTestCase {
                     dependencies: []
                 )
 
-                let targets = [swiftStaticLibraryWithHeader, swiftStaticLibraryWithoutHeader1, swiftStaticLibraryWithoutHeader2, objCStaticLibrary]
+                let targets = [swiftStaticLibraryWithHeader, swiftStaticLibraryWithoutHeader1, swiftStaticLibraryWithoutHeader2, swiftStaticLibraryWithoutHeader3, objCStaticLibrary]
 
                 let project = Project(
                     basePath: fixturePath + "TestProject",
@@ -879,6 +887,7 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(scriptBuildPhases(target: swiftStaticLibraryWithHeader)) == [expectedScriptPhase]
                 try expect(scriptBuildPhases(target: swiftStaticLibraryWithoutHeader1)) == []
                 try expect(scriptBuildPhases(target: swiftStaticLibraryWithoutHeader2)) == []
+                try expect(scriptBuildPhases(target: swiftStaticLibraryWithoutHeader3)) == []
                 try expect(scriptBuildPhases(target: objCStaticLibrary)) == []
             }
 


### PR DESCRIPTION
I'm not sure if true/false literals are valid values for xcconfig, but I guess we'll need to continue supporting it for backwards compatibility.

For reference: https://github.com/yonaskolb/XcodeGen/pull/805
/cc @kateinoigakukun 