### PR TITLE
Fixes dumping project references in Project.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix handling of SWIFT_INSTALL_OBJC_HEADER when its value is YES/NO. [#827](https://github.com/yonaskolb/XcodeGen/pull/827) @ileitch
 - Set `preActions` and `postActions` on the `build` action of a TargetScheme instead of the other actions. [#823](https://github.com/yonaskolb/XcodeGen/pull/823) @brentleyjones
 - Implicitly include bundles in the Copy Bundle Resources build phase. [#838](https://github.com/yonaskolb/XcodeGen/pull/838) @skirchmeier
+- Fixed dumping a project manifest which contains an array of project references @paciej00
 
 ## 2.15.1
 

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -292,7 +292,7 @@ extension Project: JSONEncodable {
         dictionary["aggregateTargets"] = Dictionary(uniqueKeysWithValues: aggregateTargetsPairs)
         dictionary["schemes"] = Dictionary(uniqueKeysWithValues: schemesPairs)
         dictionary["settingGroups"] = settingGroups.mapValues { $0.toJSONValue() }
-        dictionary["projectReferences"] = projectReferencesPairs
+        dictionary["projectReferences"] = Dictionary(uniqueKeysWithValues: projectReferencesPairs)
 
         return dictionary
     }


### PR DESCRIPTION
# What
When dumping to YAML a manifest that contains project references one can get the following `fatalError`:

```
Error: Failed to represent ("MyProject", ["path": "../MyProject/MyProject.xcodeproj"])
```

It is caused by wrong representation of project references (`[(String, Any)]` instead of a `Dictionary`)