### PR TITLE
Don't deduplicate files in `include` with different paths but a same name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Implicitly include bundles in the Copy Bundle Resources build phase. [#838](https://github.com/yonaskolb/XcodeGen/pull/838) @skirchmeier
 - Fixed dumping a project manifest which contains an array of project references @paciej00
 - Generate correct PBXTargetDependency for external targets. [#843](https://github.com/yonaskolb/XcodeGen/pull/843) @ileitch
+- Don't deduplicate files in `include` with different path but same name. [#849](https://github.com/yonaskolb/XcodeGen/pull/849) @akkyie
 
 ## 2.15.1
 

--- a/Tests/Fixtures/duplicated_include/different_path/duplicated_import_root.yml
+++ b/Tests/Fixtures/duplicated_include/different_path/duplicated_import_root.yml
@@ -1,0 +1,3 @@
+name: DuplicatedImportRoot
+fileGroups:
+  - Third

--- a/Tests/Fixtures/duplicated_include/duplicated_import_sut.yml
+++ b/Tests/Fixtures/duplicated_include/duplicated_import_sut.yml
@@ -2,6 +2,7 @@ include:
   - duplicated_import_transitive.yml
   - duplicated_import_root.yml
   - duplicated_import_root.yml
+  - different_path/duplicated_import_root.yml
 name: DuplicatedImportDependent
 targets:
   IncludedTarget:

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -16,7 +16,7 @@ class SpecLoadingTests: XCTestCase {
                 let path = fixturePath + "duplicated_include/duplicated_import_sut.yml"
                 let project = try loadSpec(path: path)
 
-                try expect(project.fileGroups) == ["First", "Second"]
+                try expect(project.fileGroups) == ["First", "Second", "Third"]
 
                 let sutTarget = project.targets.first
                 try expect(sutTarget?.sources) == [TargetSource(path: "template")]


### PR DESCRIPTION
XcodeGen removes duplication among included files by their file names, not paths.
This could be problematic, when you want to define multiple targets in their respective specs:

```
- project.yml (root spec)
- Modules
 \- App
   \- targets.yml
   \- Sources
   \- Tests
 \- UI
   \- targets.yml
   \- Sources
   \- Tests
 \- Core
   \- targets.yml
   \- Sources
   \- Tests
...
```

When you include three `targets.yml`s from the `project.yml`, only the first in the `include:` list is actually included while the others are just ignored. 

This changes that by allowing SpecFile use the full path of subspecs to merge them. 
Test changes included.

Related: #599