### PR TITLE
Add ability to specify "full" scheme actions with `TargetScheme`

### DIFF
--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -9,10 +9,10 @@ public struct Scheme: Equatable {
     public var name: String
     public var build: Build
     public var run: Run?
-    public var archive: Archive?
-    public var analyze: Analyze?
     public var test: Test?
     public var profile: Profile?
+    public var analyze: Analyze?
+    public var archive: Archive?
 
     public init(
         name: String,

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -62,6 +62,7 @@ public struct Scheme: Equatable {
         public var script: String
         public var name: String
         public var settingsTarget: String?
+        
         public init(name: String, script: String, settingsTarget: String? = nil) {
             self.script = script
             self.name = name
@@ -78,6 +79,7 @@ public struct Scheme: Equatable {
         public var buildImplicitDependencies: Bool
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
+        
         public init(
             targets: [BuildTarget],
             parallelizeBuild: Bool = parallelizeBuildDefault,
@@ -228,6 +230,7 @@ public struct Scheme: Equatable {
 
     public struct Analyze: BuildAction {
         public var config: String?
+        
         public init(config: String) {
             self.config = config
         }
@@ -239,6 +242,7 @@ public struct Scheme: Equatable {
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
         public var environmentVariables: [XCScheme.EnvironmentVariable]
+        
         public init(
             config: String,
             commandLineArguments: [String: Bool] = [:],
@@ -266,6 +270,7 @@ public struct Scheme: Equatable {
         public var revealArchiveInOrganizer: Bool
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
+        
         public init(
             config: String,
             customArchiveName: String? = nil,

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -198,7 +198,6 @@ public struct Scheme: Equatable {
             coverageTargets: [TargetReference] = [],
             disableMainThreadChecker: Bool = disableMainThreadCheckerDefault,
             randomExecutionOrder: Bool = false,
-            parallelizable: Bool = false,
             commandLineArguments: [String: Bool] = [:],
             targets: [TestTarget] = [],
             preActions: [ExecutionAction] = [],

--- a/Sources/ProjectSpec/TargetScheme.swift
+++ b/Sources/ProjectSpec/TargetScheme.swift
@@ -10,6 +10,7 @@ public struct TargetScheme: Equatable {
     public var region: String?
     public var disableMainThreadChecker: Bool?
     public var stopOnEveryMainThreadCheckerIssue: Bool?
+    public var parallelizeBuild: Bool?
     public var buildImplicitDependencies: Bool?
     public var commandLineArguments: [String: Bool]
     public var environmentVariables: [XCScheme.EnvironmentVariable]
@@ -24,6 +25,7 @@ public struct TargetScheme: Equatable {
         region: String? = nil,
         disableMainThreadChecker: Bool? = nil,
         stopOnEveryMainThreadCheckerIssue: Bool? = nil,
+        parallelizeBuild: Bool? = nil,
         buildImplicitDependencies: Bool? = nil,
         commandLineArguments: [String: Bool] = [:],
         environmentVariables: [XCScheme.EnvironmentVariable] = [],
@@ -37,6 +39,7 @@ public struct TargetScheme: Equatable {
         self.region = region
         self.disableMainThreadChecker = disableMainThreadChecker
         self.stopOnEveryMainThreadCheckerIssue = stopOnEveryMainThreadCheckerIssue
+        self.parallelizeBuild = parallelizeBuild
         self.buildImplicitDependencies = buildImplicitDependencies
         self.commandLineArguments = commandLineArguments
         self.environmentVariables = environmentVariables
@@ -67,6 +70,7 @@ extension TargetScheme: JSONObjectConvertible {
         region = jsonDictionary.json(atKeyPath: "region")
         disableMainThreadChecker = jsonDictionary.json(atKeyPath: "disableMainThreadChecker")
         stopOnEveryMainThreadCheckerIssue = jsonDictionary.json(atKeyPath: "stopOnEveryMainThreadCheckerIssue")
+        parallelizeBuild = jsonDictionary.json(atKeyPath: "parallelizeBuild")
         buildImplicitDependencies = jsonDictionary.json(atKeyPath: "buildImplicitDependencies")
         commandLineArguments = jsonDictionary.json(atKeyPath: "commandLineArguments") ?? [:]
         environmentVariables = try XCScheme.EnvironmentVariable.parseAll(jsonDictionary: jsonDictionary)
@@ -96,6 +100,10 @@ extension TargetScheme: JSONEncodable {
       
         if let stopOnEveryMainThreadCheckerIssue = stopOnEveryMainThreadCheckerIssue {
             dict["stopOnEveryMainThreadCheckerIssue"] = stopOnEveryMainThreadCheckerIssue
+        }
+        
+        if let parallelizeBuild = parallelizeBuild {
+            dict["parallelizeBuild"] = parallelizeBuild
         }
 
         if let buildImplicitDependencies = buildImplicitDependencies {

--- a/Sources/ProjectSpec/TargetScheme.swift
+++ b/Sources/ProjectSpec/TargetScheme.swift
@@ -3,6 +3,14 @@ import JSONUtilities
 import XcodeProj
 
 public struct TargetScheme: Equatable {
+    // Explicit action overrides. If these are specified they take precedence over generated actions.
+    public var build: Scheme.Build?
+    public var run: Scheme.Run?
+    public var test: Scheme.Test?
+    public var profile: Scheme.Profile?
+    public var analyze: Scheme.Analyze?
+    public var archive: Scheme.Archive?
+
     public var testTargets: [Scheme.Test.TestTarget]
     public var configVariants: [String]
     public var gatherCoverageData: Bool?
@@ -18,6 +26,12 @@ public struct TargetScheme: Equatable {
     public var postActions: [Scheme.ExecutionAction]
 
     public init(
+        build: Scheme.Build? = nil,
+        run: Scheme.Run? = nil,
+        test: Scheme.Test? = nil,
+        profile: Scheme.Profile? = nil,
+        analyze: Scheme.Analyze? = nil,
+        archive: Scheme.Archive? = nil,
         testTargets: [Scheme.Test.TestTarget] = [],
         configVariants: [String] = [],
         gatherCoverageData: Bool? = nil,
@@ -32,6 +46,12 @@ public struct TargetScheme: Equatable {
         preActions: [Scheme.ExecutionAction] = [],
         postActions: [Scheme.ExecutionAction] = []
     ) {
+        self.build = build
+        self.run = run
+        self.test = test
+        self.profile = profile
+        self.analyze = analyze
+        self.archive = archive
         self.testTargets = testTargets
         self.configVariants = configVariants
         self.gatherCoverageData = gatherCoverageData
@@ -51,6 +71,13 @@ public struct TargetScheme: Equatable {
 extension TargetScheme: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
+        build = jsonDictionary.json(atKeyPath: "build")
+        run = jsonDictionary.json(atKeyPath: "run")
+        test = jsonDictionary.json(atKeyPath: "test")
+        profile = jsonDictionary.json(atKeyPath: "profile")
+        analyze = jsonDictionary.json(atKeyPath: "analyze")
+        archive = jsonDictionary.json(atKeyPath: "archive")
+        
         if let targets = jsonDictionary["testTargets"] as? [Any] {
             testTargets = try targets.compactMap { target in
                 if let string = target as? String {
@@ -89,6 +116,25 @@ extension TargetScheme: JSONEncodable {
             "preActions": preActions.map { $0.toJSONValue() },
             "postActions": postActions.map { $0.toJSONValue() },
         ]
+        
+        if let build = build {
+            dict["build"] = build.toJSONValue()
+        }
+        if let run = run {
+            dict["run"] = run.toJSONValue()
+        }
+        if let test = test {
+            dict["test"] = test.toJSONValue()
+        }
+        if let profile = profile {
+            dict["profile"] = profile.toJSONValue()
+        }
+        if let analyze = analyze {
+            dict["analyze"] = analyze.toJSONValue()
+        }
+        if let archive = archive {
+            dict["archive"] = archive.toJSONValue()
+        }
 
         if let gatherCoverageData = gatherCoverageData {
             dict["gatherCoverageData"] = gatherCoverageData

--- a/Sources/ProjectSpec/TargetScheme.swift
+++ b/Sources/ProjectSpec/TargetScheme.swift
@@ -3,19 +3,14 @@ import JSONUtilities
 import XcodeProj
 
 public struct TargetScheme: Equatable {
-    public static let gatherCoverageDataDefault = false
-    public static let disableMainThreadCheckerDefault = false
-    public static let stopOnEveryMainThreadCheckerIssueDefault = false
-    public static let buildImplicitDependenciesDefault = true
-
     public var testTargets: [Scheme.Test.TestTarget]
     public var configVariants: [String]
-    public var gatherCoverageData: Bool
+    public var gatherCoverageData: Bool?
     public var language: String?
     public var region: String?
-    public var disableMainThreadChecker: Bool
-    public var stopOnEveryMainThreadCheckerIssue: Bool
-    public var buildImplicitDependencies: Bool
+    public var disableMainThreadChecker: Bool?
+    public var stopOnEveryMainThreadCheckerIssue: Bool?
+    public var buildImplicitDependencies: Bool?
     public var commandLineArguments: [String: Bool]
     public var environmentVariables: [XCScheme.EnvironmentVariable]
     public var preActions: [Scheme.ExecutionAction]
@@ -24,12 +19,12 @@ public struct TargetScheme: Equatable {
     public init(
         testTargets: [Scheme.Test.TestTarget] = [],
         configVariants: [String] = [],
-        gatherCoverageData: Bool = gatherCoverageDataDefault,
+        gatherCoverageData: Bool? = nil,
         language: String? = nil,
         region: String? = nil,
-        disableMainThreadChecker: Bool = disableMainThreadCheckerDefault,
-        stopOnEveryMainThreadCheckerIssue: Bool = stopOnEveryMainThreadCheckerIssueDefault,
-        buildImplicitDependencies: Bool = buildImplicitDependenciesDefault,
+        disableMainThreadChecker: Bool? = nil,
+        stopOnEveryMainThreadCheckerIssue: Bool? = nil,
+        buildImplicitDependencies: Bool? = nil,
         commandLineArguments: [String: Bool] = [:],
         environmentVariables: [XCScheme.EnvironmentVariable] = [],
         preActions: [Scheme.ExecutionAction] = [],
@@ -67,12 +62,12 @@ extension TargetScheme: JSONObjectConvertible {
             testTargets = []
         }
         configVariants = jsonDictionary.json(atKeyPath: "configVariants") ?? []
-        gatherCoverageData = jsonDictionary.json(atKeyPath: "gatherCoverageData") ?? TargetScheme.gatherCoverageDataDefault
+        gatherCoverageData = jsonDictionary.json(atKeyPath: "gatherCoverageData")
         language = jsonDictionary.json(atKeyPath: "language")
         region = jsonDictionary.json(atKeyPath: "region")
-        disableMainThreadChecker = jsonDictionary.json(atKeyPath: "disableMainThreadChecker") ?? TargetScheme.disableMainThreadCheckerDefault
-        stopOnEveryMainThreadCheckerIssue = jsonDictionary.json(atKeyPath: "stopOnEveryMainThreadCheckerIssue") ?? TargetScheme.stopOnEveryMainThreadCheckerIssueDefault
-        buildImplicitDependencies = jsonDictionary.json(atKeyPath: "buildImplicitDependencies") ?? TargetScheme.buildImplicitDependenciesDefault
+        disableMainThreadChecker = jsonDictionary.json(atKeyPath: "disableMainThreadChecker")
+        stopOnEveryMainThreadCheckerIssue = jsonDictionary.json(atKeyPath: "stopOnEveryMainThreadCheckerIssue")
+        buildImplicitDependencies = jsonDictionary.json(atKeyPath: "buildImplicitDependencies")
         commandLineArguments = jsonDictionary.json(atKeyPath: "commandLineArguments") ?? [:]
         environmentVariables = try XCScheme.EnvironmentVariable.parseAll(jsonDictionary: jsonDictionary)
         preActions = jsonDictionary.json(atKeyPath: "preActions") ?? []
@@ -91,19 +86,19 @@ extension TargetScheme: JSONEncodable {
             "postActions": postActions.map { $0.toJSONValue() },
         ]
 
-        if gatherCoverageData != TargetScheme.gatherCoverageDataDefault {
+        if let gatherCoverageData = gatherCoverageData {
             dict["gatherCoverageData"] = gatherCoverageData
         }
 
-        if disableMainThreadChecker != TargetScheme.disableMainThreadCheckerDefault {
+        if let disableMainThreadChecker = disableMainThreadChecker  {
             dict["disableMainThreadChecker"] = disableMainThreadChecker
         }
       
-        if stopOnEveryMainThreadCheckerIssue != TargetScheme.stopOnEveryMainThreadCheckerIssueDefault {
+        if let stopOnEveryMainThreadCheckerIssue = stopOnEveryMainThreadCheckerIssue {
             dict["stopOnEveryMainThreadCheckerIssue"] = stopOnEveryMainThreadCheckerIssue
         }
 
-        if buildImplicitDependencies != TargetScheme.buildImplicitDependenciesDefault {
+        if let buildImplicitDependencies = buildImplicitDependencies {
             dict["buildImplicitDependencies"] = buildImplicitDependencies
         }
 

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -314,6 +314,7 @@ extension Scheme {
             name: name,
             build: .init(
                 targets: Scheme.buildTargets(for: target, project: project),
+                parallelizeBuild: targetScheme.parallelizeBuild ?? Build.parallelizeBuildDefault,
                 buildImplicitDependencies: targetScheme.buildImplicitDependencies ?? Build.buildImplicitDependenciesDefault,
                 preActions: targetScheme.preActions,
                 postActions: targetScheme.postActions

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -314,7 +314,7 @@ extension Scheme {
             name: name,
             build: .init(
                 targets: Scheme.buildTargets(for: target, project: project),
-                buildImplicitDependencies: targetScheme.buildImplicitDependencies,
+                buildImplicitDependencies: targetScheme.buildImplicitDependencies ?? Build.buildImplicitDependenciesDefault,
                 preActions: targetScheme.preActions,
                 postActions: targetScheme.postActions
             ),
@@ -322,15 +322,15 @@ extension Scheme {
                 config: debugConfig,
                 commandLineArguments: targetScheme.commandLineArguments,
                 environmentVariables: targetScheme.environmentVariables,
-                disableMainThreadChecker: targetScheme.disableMainThreadChecker,
-                stopOnEveryMainThreadCheckerIssue: targetScheme.stopOnEveryMainThreadCheckerIssue,
+                disableMainThreadChecker: targetScheme.disableMainThreadChecker ?? Run.disableMainThreadCheckerDefault,
+                stopOnEveryMainThreadCheckerIssue: targetScheme.stopOnEveryMainThreadCheckerIssue ?? Run.stopOnEveryMainThreadCheckerIssueDefault,
                 language: targetScheme.language,
                 region: targetScheme.region
             ),
             test: .init(
                 config: debugConfig,
-                gatherCoverageData: targetScheme.gatherCoverageData,
-                disableMainThreadChecker: targetScheme.disableMainThreadChecker,
+                gatherCoverageData: targetScheme.gatherCoverageData ?? Test.gatherCoverageDataDefault,
+                disableMainThreadChecker: targetScheme.disableMainThreadChecker ?? Test.disableMainThreadCheckerDefault,
                 commandLineArguments: targetScheme.commandLineArguments,
                 targets: targetScheme.testTargets,
                 environmentVariables: targetScheme.environmentVariables,

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -312,14 +312,14 @@ extension Scheme {
     public init(name: String, target: Target, targetScheme: TargetScheme, project: Project, debugConfig: String, releaseConfig: String) {
         self.init(
             name: name,
-            build: .init(
+            build: targetScheme.build ?? .init(
                 targets: Scheme.buildTargets(for: target, project: project),
                 parallelizeBuild: targetScheme.parallelizeBuild ?? Build.parallelizeBuildDefault,
                 buildImplicitDependencies: targetScheme.buildImplicitDependencies ?? Build.buildImplicitDependenciesDefault,
                 preActions: targetScheme.preActions,
                 postActions: targetScheme.postActions
             ),
-            run: .init(
+            run: targetScheme.run ?? .init(
                 config: debugConfig,
                 commandLineArguments: targetScheme.commandLineArguments,
                 environmentVariables: targetScheme.environmentVariables,
@@ -328,7 +328,7 @@ extension Scheme {
                 language: targetScheme.language,
                 region: targetScheme.region
             ),
-            test: .init(
+            test: targetScheme.test ?? .init(
                 config: debugConfig,
                 gatherCoverageData: targetScheme.gatherCoverageData ?? Test.gatherCoverageDataDefault,
                 disableMainThreadChecker: targetScheme.disableMainThreadChecker ?? Test.disableMainThreadCheckerDefault,
@@ -338,15 +338,15 @@ extension Scheme {
                 language: targetScheme.language,
                 region: targetScheme.region
             ),
-            profile: .init(
+            profile: targetScheme.profile ?? .init(
                 config: releaseConfig,
                 commandLineArguments: targetScheme.commandLineArguments,
                 environmentVariables: targetScheme.environmentVariables
             ),
-            analyze: .init(
+            analyze: targetScheme.analyze ?? .init(
                 config: debugConfig
             ),
-            archive: .init(
+            archive: targetScheme.archive ?? .init(
                 config: releaseConfig
             )
         )

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -482,6 +482,7 @@
 		187E665975BB5611AF0F27E1 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		1BC32A813B80A53962A1F365 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1D0C79A8C750EC0DE748C463 /* StaticLibrary_ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticLibrary_ObjC.m; sourceTree = "<group>"; };
+		216E85EF1AF0711CCC53C84F /* FullSchemeApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = FullSchemeApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		22237B8EBD9E6BE8EBC8735F /* XPC Service.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = "XPC Service.xpc"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2233774B86539B1574D206B0 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		28360ECA4D727FAA58557A81 /* example.mp4 */ = {isa = PBXFileReference; path = example.mp4; sourceTree = "<group>"; };
@@ -926,6 +927,7 @@
 				2233774B86539B1574D206B0 /* Framework2.framework */,
 				A0DC40025AB59B688E758829 /* Framework2.framework */,
 				AB055761199DF36DB0C629A6 /* Framework2.framework */,
+				216E85EF1AF0711CCC53C84F /* FullSchemeApp.app */,
 				9A87A926D563773658FB87FE /* iMessageApp.app */,
 				D629E142AB87C681D4EC90F7 /* iMessageExtension.appex */,
 				C53ACB2962FED621389C36A2 /* iMessageStickersExtension.appex */,
@@ -1581,6 +1583,21 @@
 			productReference = 22237B8EBD9E6BE8EBC8735F /* XPC Service.xpc */;
 			productType = "com.apple.product-type.xpc-service";
 		};
+		E8B6606CD473C6A434CE5207 /* FullSchemeApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6D086C56F0E1E7EE76F0F568 /* Build configuration list for PBXNativeTarget "FullSchemeApp" */;
+			buildPhases = (
+				2E52EE7B48FF024E3B119530 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = FullSchemeApp;
+			productName = FullSchemeApp;
+			productReference = 216E85EF1AF0711CCC53C84F /* FullSchemeApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 		F674B2CFC4738EEC49BAD0DA /* App_iOS_UITests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 68CC35789B0DB020E2CFC517 /* Build configuration list for PBXNativeTarget "App_iOS_UITests" */;
@@ -1674,6 +1691,7 @@
 				53A3B531E3947D8A8722745E /* Framework_macOS */,
 				536ACF18E4603B59207D43CE /* Framework_tvOS */,
 				71B5187E710718C1A205D4DC /* Framework_watchOS */,
+				E8B6606CD473C6A434CE5207 /* FullSchemeApp */,
 				72C923899DE05F1281872160 /* Legacy */,
 				13E8C5AB873CEE21E18E552F /* StaticLibrary_ObjC_iOS */,
 				578C80E461E675508CED5DC3 /* StaticLibrary_ObjC_macOS */,
@@ -1991,6 +2009,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				75F2774F183838AF34CA9B8A /* StaticLibrary_ObjC.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2E52EE7B48FF024E3B119530 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2620,6 +2645,21 @@
 			};
 			name = "Staging Release";
 		};
+		0F571B1039588A8592DABB27 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FullSchemeApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
 		10E250D1DC79E11058B933F9 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2789,6 +2829,21 @@
 				SDKROOT = macosx;
 			};
 			name = "Staging Release";
+		};
+		19527791129C46494575D2B0 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FullSchemeApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
 		};
 		196FEEE6C4B0DDE53AD16BD6 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
@@ -3118,6 +3173,21 @@
 			};
 			name = "Test Debug";
 		};
+		4052803333EAF29ABE344F12 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FullSchemeApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
 		4089B74CA10172B8ED2D004B /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3209,6 +3279,21 @@
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
 			};
 			name = "Test Debug";
+		};
+		45BFFB3154AF1DE1E6CBDD86 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FullSchemeApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
 		};
 		4621C6C8A78FBB1CF4078178 /* Production Release */ = {
 			isa = XCBuildConfiguration;
@@ -4176,6 +4261,21 @@
 			};
 			name = "Test Debug";
 		};
+		8F195EBE8CF35C79D1A35CE8 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FullSchemeApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
 		921EC740167F616C38809275 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4620,6 +4720,21 @@
 				SDKROOT = macosx;
 			};
 			name = "Test Release";
+		};
+		AE24525357169AC93A243002 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FullSchemeApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
 		};
 		AE37A01B34B4B956E784082C /* Production Debug */ = {
 			isa = XCBuildConfiguration;
@@ -6136,6 +6251,19 @@
 				7B2A1BE6CA654E9903A4C680 /* Staging Release */,
 				00FD318C7418F3351FC00744 /* Test Debug */,
 				F3AC6A112F81D0958A316D82 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		6D086C56F0E1E7EE76F0F568 /* Build configuration list for PBXNativeTarget "FullSchemeApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4052803333EAF29ABE344F12 /* Production Debug */,
+				AE24525357169AC93A243002 /* Production Release */,
+				19527791129C46494575D2B0 /* Staging Debug */,
+				8F195EBE8CF35C79D1A35CE8 /* Staging Release */,
+				0F571B1039588A8592DABB27 /* Test Debug */,
+				45BFFB3154AF1DE1E6CBDD86 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/FullSchemeApp.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/FullSchemeApp.xcscheme
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo Starting Build">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "E8B6606CD473C6A434CE5207"
+                     BuildableName = "FullSchemeApp.app"
+                     BlueprintName = "FullSchemeApp"
+                     ReferencedContainer = "container:Project.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E8B6606CD473C6A434CE5207"
+               BuildableName = "FullSchemeApp.app"
+               BlueprintName = "FullSchemeApp"
+               ReferencedContainer = "container:Project.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Production Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "ja"
+      region = "en"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E8B6606CD473C6A434CE5207"
+            BuildableName = "FullSchemeApp.app"
+            BlueprintName = "FullSchemeApp"
+            ReferencedContainer = "container:Project.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Production Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E8B6606CD473C6A434CE5207"
+            BuildableName = "FullSchemeApp.app"
+            BlueprintName = "FullSchemeApp"
+            ReferencedContainer = "container:Project.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "argument"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "argument.with.dot"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Production Release"
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E8B6606CD473C6A434CE5207"
+            BuildableName = "FullSchemeApp.app"
+            BlueprintName = "FullSchemeApp"
+            ReferencedContainer = "container:Project.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OTHER_VAR"
+            value = "YES"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "VAR"
+            value = "NO"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Production Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Production Release"
+      customArchiveName = "Custom"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -145,6 +145,33 @@ targets:
       path: App_iOS/App.entitlements
       properties:
         com.apple.security.application-groups: group.com.app
+        
+  FullSchemeApp:
+    type: application
+    platform: iOS
+    templates: [FullSchemeTemplate]
+    scheme:
+      build:
+        parallelizeBuild: false
+        buildImplicitDependencies: false
+        targets:
+          FullSchemeApp: all
+        preActions:
+          - script: echo Starting Build
+            settingsTarget: FullSchemeApp
+      run:
+        commandLineArguments:
+          argument: YES
+          argument.with.dot: YES
+      test:
+        gatherCoverageData: true
+        language: ja
+        region: en
+      profile:
+        environmentVariables:
+          VAR: NO
+      archive:
+        customArchiveName: Custom
 
   App_watchOS:
       type: application.watchapp2
@@ -306,6 +333,11 @@ schemes:
 targetTemplates:
   MyTemplate:
     scheme: {}
+  FullSchemeTemplate:
+    scheme:
+      profile:
+        environmentVariables:
+          OTHER_VAR: YES
     
 schemeTemplates:
   TestScheme:

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -271,6 +271,7 @@ targets:
 
 schemes:
   Framework:
+    templates: [TestScheme]
     build:
       parallelizeBuild: false
       buildImplicitDependencies: false
@@ -284,7 +285,6 @@ schemes:
         argument: YES
         argument.with.dot: YES
     test:
-      gatherCoverageData: true
       language: ja
       region: en
   App_Scheme:
@@ -302,9 +302,16 @@ schemes:
         - name: App_iOS_Tests
           parallelizable: true
           randomExecutionOrder: true
+
 targetTemplates:
   MyTemplate:
     scheme: {}
+    
+schemeTemplates:
+  TestScheme:
+    test:
+      gatherCoverageData: true
+
 aggregateTargets:
   SuperTarget:
     attributes:

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -114,6 +114,8 @@ targets:
       testTargets:
         - App_iOS_Tests
         - App_iOS_UITests
+      parallelizeBuild: false
+      buildImplicitDependencies: false
       gatherCoverageData: true
       disableMainThreadChecker: true
       stopOnEveryMainThreadCheckerIssue: true

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -510,7 +510,6 @@ class ProjectSpecTests: XCTestCase {
                                                                       gatherCoverageData: true,
                                                                       disableMainThreadChecker: true,
                                                                       randomExecutionOrder: false,
-                                                                      parallelizable: false,
                                                                       commandLineArguments: ["foo": true],
                                                                       targets: [Scheme.Test.TestTarget(targetReference: "foo",
                                                                                                        randomExecutionOrder: false,


### PR DESCRIPTION
FYI: I'll break this in a couple PRs (code cleanup, adding `parallelizeBuild`, adding some test fixtures, and finally adding the full scheme support to `target`) if everything looks good.

---

This PR adds support for specifying full scheme configuration to `target: Target: scheme:`. If any of the actions are specified (e.g. `build`, `test`, `profile`) then that block will be used the same as a top level `scheme` declaration. For any steps not specified they will use the existing helper/defaulting logic.

This allows one to do something like this:

```yml
targets:
  App:
    scheme:
      build:
        targets:
          App: all
      run:
        commandLineArguments:
          "-enable-perf-logging": false
        environmentVariables:
          - variable: TSAN_OPTIONS
            value: suppressions=$(SRCROOT)/tsan-suppressions.txt
            isEnabled: true
      test:
        targets:
         - Apps Tests
        gatherCoverageData: true
      profile:
        config: Profile
      archive:
        config: Release
```

This should help address issue like #656.