### PR TITLE
Add staticBinary linkType for Carthage dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Improve speed of metadata parsing and dependency resolution. [#803](https://github.com/yonaskolb/XcodeGen/pull/803) @michaeleisel
 - Improve support for iOS sticker packs and add support for `launchAutomaticallySubstyle` to run schemes. [#824](https://github.com/yonaskolb/XcodeGen/pull/824) @scelis
 - Add --project-root option to generate command. [#828](https://github.com/yonaskolb/XcodeGen/pull/828) @ileitch
-- Add an ability to set an order of groups with `options.groupOrdering` [#480](https://github.com/yonaskolb/XcodeGen/pull/613) @Beniamiiin
+- Add an ability to set an order of groups with `options.groupOrdering` [#613](https://github.com/yonaskolb/XcodeGen/pull/613) @Beniamiiin
+- Add `staticBinary` linkType for Carthage dependency [#847](https://github.com/yonaskolb/XcodeGen/pull/847) @d-date
 
 #### Fixed
 - Fixed issue when linking and embeding static frameworks: they should be linked and NOT embed. [#820](https://github.com/yonaskolb/XcodeGen/pull/820) @acecilia

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -423,7 +423,7 @@ This only applies to `framework` dependencies. Implicit framework dependencies a
 **Carthage Dependency**
 
 - [ ] **findFrameworks**: **Bool** - Whether to find Carthage frameworks automatically. Defaults to `true` .
-- [ ] **linkType**: **String** - Dependency link type. This value should be `dynamic` or `static`. Default value is `dynamic` .
+- [ ] **linkType**: **String** - Dependency link type. This value should be `dynamic`,  `static` or `staticBinary`. Default value is `dynamic` . When you use Carthage with binary only framework with `binary` keyword, use `staticBinary`.
 
 Carthage frameworks are expected to be in `CARTHAGE_BUILD_PATH/PLATFORM/FRAMEWORK.framework` where:
 

--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -36,6 +36,7 @@ public struct Dependency: Equatable {
     public enum CarthageLinkType: String {
         case dynamic
         case `static`
+        case staticBinary
 
         public static let `default` = dynamic
     }

--- a/Sources/XcodeGenKit/CarthageDependencyResolver.swift
+++ b/Sources/XcodeGenKit/CarthageDependencyResolver.swift
@@ -39,7 +39,7 @@ public class CarthageDependencyResolver {
         switch linkType {
         case .static:
             return "\(buildPath)/\(platform.carthageName)/Static"
-        case .dynamic:
+        case .dynamic, .staticBinary:
             return "\(buildPath)/\(platform.carthageName)"
         }
     }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -843,7 +843,7 @@ public class PBXProjGenerator {
                     self.carthageFrameworksByPlatform[target.platform.carthageName, default: []].insert(fileReference)
 
                     let isStaticLibrary = target.type == .staticLibrary
-                    let isCarthageStaticLink = dependency.carthageLinkType == .static
+                    let isCarthageStaticLink = (dependency.carthageLinkType == .static || dependency.carthageLinkType == .staticBinary)
                     if dependency.link ?? (!isStaticLibrary && !isCarthageStaticLink) {
                         let buildFile = self.addObject(
                             PBXBuildFile(file: fileReference, settings: getDependencyFrameworkSettings(dependency: dependency))
@@ -911,14 +911,14 @@ public class PBXProjGenerator {
 
             let embed = dependency.embed ?? target.shouldEmbedCarthageDependencies
 
-            var platformPath = Path(carthageResolver.buildPath(for: target.platform, linkType: dependency.carthageLinkType ?? .default))
+            let platformPath = Path(carthageResolver.buildPath(for: target.platform, linkType: dependency.carthageLinkType ?? .default))
             var frameworkPath = platformPath + dependency.reference
             if frameworkPath.extension == nil {
                 frameworkPath = Path(frameworkPath.string + ".framework")
             }
             let fileReference = sourceGenerator.getFileReference(path: frameworkPath, inPath: platformPath)
 
-            if dependency.carthageLinkType == .static {
+            if (dependency.carthageLinkType == .static || dependency.carthageLinkType == .staticBinary) {
                 let embedFile = addObject(
                     PBXBuildFile(file: fileReference, settings: getDependencyFrameworkSettings(dependency: dependency))
                 )
@@ -1196,16 +1196,20 @@ public class PBXProjGenerator {
             // set Carthage search paths
             let configFrameworkBuildPaths: [String]
             if !carthageDependencies.isEmpty {
-                var carthagePlatformBuildPaths: [String] = []
+                var carthagePlatformBuildPaths: Set<String> = []
                 if carthageDependencies.contains(where: { $0.carthageLinkType == .static }) {
                     let carthagePlatformBuildPath = "$(PROJECT_DIR)/" + carthageResolver.buildPath(for: target.platform, linkType: .static)
-                    carthagePlatformBuildPaths.append(carthagePlatformBuildPath)
+                    carthagePlatformBuildPaths.insert(carthagePlatformBuildPath)
                 }
                 if carthageDependencies.contains(where: { $0.carthageLinkType == .dynamic }) {
                     let carthagePlatformBuildPath = "$(PROJECT_DIR)/" + carthageResolver.buildPath(for: target.platform, linkType: .dynamic)
-                    carthagePlatformBuildPaths.append(carthagePlatformBuildPath)
+                    carthagePlatformBuildPaths.insert(carthagePlatformBuildPath)
                 }
-                configFrameworkBuildPaths = carthagePlatformBuildPaths + frameworkBuildPaths.sorted()
+                if carthageDependencies.contains(where: { $0.carthageLinkType == .staticBinary }) {
+                    let carthagePlatformBuildPath = "$(PROJECT_DIR)/" + carthageResolver.buildPath(for: target.platform, linkType: .staticBinary)
+                    carthagePlatformBuildPaths.insert(carthagePlatformBuildPath)
+                }
+                configFrameworkBuildPaths = Array(carthagePlatformBuildPaths) + frameworkBuildPaths.sorted()
             } else {
                 configFrameworkBuildPaths = frameworkBuildPaths.sorted()
             }

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -380,6 +380,7 @@ class SpecLoadingTests: XCTestCase {
                     ["target": "project/name", "embed": false],
                     ["carthage": "name", "findFrameworks": true],
                     ["carthage": "name", "findFrameworks": true, "linkType": "static"],
+                    ["carthage": "name", "findFrameworks": true, "linkType": "staticBinary"],
                     ["framework": "path", "weak": true],
                     ["sdk": "Contacts.framework"],
                     [
@@ -388,14 +389,15 @@ class SpecLoadingTests: XCTestCase {
                     ],
                 ]
                 let target = try Target(name: "test", jsonDictionary: targetDictionary)
-                try expect(target.dependencies.count) == 7
+                try expect(target.dependencies.count) == 8
                 try expect(target.dependencies[0]) == Dependency(type: .target, reference: "name", embed: false)
                 try expect(target.dependencies[1]) == Dependency(type: .target, reference: "project/name", embed: false)
                 try expect(target.dependencies[2]) == Dependency(type: .carthage(findFrameworks: true, linkType: .dynamic), reference: "name")
                 try expect(target.dependencies[3]) == Dependency(type: .carthage(findFrameworks: true, linkType: .static), reference: "name")
-                try expect(target.dependencies[4]) == Dependency(type: .framework, reference: "path", weakLink: true)
-                try expect(target.dependencies[5]) == Dependency(type: .sdk(root: nil), reference: "Contacts.framework")
-                try expect(target.dependencies[6]) == Dependency(type: .sdk(root: "DEVELOPER_DIR"), reference: "Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework")
+                try expect(target.dependencies[4]) == Dependency(type: .carthage(findFrameworks: true, linkType: .staticBinary), reference: "name")
+                try expect(target.dependencies[5]) == Dependency(type: .framework, reference: "path", weakLink: true)
+                try expect(target.dependencies[6]) == Dependency(type: .sdk(root: nil), reference: "Contacts.framework")
+                try expect(target.dependencies[7]) == Dependency(type: .sdk(root: "DEVELOPER_DIR"), reference: "Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework")
             }
 
             $0.it("parses info plist") {

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1128,7 +1128,7 @@ class ProjectGeneratorTests: XCTestCase {
 
                         let target = pbxProject.nativeTargets.first!
                         let configuration = target.buildConfigurationList!.buildConfigurations.first!
-                        try expect(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String]) == ["$(inherited)", "$(PROJECT_DIR)/Carthage/Build/iOS/Static"]
+                        try expect(Set<String>(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as! [String])) == Set<String>(arrayLiteral: "$(inherited)", "$(PROJECT_DIR)/Carthage/Build/iOS/Static")
                         let frameworkBuildPhase = try target.frameworksBuildPhase()
                         guard let files = frameworkBuildPhase?.files, let file = files.first else {
                             return XCTFail("frameworkBuildPhase should have files")
@@ -1156,7 +1156,7 @@ class ProjectGeneratorTests: XCTestCase {
 
                         let target = pbxProject.nativeTargets.first!
                         let configuration = target.buildConfigurationList!.buildConfigurations.first!
-                        try expect(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String]) == ["$(inherited)", "$(PROJECT_DIR)/Carthage/Build/iOS/Static", "$(PROJECT_DIR)/Carthage/Build/iOS"]
+                        try expect(Set<String>(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as! [String])) == Set<String>(arrayLiteral: "$(inherited)", "$(PROJECT_DIR)/Carthage/Build/iOS/Static", "$(PROJECT_DIR)/Carthage/Build/iOS")
                         let frameworkBuildPhase = try target.frameworksBuildPhase()
                         guard let files = frameworkBuildPhase?.files else {
                             return XCTFail("frameworkBuildPhase should have files")
@@ -1269,7 +1269,7 @@ class ProjectGeneratorTests: XCTestCase {
 
                         let target = pbxProject.nativeTargets.first!
                         let configuration = target.buildConfigurationList!.buildConfigurations.first!
-                        try expect(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String]) == ["$(inherited)", "$(PROJECT_DIR)/Carthage/Build/iOS/Static"]
+                        try expect(Set<String>(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as! [String])) == Set<String>(arrayLiteral: "$(inherited)", "$(PROJECT_DIR)/Carthage/Build/iOS/Static")
                         let frameworkBuildPhase = try target.frameworksBuildPhase()
                         guard let files = frameworkBuildPhase?.files, let file = files.first else {
                             return XCTFail("frameworkBuildPhase should have files")
@@ -1296,7 +1296,7 @@ class ProjectGeneratorTests: XCTestCase {
 
                         let target = pbxProject.nativeTargets.first!
                         let configuration = target.buildConfigurationList!.buildConfigurations.first!
-                        try expect(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String]) == ["$(inherited)", "$(PROJECT_DIR)/Carthage/Build/iOS"]
+                        try expect(Set<String>(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as! [String])) == Set<String>(arrayLiteral: "$(inherited)", "$(PROJECT_DIR)/Carthage/Build/iOS")
                         let frameworkBuildPhase = try target.frameworksBuildPhase()
                         guard let files = frameworkBuildPhase?.files, let file = files.first else {
                             return XCTFail("frameworkBuildPhase should have files")


### PR DESCRIPTION
When we try to use binary only framework with Carthage with Cartfile as below,  XcodeGen generate only `"$(PROJECT_DIR)/Carthage/Build/iOS/Static"` in `FRAMEWORK_SEARCH_PATH`.

Binary only framework in Carthage will download binary at `"$(PROJECT_DIR)/Carthage/Build/iOS"` so we need to distinguish these.

Cartfile
```
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAuthBinary.json"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseCrashlyticsBinary.json"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseDynamicLinksBinary.json"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseInAppMessagingBinary.json"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebasePerformanceBinary.json"
binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseRemoteConfigBinary.json"
```

project.yml (Before)
```yaml
    dependencies:
      - carthage: FirebaseABTesting
        linkType: static
      - carthage: FirebaseAnalytics
        linkType: static
      - carthage: FirebaseAuth
        linkType: static
      - carthage: FirebaseCore
        linkType: static
      ...
```

project.yml (After)
```yaml
    dependencies:
      - carthage: FirebaseABTesting
        linkType: staticBinary
      - carthage: FirebaseAnalytics
        linkType: staticBinary
      - carthage: FirebaseAuth
        linkType: staticBinary
      - carthage: FirebaseCore
        linkType: staticBinary
      ...
```