### PR TITLE
Generate correct PBXTargetDependency for external targets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Prevent test targets from being set as a scheme's launch action [#835](https://github.com/yonaskolb/XcodeGen/pull/835) @brentleyjones
 - Implicitly include bundles in the Copy Bundle Resources build phase. [#838](https://github.com/yonaskolb/XcodeGen/pull/838) @skirchmeier
 - Fixed dumping a project manifest which contains an array of project references @paciej00
+- Generate correct PBXTargetDependency for external targets. [#843](https://github.com/yonaskolb/XcodeGen/pull/843) @ileitch
 
 ## 2.15.1
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -413,7 +413,7 @@ public class PBXProjGenerator {
 
         let targetDependency = addObject(
             PBXTargetDependency(
-                target: targetObject,
+                name: targetObject.name,
                 targetProxy: targetProxy
             )
         )

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -1204,7 +1204,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				7C4CC3918BD0DA1E04A5E2B0 /* PBXTargetDependency */,
+				4FA29DA80DA668224AED741F /* PBXTargetDependency */,
 				0D33D01C71E8002A07F02122 /* PBXTargetDependency */,
 				A94F38390A74E215EC107BB5 /* PBXTargetDependency */,
 				E84285243DE0BB361A708079 /* PBXTargetDependency */,
@@ -2212,6 +2212,11 @@
 			target = 0867B0DACEF28C11442DE8F7 /* App_iOS */;
 			targetProxy = 469D922BE967C6D52ED84552 /* PBXContainerItemProxy */;
 		};
+		4FA29DA80DA668224AED741F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ExternalTarget;
+			targetProxy = FF75DC967D1097BC31DCF5E6 /* PBXContainerItemProxy */;
+		};
 		62DA64F61B337719A2CF993D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 307AE3FA155FFD09B74AE351 /* App_watchOS Extension */;
@@ -2221,11 +2226,6 @@
 			isa = PBXTargetDependency;
 			target = 0636AAF06498C336E1CEEDE4 /* TestFramework */;
 			targetProxy = C42BA4EA0239AF536F0F0993 /* PBXContainerItemProxy */;
-		};
-		7C4CC3918BD0DA1E04A5E2B0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = E76A5F5E363E470416D3B487;
-			targetProxy = FF75DC967D1097BC31DCF5E6 /* PBXContainerItemProxy */;
 		};
 		7EFC0278E67CD35F8981993C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
Xcode does not include the target attribute on PBXTargetDependency for external targets, but instead includes the name.

This also resolves warnings output by CocoaPods, e.g:
```
[!] `<PBXTargetDependency UUID=`C445C9EFB768C6946E0137E9`>` attempted to initialize an object with an unknown UUID. `81DE8F467B21B81B5BEEE6B2` for attribute: `target`. This can be the result of a merge and the unknown UUID is being discarded.
```