### PR TITLE
Fix to prevent duplicate addition of carthage static frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Fixed
 - Fixed issue when linking and embeding static frameworks: they should be linked and NOT embed. [#820](https://github.com/yonaskolb/XcodeGen/pull/820) @acecilia
 - Fixed issue when generating projects for paths with a dot in the folder for swift sources. [#826](https://github.com/yonaskolb/XcodeGen/pull/826) @asifmohd
+- Fixed duplicate addition of carthage static frameworks. [#829](https://github.com/yonaskolb/XcodeGen/pull/829) @funzin
 
 ## 2.15.1
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -787,7 +787,9 @@ public class PBXProjGenerator {
 
                     self.carthageFrameworksByPlatform[target.platform.carthageName, default: []].insert(fileReference)
 
-                    if dependency.link ?? (target.type != .staticLibrary) {
+                    let isStaticLibrary = target.type == .staticLibrary
+                    let isCarthageStaticLink = dependency.carthageLinkType == .static
+                    if dependency.link ?? (!isStaticLibrary && !isCarthageStaticLink) {
                         let buildFile = self.addObject(
                             PBXBuildFile(file: fileReference, settings: getDependencyFrameworkSettings(dependency: dependency))
                         )

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1124,6 +1124,7 @@ class ProjectGeneratorTests: XCTestCase {
                         guard let files = frameworkBuildPhase?.files, let file = files.first else {
                             return XCTFail("frameworkBuildPhase should have files")
                         }
+                        try expect(files.count) == 1
                         try expect(file.file?.nameOrPath) == "MyStaticFramework.framework"
 
                         try expect(target.carthageCopyFrameworkBuildPhase).beNil()
@@ -1151,6 +1152,8 @@ class ProjectGeneratorTests: XCTestCase {
                         guard let files = frameworkBuildPhase?.files else {
                             return XCTFail("frameworkBuildPhase should have files")
                         }
+                        try expect(files.count) == 2
+
                         guard let dynamicFramework = files.first(where: { $0.file?.nameOrPath == "MyDynamicFramework.framework" }) else {
                             return XCTFail("Framework Build Phase should have Dynamic Framework")
                         }
@@ -1262,6 +1265,7 @@ class ProjectGeneratorTests: XCTestCase {
                         guard let files = frameworkBuildPhase?.files, let file = files.first else {
                             return XCTFail("frameworkBuildPhase should have files")
                         }
+                        try expect(files.count) == 1
                         try expect(file.file?.nameOrPath) == "MyStaticFramework.framework"
 
                         try expect(target.carthageCopyFrameworkBuildPhase).beNil()
@@ -1289,6 +1293,8 @@ class ProjectGeneratorTests: XCTestCase {
                         guard let files = frameworkBuildPhase?.files else {
                             return XCTFail("frameworkBuildPhase should have files")
                         }
+                        try expect(files.count) == 2
+
                         guard let dynamicFramework = files.first(where: { $0.file?.nameOrPath == "MyDynamicFramework.framework" }) else {
                             return XCTFail("Framework Build Phase should have Dynamic Framework")
                         }


### PR DESCRIPTION
Sample project.yml
```yml
name: SampleApp
options:
  bundleIdPrefix: com.xxx
  deploymentTarget:
    iOS: 9.3
targets:
  SampleApp:
    type: application
    platform: iOS
    sources: [SampleApp]
    settings:
      base:
        INFOPLIST_FILE: "SampleApp/Resource/Supporting File/Info.plist"
    dependencies:
      - carthage: RxSwift.framework
        linkType: static
      - carthage: RxCocoa.framework
        linkType: static
      - carthage: RxRelay.framework
        linkType: static
```

When I created the project.yml and executed, but duplicate frameworks have been added to the  `Link Binary With Libraries`
<img width="825" alt="Screen Shot 2020-04-12 at 13 27 32" src="https://user-images.githubusercontent.com/12893657/79060569-98a98400-7cc1-11ea-8644-571089bc49e0.png">

The reason is that `targetFrameworkBuildFiles.append`is being performed in two places.
- https://github.com/yonaskolb/XcodeGen/blob/master/Sources/XcodeGenKit/PBXProjGenerator.swift#L794
- https://github.com/yonaskolb/XcodeGen/blob/master/Sources/XcodeGenKit/PBXProjGenerator.swift#L868

I fixed to prevent duplicate addition of carthage static frameworks.