### PR TITLE
Add --project-root option to generate command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 #### Added
 - Improve speed of metadata parsing and dependency resolution. [#803](https://github.com/yonaskolb/XcodeGen/pull/803) @michaeleisel
 - Improve support for iOS sticker packs and add support for `launchAutomaticallySubstyle` to run schemes. [#824](https://github.com/yonaskolb/XcodeGen/pull/824) @scelis
+- Add --project-root option to generate command. [#828](https://github.com/yonaskolb/XcodeGen/pull/828) @ileitch
 
 #### Fixed
 - Fixed issue when linking and embeding static frameworks: they should be linked and NOT embed. [#820](https://github.com/yonaskolb/XcodeGen/pull/820) @acecilia

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -15,10 +15,10 @@ public class SpecLoader {
         self.version = version
     }
 
-    public func loadProject(path: Path, variables: [String: String] = [:]) throws -> Project {
+    public func loadProject(path: Path, projectRoot: Path? = nil, variables: [String: String] = [:]) throws -> Project {
         let spec = try SpecFile(path: path)
         let resolvedDictionary = spec.resolvedDictionary(variables: variables)
-        let project = try Project(basePath: spec.basePath, jsonDictionary: resolvedDictionary)
+        let project = try Project(basePath: projectRoot ?? spec.basePath, jsonDictionary: resolvedDictionary)
 
         self.project = project
         projectDictionary = resolvedDictionary

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -15,11 +15,11 @@ class ProjectCommand: Command {
     @Key("-s", "--spec", description: "The path to the project spec file. Defaults to project.yml")
     var spec: Path?
 
-    @Flag("-n", "--no-env", description: "Disable environment variable expansions")
-    var disableEnvExpansion: Bool
-
     @Key("-r", "--project-root", description: "The path to the project root directory. Defaults to the directory containing the project spec.")
     var projectRoot: Path?
+
+    @Flag("-n", "--no-env", description: "Disable environment variable expansions")
+    var disableEnvExpansion: Bool
 
     init(version: Version, name: String, shortDescription: String) {
         self.version = version

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -18,6 +18,9 @@ class ProjectCommand: Command {
     @Flag("-n", "--no-env", description: "Disable environment variable expansions")
     var disableEnvExpansion: Bool
 
+    @Key("-r", "--project-root", description: "The path to the project root directory. Defaults to the directory containing the project spec.")
+    var projectRoot: Path?
+
     init(version: Version, name: String, shortDescription: String) {
         self.version = version
         self.name = name
@@ -38,7 +41,7 @@ class ProjectCommand: Command {
         let variables: [String: String] = disableEnvExpansion ? [:] : ProcessInfo.processInfo.environment
 
         do {
-            project = try specLoader.loadProject(path: projectSpecPath, variables: variables)
+            project = try specLoader.loadProject(path: projectSpecPath, projectRoot: projectRoot, variables: variables)
         } catch {
             throw GenerationError.projectSpecParsingError(error)
         }


### PR DESCRIPTION
I'm integrating XcodeGen into a rather large & complex project, and thus I'm trying to keep the directory structure clean.

I've a project named `TTKit`, and I'm placing the `project.yml` and all includes in `TTKit/Config`. Currently this requires that I prefix all file references with `../` to access the project root, which I think it's a bit messy.

This change adds a `--project-root` option to `generate` so that I may override the default base directory.