### PR TITLE
Test plans continued

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -868,7 +868,7 @@ schemes:
     test:
       testPlans:
         - path: app.xctestplan
-          default: true
+          defaultPlan: true
 ```
 
 ### Scheme Template

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -620,6 +620,7 @@ This is a convenience used to automatically generate schemes for a target based 
 - [ ] **region**: **String** - a String that indicates the region used for running and testing. This defaults to nil
 - [ ] **commandLineArguments**: **[String:Bool]** - a dictionary from the argument name (`String`) to if it is enabled (`Bool`). These arguments will be added to the Test, Profile and Run scheme actions
 - [ ] **environmentVariables**: **[[Environment Variable](#environment-variable)]** or **[String:String]** - environment variables for Run, Test and Profile scheme actions. When passing a dictionary, every key-value entry maps to a corresponding variable that is enabled.
+- [ ] **testPlans**: **[String]** - List of test plan locations that will be referenced in the scheme.
 - [ ] **preActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *before* the build action
 - [ ] **postActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *after* the build action
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -620,7 +620,7 @@ This is a convenience used to automatically generate schemes for a target based 
 - [ ] **region**: **String** - a String that indicates the region used for running and testing. This defaults to nil
 - [ ] **commandLineArguments**: **[String:Bool]** - a dictionary from the argument name (`String`) to if it is enabled (`Bool`). These arguments will be added to the Test, Profile and Run scheme actions
 - [ ] **environmentVariables**: **[[Environment Variable](#environment-variable)]** or **[String:String]** - environment variables for Run, Test and Profile scheme actions. When passing a dictionary, every key-value entry maps to a corresponding variable that is enabled.
-- [ ] **testPlans**: **[String]** - List of test plan locations that will be referenced in the scheme.
+- [ ] **testPlans**:  **[[Test Plan](#test-plan)]** - List of test plan locations that will be referenced in the scheme.
 - [ ] **preActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *before* the build action
 - [ ] **postActions**: **[[Execution Action](#execution-action)]** - Scripts that are run *after* the build action
 
@@ -856,6 +856,19 @@ schemes:
       config: prod-release
       customArchiveName: MyTarget
       revealArchiveInOrganizer: false
+```
+### Test Plan
+
+- [x] **path**: **String** - path that provides the `xctestplan` location.
+- [ ] **defaultPlan**: **Bool** - a bool that defines if given plan is the default one. Defaults to false.
+
+```yaml
+schemes:
+  TestTarget:
+    test:
+      testPlans:
+        - path: app.xctestplan
+          default: true
 ```
 
 ### Scheme Template

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -225,6 +225,7 @@ extension Project: PathContainer {
             .object("targets", Target.pathProperties),
             .object("targetTemplates", Target.pathProperties),
             .object("aggregateTargets", AggregateTarget.pathProperties),
+            .object("schemes", Scheme.pathProperties),
             .object("projectReferences", ProjectReference.pathProperties),
         ]
     }

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -157,7 +157,7 @@ public struct Scheme: Equatable {
         public var language: String?
         public var region: String?
         public var debugEnabled: Bool
-        public var testPlans: [String]
+        public var testPlans: [TestPlan]
 
         public struct TestTarget: Equatable, ExpressibleByStringLiteral {
             public static let randomExecutionOrderDefault = false
@@ -205,7 +205,7 @@ public struct Scheme: Equatable {
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
             environmentVariables: [XCScheme.EnvironmentVariable] = [],
-            testPlans: [String] = [],
+            testPlans: [TestPlan] = [],
             language: String? = nil,
             region: String? = nil,
             debugEnabled: Bool = debugEnabledDefault
@@ -442,7 +442,7 @@ extension Scheme.Test: JSONObjectConvertible {
         preActions = jsonDictionary.json(atKeyPath: "preActions") ?? []
         postActions = jsonDictionary.json(atKeyPath: "postActions") ?? []
         environmentVariables = try XCScheme.EnvironmentVariable.parseAll(jsonDictionary: jsonDictionary)
-        testPlans = jsonDictionary.json(atKeyPath: "testPlans") ?? []
+        testPlans = try (jsonDictionary.json(atKeyPath: "testPlans") ?? []).map { try TestPlan(jsonDictionary: $0) }
         language = jsonDictionary.json(atKeyPath: "language")
         region = jsonDictionary.json(atKeyPath: "region")
         debugEnabled = jsonDictionary.json(atKeyPath: "debugEnabled") ?? Scheme.Test.debugEnabledDefault

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -112,7 +112,7 @@ public struct Scheme: Equatable {
         public var simulateLocation: SimulateLocation?
 
         public init(
-            config: String,
+            config: String? = nil,
             commandLineArguments: [String: Bool] = [:],
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
@@ -157,6 +157,7 @@ public struct Scheme: Equatable {
         public var language: String?
         public var region: String?
         public var debugEnabled: Bool
+        public var testPlans: [String]
 
         public struct TestTarget: Equatable, ExpressibleByStringLiteral {
             public static let randomExecutionOrderDefault = false
@@ -193,7 +194,7 @@ public struct Scheme: Equatable {
         }
 
         public init(
-            config: String,
+            config: String? = nil,
             gatherCoverageData: Bool = gatherCoverageDataDefault,
             coverageTargets: [TargetReference] = [],
             disableMainThreadChecker: Bool = disableMainThreadCheckerDefault,
@@ -204,6 +205,7 @@ public struct Scheme: Equatable {
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
             environmentVariables: [XCScheme.EnvironmentVariable] = [],
+            testPlans: [String] = [],
             language: String? = nil,
             region: String? = nil,
             debugEnabled: Bool = debugEnabledDefault
@@ -217,6 +219,7 @@ public struct Scheme: Equatable {
             self.preActions = preActions
             self.postActions = postActions
             self.environmentVariables = environmentVariables
+            self.testPlans = testPlans
             self.language = language
             self.region = region
             self.debugEnabled = debugEnabled
@@ -241,7 +244,7 @@ public struct Scheme: Equatable {
         public var postActions: [ExecutionAction]
         public var environmentVariables: [XCScheme.EnvironmentVariable]
         public init(
-            config: String,
+            config: String? = nil,
             commandLineArguments: [String: Bool] = [:],
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
@@ -268,7 +271,7 @@ public struct Scheme: Equatable {
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
         public init(
-            config: String,
+            config: String? = nil,
             customArchiveName: String? = nil,
             revealArchiveInOrganizer: Bool = revealArchiveInOrganizerDefault,
             preActions: [ExecutionAction] = [],
@@ -290,6 +293,17 @@ public struct Scheme: Equatable {
             self.target = target
             self.buildTypes = buildTypes
         }
+    }
+}
+
+extension Scheme: PathContainer {
+
+    static var pathProperties: [PathProperty] {
+        [
+            .dictionary([
+                .object("test", Test.pathProperties),
+            ]),
+        ]
     }
 }
 
@@ -395,6 +409,15 @@ extension Scheme.Run: JSONEncodable {
     }
 }
 
+extension Scheme.Test: PathContainer {
+
+    static var pathProperties: [PathProperty] {
+        [
+            .string("testPlans")
+        ]
+    }
+}
+
 extension Scheme.Test: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
@@ -419,6 +442,7 @@ extension Scheme.Test: JSONObjectConvertible {
         preActions = jsonDictionary.json(atKeyPath: "preActions") ?? []
         postActions = jsonDictionary.json(atKeyPath: "postActions") ?? []
         environmentVariables = try XCScheme.EnvironmentVariable.parseAll(jsonDictionary: jsonDictionary)
+        testPlans = jsonDictionary.json(atKeyPath: "testPlans") ?? []
         language = jsonDictionary.json(atKeyPath: "language")
         region = jsonDictionary.json(atKeyPath: "region")
         debugEnabled = jsonDictionary.json(atKeyPath: "debugEnabled") ?? Scheme.Test.debugEnabledDefault
@@ -433,6 +457,7 @@ extension Scheme.Test: JSONEncodable {
             "preActions": preActions.map { $0.toJSONValue() },
             "postActions": postActions.map { $0.toJSONValue() },
             "environmentVariables": environmentVariables.map { $0.toJSONValue() },
+            "testPlans": testPlans,
             "config": config,
             "language": language,
             "region": region,

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -201,6 +201,10 @@ extension Project {
             if let action = scheme.run, let config = action.config, getConfig(config) == nil {
                 errors.append(.invalidSchemeConfig(scheme: scheme.name, config: config))
             }
+
+            let invalidTestPlans: [TestPlan] = scheme.test?.testPlans.filter { !(basePath + $0.path).exists } ?? []
+            errors.append(contentsOf: invalidTestPlans.map{ .invalidTestPlan($0) })
+
             if let action = scheme.test, let config = action.config, getConfig(config) == nil {
                 errors.append(.invalidSchemeConfig(scheme: scheme.name, config: config))
             }

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -205,6 +205,11 @@ extension Project {
             let invalidTestPlans: [TestPlan] = scheme.test?.testPlans.filter { !(basePath + $0.path).exists } ?? []
             errors.append(contentsOf: invalidTestPlans.map{ .invalidTestPlan($0) })
 
+            let defaultPlanCount = scheme.test?.testPlans.filter { $0.defaultPlan }.count ?? 0
+            if (defaultPlanCount > 1) {
+                errors.append(.multipleDefaultTestPlans)
+            }
+
             if let action = scheme.test, let config = action.config, getConfig(config) == nil {
                 errors.append(.invalidSchemeConfig(scheme: scheme.name, config: config))
             }

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -33,6 +33,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidProjectReference(scheme: String, reference: String)
         case invalidProjectReferencePath(ProjectReference)
         case invalidTestPlan(TestPlan)
+        case multipleDefaultTestPlans
 
         public var description: String {
             switch self {
@@ -82,6 +83,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Project reference \(reference.name) has a project file path that doesn't exist \"\(reference.path)\""
             case let .invalidTestPlan(testPlan):
                 return "Test path \(testPlan.path) doesn't exist"
+            case let .multipleDefaultTestPlans:
+                return "Your test plan definition contains more than one default test plan"
             }
         }
     }

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -32,6 +32,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidPerConfigSettings
         case invalidProjectReference(scheme: String, reference: String)
         case invalidProjectReferencePath(ProjectReference)
+        case invalidTestPlan(TestPlan)
 
         public var description: String {
             switch self {
@@ -79,6 +80,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Scheme \(scheme.quoted) has invalid project reference \(project.quoted)"
             case let .invalidProjectReferencePath(reference):
                 return "Project reference \(reference.name) has a project file path that doesn't exist \"\(reference.path)\""
+            case let .invalidTestPlan(testPlan):
+                return "Test path \(testPlan.path) doesn't exist"
             }
         }
     }

--- a/Sources/ProjectSpec/TestPlan.swift
+++ b/Sources/ProjectSpec/TestPlan.swift
@@ -1,0 +1,43 @@
+import Foundation
+import JSONUtilities
+
+public struct TestPlan: Equatable {
+    public var path: String
+    public var defaultPlan: Bool
+
+    public init(path: String, defaultPlan: Bool = false) {
+        self.defaultPlan = defaultPlan
+        self.path = path
+    }
+
+    public static func == (lhs: TestPlan, rhs: TestPlan) -> Bool {
+        lhs.path == rhs.path && lhs.defaultPlan == rhs.defaultPlan
+    }
+}
+
+
+extension TestPlan: JSONObjectConvertible {
+
+    public init(jsonDictionary: JSONDictionary) throws {
+        path = try jsonDictionary.json(atKeyPath: "path")
+        defaultPlan = jsonDictionary.json(atKeyPath: "defaultPlan") ?? false
+    }
+}
+
+extension TestPlan: JSONEncodable {
+    public func toJSONValue() -> Any {
+        [
+            "path": path,
+            "defaultPlan": defaultPlan,
+        ]
+    }
+}
+
+extension TestPlan: PathContainer {
+
+    static var pathProperties: [PathProperty] {
+        [
+            .string("path"),
+        ]
+    }
+}

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -197,10 +197,18 @@ public class SchemeGenerator {
         let launchVariables = scheme.run.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
         let profileVariables = scheme.profile.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
 
+        var testPlans: [XCScheme.TestPlanReference]?
+        if let plans = scheme.test?.testPlans, !plans.isEmpty {
+            testPlans = plans.enumerated().map { index, path in
+                .init(reference: "container:\(path)", default: index == 0)
+            }
+        }
+
         let testAction = XCScheme.TestAction(
             buildConfiguration: scheme.test?.config ?? defaultDebugConfig.name,
             macroExpansion: buildableReference,
             testables: testables,
+            testPlans: testPlans,
             preActions: scheme.test?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.test?.postActions.map(getExecutionAction) ?? [],
             selectedDebuggerIdentifier: (scheme.test?.debugEnabled ?? Scheme.Test.debugEnabledDefault) ? XCScheme.defaultDebugger : "",

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -197,8 +197,11 @@ public class SchemeGenerator {
         let launchVariables = scheme.run.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
         let profileVariables = scheme.profile.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
 
-        let testPlans = scheme.test?.testPlans.enumerated().map { index, path in
-            XCScheme.TestPlanReference(reference: "container:\(path)", default: index == 0)
+        let testPlans = scheme.test?.testPlans.map {
+            testPlan in XCScheme.TestPlanReference(
+                reference: "container:\(testPlan.path)",
+                default: testPlan.defaultPlan
+            )
         } ?? []
 
         let testAction = XCScheme.TestAction(

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -197,18 +197,15 @@ public class SchemeGenerator {
         let launchVariables = scheme.run.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
         let profileVariables = scheme.profile.flatMap { $0.environmentVariables.isEmpty ? nil : $0.environmentVariables }
 
-        var testPlans: [XCScheme.TestPlanReference]?
-        if let plans = scheme.test?.testPlans, !plans.isEmpty {
-            testPlans = plans.enumerated().map { index, path in
-                .init(reference: "container:\(path)", default: index == 0)
-            }
-        }
+        let testPlans = scheme.test?.testPlans.enumerated().map { index, path in
+            XCScheme.TestPlanReference(reference: "container:\(path)", default: index == 0)
+        } ?? []
 
         let testAction = XCScheme.TestAction(
             buildConfiguration: scheme.test?.config ?? defaultDebugConfig.name,
             macroExpansion: buildableReference,
             testables: testables,
-            testPlans: testPlans,
+            testPlans: testPlans.isEmpty ? nil : testPlans,
             preActions: scheme.test?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.test?.postActions.map(getExecutionAction) ?? [],
             selectedDebuggerIdentifier: (scheme.test?.debugEnabled ?? Scheme.Test.debugEnabledDefault) ? XCScheme.defaultDebugger : "",

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -270,7 +270,8 @@ class SourceGenerator {
                  "lproj",
                  "xcfilelist",
                  "apns",
-                 "pch":
+                 "pch",
+                 "xctestplan":
                 return nil
             default:
                 return .resources

--- a/Sources/XcodeGenKit/Version.swift
+++ b/Sources/XcodeGenKit/Version.swift
@@ -8,11 +8,11 @@ extension Project {
     }
 
     var schemeVersion: String {
-        "1.3"
+        "1.7"
     }
 
     var compatibilityVersion: String {
-        "Xcode 10.0"
+        "Xcode 11.0"
     }
 
     var objectVersion: UInt {

--- a/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 				};
 			};
 			buildConfigurationList = D91E14E36EC0B415578456F2 /* Build configuration list for PBXProject "Project" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 11.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3986ED6965842721C46C0452 /* SwiftRoaringDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */; };
 		4CC663B42B270404EF5FD037 /* libStaticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CAB5625F6FEA668410ED5482 /* libStaticLibrary.a */; };
 		578E78BC3627CF48FB2CE129 /* App.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = A9601593D0AD02931266A4E5 /* App.xctestplan */; };
+		78E2E1F9F271C0C4CDA04BD9 /* StaticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F7AFEF8ECCC678519EA643C /* StaticLibrary.a */; };
 		9AD886A88D3E4A1B5E900687 /* SPMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7970A2253B14A9B27C307FAC /* SPMTests.swift */; };
 		9C4AD0711D706FD3ED0E436D /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C17B77601A9D1B7895AB42 /* StaticLibrary.swift */; };
 		B89EA0F3859878A1DCF7BAFD /* SwiftRoaringDynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -235,7 +236,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				578E78BC3627CF48FB2CE129 /* App.xctestplan in Resources */,
 				E368431019ABC696E4FFC0CF /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -10,8 +10,6 @@
 		2DA7998902987953B119E4CE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F7EFEE613987D1E1258A60 /* AppDelegate.swift */; };
 		3986ED6965842721C46C0452 /* SwiftRoaringDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */; };
 		4CC663B42B270404EF5FD037 /* libStaticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CAB5625F6FEA668410ED5482 /* libStaticLibrary.a */; };
-		578E78BC3627CF48FB2CE129 /* App.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = A9601593D0AD02931266A4E5 /* App.xctestplan */; };
-		78E2E1F9F271C0C4CDA04BD9 /* StaticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F7AFEF8ECCC678519EA643C /* StaticLibrary.a */; };
 		9AD886A88D3E4A1B5E900687 /* SPMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7970A2253B14A9B27C307FAC /* SPMTests.swift */; };
 		9C4AD0711D706FD3ED0E436D /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C17B77601A9D1B7895AB42 /* StaticLibrary.swift */; };
 		B89EA0F3859878A1DCF7BAFD /* SwiftRoaringDynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -209,7 +209,7 @@
 				};
 			};
 			buildConfigurationList = 425866ADA259DB93FC4AF1E3 /* Build configuration list for PBXProject "SPM" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 11.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
@@ -83,7 +83,7 @@
 				};
 			};
 			buildConfigurationList = 3DFC1105373EDB6483D4BC5D /* Build configuration list for PBXProject "AnotherProject" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 11.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/Tests/Fixtures/TestProject/App_iOS/App_iOS.xctestplan
+++ b/Tests/Fixtures/TestProject/App_iOS/App_iOS.xctestplan
@@ -1,0 +1,45 @@
+{
+  "configurations" : [
+    {
+      "id" : "AC4AE1EF-F65C-4037-8994-D607D2E5841E",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "MyDisabledArgument",
+        "enabled" : false
+      },
+      {
+        "argument" : "MyEnabledArgument"
+      }
+    ],
+    "mainThreadCheckerEnabled" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Project.xcodeproj",
+      "identifier" : "0867B0DACEF28C11442DE8F7",
+      "name" : "App_iOS"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:Project.xcodeproj",
+        "identifier" : "DC2F16BAA6E13B44AB62F888",
+        "name" : "App_iOS_Tests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Project.xcodeproj",
+        "identifier" : "F674B2CFC4738EEC49BAD0DA",
+        "name" : "App_iOS_UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -1652,7 +1652,7 @@
 				);
 			};
 			buildConfigurationList = D91E14E36EC0B415578456F2 /* Build configuration list for PBXProject "Project" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 11.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -543,6 +543,7 @@
 		A680BE9F68A255B0FB291AE6 /* App_watchOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_watchOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AAA49985DFFE797EE8416887 /* inputList.xcfilelist */ = {isa = PBXFileReference; lastKnownFileType = text.xcfilelist; path = inputList.xcfilelist; sourceTree = "<group>"; };
 		AB055761199DF36DB0C629A6 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AEBCA8CFF769189C0D52031E /* App_iOS.xctestplan */ = {isa = PBXFileReference; path = App_iOS.xctestplan; sourceTree = "<group>"; };
 		B17B8D9C9B391332CD176A35 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LocalizedStoryboard.storyboard; sourceTree = "<group>"; };
 		B198242976C3395E31FE000A /* MessagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
 		B1C33BB070583BE3B0EC0E68 /* App_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -699,6 +700,7 @@
 			isa = PBXGroup;
 			children = (
 				2F80635127D17ECB7748067B /* FolderWithDot2.0 */,
+				AEBCA8CFF769189C0D52031E /* App_iOS.xctestplan */,
 				F0D48A913C087D049C8EDDD7 /* App.entitlements */,
 				7F1A2F579A6F79C62DDA0571 /* AppDelegate.swift */,
 				3797E591F302ECC0AA2FC607 /* Assets.xcassets */,

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
@@ -29,6 +29,12 @@
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            default = "YES"
+            reference = "container:App_iOS.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
@@ -29,12 +29,6 @@
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <TestPlans>
-         <TestPlanReference
-            default = "YES"
-            reference = "container:App_iOS.xctestplan">
-         </TestPlanReference>
-      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_macOS.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_macOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_watchOS.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_watchOS.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/iMessageApp.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/iMessageApp.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1020"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -304,6 +304,8 @@ schemes:
         - name: App_iOS_Tests
           parallelizable: true
           randomExecutionOrder: true
+      testPlans:
+        - App_iOS.xctestplan
 targetTemplates:
   MyTemplate:
     scheme: {}

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -37,3 +37,11 @@ targetTemplates:
   Template1:
     sources:
       - template_source
+schemes:
+  Scheme:
+    build:
+      targets:
+        NewTarget: all
+    test:
+      testPlans:
+        - TestPlan.xctestplan

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -44,4 +44,4 @@ schemes:
         NewTarget: all
     test:
       testPlans:
-        - TestPlan.xctestplan
+        - path: paths_test/TestPlan.xctestplan

--- a/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
@@ -55,7 +55,7 @@
 				};
 			};
 			buildConfigurationList = E903F6E8184E2A86CEC31778 /* Build configuration list for PBXProject "TestProject" */;
-			compatibilityVersion = "Xcode 10.0";
+			compatibilityVersion = "Xcode 11.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -339,6 +339,34 @@ class ProjectSpecTests: XCTestCase {
                 project.schemes = [scheme]
                 try project.validate()
             }
+
+            $0.it("fails on missing test plan file") {
+                var project = baseProject
+
+                project.configs = Config.defaultConfigs
+
+                project.targets = [Target(
+                    name: "target1",
+                    type: .application,
+                    platform: .iOS
+                )]
+
+                let testPlan = try TestPlan(path: "does-not-exist.xctestplan")
+
+                let scheme = Scheme(
+                    name: "xctestplan-scheme",
+                    build: Scheme.Build(targets: [
+                        Scheme.BuildTarget(target: "target1")
+                    ]),
+                    test: Scheme.Test(config: "Debug",
+                        testPlans: [testPlan]
+                    )
+                )
+
+                project.schemes = [scheme]
+
+                try expectValidationError(project, .invalidTestPlan(testPlan))
+            }
         }
     }
 

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -367,6 +367,37 @@ class ProjectSpecTests: XCTestCase {
 
                 try expectValidationError(project, .invalidTestPlan(testPlan))
             }
+
+
+
+            $0.it("fails on multiple default test plans") {
+                var project = baseProject
+
+                project.configs = Config.defaultConfigs
+
+                project.targets = [Target(
+                    name: "target1",
+                    type: .application,
+                    platform: .iOS
+                )]
+
+                let testPlan1 = try TestPlan(path: "\(fixturePath.string)/TestProject/App_iOS/App_iOS.xctestplan", defaultPlan: true)
+                let testPlan2 = try TestPlan(path: "\(fixturePath.string)/TestProject/App_iOS/App_iOS.xctestplan", defaultPlan: true)
+
+                let scheme = Scheme(
+                    name: "xctestplan-scheme",
+                    build: Scheme.Build(targets: [
+                        Scheme.BuildTarget(target: "target1")
+                    ]),
+                    test: Scheme.Test(config: "Debug",
+                        testPlans: [testPlan1, testPlan2]
+                    )
+                )
+
+                project.schemes = [scheme]
+
+                try expectValidationError(project, .multipleDefaultTestPlans)
+            }
         }
     }
 

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -135,7 +135,7 @@ class SpecLoadingTests: XCTestCase {
                     Scheme(
                         name: "Scheme",
                         build: .init(targets: [.init(target: "NewTarget")]),
-                        test: .init(testPlans: ["paths_test/TestPlan.xctestplan"])
+                        test: .init(testPlans: [.init(path: "paths_test/TestPlan.xctestplan")])
                     )
                 ]
             }
@@ -799,7 +799,14 @@ class SpecLoadingTests: XCTestCase {
                         "gatherCoverageData": true,
                         "disableMainThreadChecker": true,
                         "stopOnEveryMainThreadCheckerIssue": true,
-                        "testPlans": ["Path/Plan.xctestplan", "Path/Plan2.xctestplan"]
+                        "testPlans": [
+                            [
+                                "path": "Path/Plan.xctestplan"
+                            ],
+                            [
+                                "path": "Path/Plan2.xctestplan"
+                            ]
+                        ]
                     ],
                 ]
                 let scheme = try Scheme(name: "Scheme", jsonDictionary: schemeDictionary)
@@ -840,7 +847,10 @@ class SpecLoadingTests: XCTestCase {
                             skippedTests: ["Test/testExample()"]
                         ),
                     ],
-                    testPlans: ["Path/Plan.xctestplan", "Path/Plan2.xctestplan"]
+                    testPlans: [
+                        .init(path: "Path/Plan.xctestplan"),
+                        .init(path: "Path/Plan2.xctestplan")
+                    ]
                 )
                 try expect(scheme.test) == expectedTest
             }

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -130,6 +130,14 @@ class SpecLoadingTests: XCTestCase {
                         postBuildScripts: [BuildScript(script: .path("paths_test/recursive_test/postBuildScript"))]
                     ),
                 ]
+
+                try expect(project.schemes) == [
+                    Scheme(
+                        name: "Scheme",
+                        build: .init(targets: [.init(target: "NewTarget")]),
+                        test: .init(testPlans: ["paths_test/TestPlan.xctestplan"])
+                    )
+                ]
             }
 
             $0.it("respects directory expansion preference") {
@@ -791,6 +799,7 @@ class SpecLoadingTests: XCTestCase {
                         "gatherCoverageData": true,
                         "disableMainThreadChecker": true,
                         "stopOnEveryMainThreadCheckerIssue": true,
+                        "testPlans": ["Path/Plan.xctestplan", "Path/Plan2.xctestplan"]
                     ],
                 ]
                 let scheme = try Scheme(name: "Scheme", jsonDictionary: schemeDictionary)
@@ -830,7 +839,8 @@ class SpecLoadingTests: XCTestCase {
                             parallelizable: true,
                             skippedTests: ["Test/testExample()"]
                         ),
-                    ]
+                    ],
+                    testPlans: ["Path/Plan.xctestplan", "Path/Plan2.xctestplan"]
                 )
                 try expect(scheme.test) == expectedTest
             }
@@ -1160,7 +1170,7 @@ class SpecLoadingTests: XCTestCase {
                 let parsedSpec = try getProjectSpec(dictionary)
                 try expect(parsedSpec) == project
             }
-            
+
             $0.it("parses old local package format") {
                 let project = Project(name: "spm", packages: [
                     "XcodeGen": .local(path: "../XcodeGen"),
@@ -1190,7 +1200,7 @@ class SpecLoadingTests: XCTestCase {
                 [ "url": "package.git", "exactVersion": "1.2.3.1" ],
                 [ "url": "package.git", "version": "foo-bar" ]
             ]
-            
+
             $0.it("is an invalid package version") {
                 for dictionary in invalidPackages {
                     try expect { _ = try SwiftPackage(jsonDictionary: dictionary) }.toThrow()

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -364,12 +364,14 @@ class SchemeGeneratorTests: XCTestCase {
             }
 
             $0.it("generate test plans ") {
+
+                let testPlanPath = fixturePath.string + "/TestProject/App_iOS/App_iOS.xctestplan"
+
                 let scheme = Scheme(
                     name: "TestScheme",
                     build: Scheme.Build(targets: [buildTarget]),
                     test: Scheme.Test(config: "Debug", testPlans: [
-                        .init(path: "Path/TestPlan.xctestplan"),
-                        .init(path: "Path/TestPlan2.xctestplan", defaultPlan: true),
+                        .init(path: testPlanPath, defaultPlan: true),
                     ])
                 )
                 let project = Project(
@@ -381,8 +383,7 @@ class SchemeGeneratorTests: XCTestCase {
 
                 let xcscheme = try unwrap(xcodeProject.sharedData?.schemes.first)
                 try expect(xcscheme.testAction?.testPlans) == [
-                    .init(reference: "container:Path/TestPlan.xctestplan", default: false),
-                    .init(reference: "container:Path/TestPlan2.xctestplan", default: true),
+                    .init(reference: "container:\(testPlanPath)", default: true),
                 ]
             }
         }

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -368,8 +368,8 @@ class SchemeGeneratorTests: XCTestCase {
                     name: "TestScheme",
                     build: Scheme.Build(targets: [buildTarget]),
                     test: Scheme.Test(config: "Debug", testPlans: [
-                        "Path/TestPlan.xctestplan",
-                        "Path/TestPlan2.xctestplan",
+                        .init(path: "Path/TestPlan.xctestplan"),
+                        .init(path: "Path/TestPlan2.xctestplan", defaultPlan: true),
                     ])
                 )
                 let project = Project(
@@ -380,10 +380,9 @@ class SchemeGeneratorTests: XCTestCase {
                 let xcodeProject = try project.generateXcodeProject()
 
                 let xcscheme = try unwrap(xcodeProject.sharedData?.schemes.first)
-
                 try expect(xcscheme.testAction?.testPlans) == [
-                    XCScheme.TestPlanReference(reference: "container:Path/TestPlan.xctestplan", default: true),
-                    XCScheme.TestPlanReference(reference: "container:Path/TestPlan2.xctestplan", default: false),
+                    .init(reference: "container:Path/TestPlan.xctestplan", default: false),
+                    .init(reference: "container:Path/TestPlan2.xctestplan", default: true),
                 ]
             }
         }

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -362,6 +362,30 @@ class SchemeGeneratorTests: XCTestCase {
                 try expect(buildEntries.first?.buildableReference.blueprintName) == "WatchApp"
                 try expect(buildEntries.last?.buildableReference.blueprintName) == "HostApp"
             }
+
+            $0.it("generate test plans ") {
+                let scheme = Scheme(
+                    name: "TestScheme",
+                    build: Scheme.Build(targets: [buildTarget]),
+                    test: Scheme.Test(config: "Debug", testPlans: [
+                        "Path/TestPlan.xctestplan",
+                        "Path/TestPlan2.xctestplan",
+                    ])
+                )
+                let project = Project(
+                    name: "test",
+                    targets: [app, framework],
+                    schemes: [scheme]
+                )
+                let xcodeProject = try project.generateXcodeProject()
+
+                let xcscheme = try unwrap(xcodeProject.sharedData?.schemes.first)
+
+                try expect(xcscheme.testAction?.testPlans) == [
+                    XCScheme.TestPlanReference(reference: "container:Path/TestPlan.xctestplan", default: true),
+                    XCScheme.TestPlanReference(reference: "container:Path/TestPlan2.xctestplan", default: false),
+                ]
+            }
         }
     }
 

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -365,7 +365,7 @@ class SchemeGeneratorTests: XCTestCase {
 
             $0.it("generate test plans ") {
 
-                let testPlanPath = fixturePath.string + "/TestProject/App_iOS/App_iOS.xctestplan"
+                let testPlanPath = "\(fixturePath.string)/TestProject/App_iOS/App_iOS.xctestplan"
 
                 let scheme = Scheme(
                     name: "TestScheme",


### PR DESCRIPTION
This supersedes #716 

### Additional changes

- [x] ability to choose a default test plan
- [x] validation errors
- [x] validation tests
- [x] docs
- [ ] way to update UUID references in test plan files

### Checklist from the previous PR

- [x]  reference test plans in schemes
- [x]  generate test plan references in schemes
- [x]  parsing tests
- [x]  generation tests
- [x]  updates scheme versions
- [x]  remove xctestplan from resources
