### PR TITLE
Adding graphviz support in dump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add --project-root option to generate command. [#828](https://github.com/yonaskolb/XcodeGen/pull/828) @ileitch
 - Add an ability to set an order of groups with `options.groupOrdering` [#613](https://github.com/yonaskolb/XcodeGen/pull/613) @Beniamiiin
 - Add `staticBinary` linkType for Carthage dependency [#847](https://github.com/yonaskolb/XcodeGen/pull/847) @d-date
+- Add the ability to output a dependency graph in graphviz format [#852](https://github.com/yonaskolb/XcodeGen/pull/852) @jeffctown
 
 #### Fixed
 - Fixed issue when linking and embeding static frameworks: they should be linked and NOT embed. [#820](https://github.com/yonaskolb/XcodeGen/pull/820) @acecilia

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "GraphViz",
+        "repositoryURL": "https://github.com/SwiftDocOrg/GraphViz.git",
+        "state": {
+          "branch": null,
+          "revision": "08e0cddd013fa2272379d27ec3e0093db51f34fb",
+          "version": "0.1.0"
+        }
+      },
+      {
         "package": "JSONUtilities",
         "repositoryURL": "https://github.com/yonaskolb/JSONUtilities.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/XcodeProj.git", .exact("7.10.0")),
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.0"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
+        .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", from: "0.1.0")
     ],
     targets: [
         .target(name: "XcodeGen", dependencies: [
@@ -39,6 +40,7 @@ let package = Package(
             "XcodeProj",
             "PathKit",
             "Core",
+            "GraphViz",
         ]),
         .target(name: "ProjectSpec", dependencies: [
             "JSONUtilities",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The project spec is a YAML or JSON file that defines your targets, configuration
 - ✅ Distribute your spec amongst multiple files for easy **sharing** and overriding
 - ✅ Easily create **multi-platform** frameworks
 - ✅ Integrate **Carthage** frameworks without any work
+- ✅ Export **Dependency Diagrams** to view in [Graphviz](https://www.graphviz.org)
 
 Given a very simple project spec file like this:
 
@@ -131,6 +132,27 @@ Options:
 - **--cache-path**: A custom path to use for your cache file. This defaults to `~/.xcodegen/cache/{PROJECT_SPEC_PATH_HASH}`
 
 There are other commands as well such as `xcodegen dump` which lets out output the resolved spec in many different formats, or write it to a file. Use `xcodegen help` to see more detailed usage information.
+
+## Dependency Diagrams
+<details>
+  <summary>Click to expand!</summary>
+
+#### How to export dependency diagrams:
+
+To stdout:
+
+```
+xcodegen dump --type graphviz
+```
+
+To a file:
+
+```
+xcodegen dump --type graphviz --file Graph.viz
+```
+
+During implementation, `graphviz` formatting was validated using [GraphvizOnline](https://dreampuf.github.io/GraphvizOnline/), [WebGraphviz](http://www.webgraphviz.com), and [Graphviz on MacOS](graphviz.org).
+</details>
 
 ## Editing
 ```shell

--- a/Sources/XcodeGenCLI/Commands/DumpCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/DumpCommand.swift
@@ -4,6 +4,7 @@ import PathKit
 import ProjectSpec
 import Yams
 import Version
+import XcodeGenKit
 
 class DumpCommand: ProjectCommand {
 
@@ -40,6 +41,8 @@ class DumpCommand: ProjectCommand {
             output = try Yams.dump(object: project.toJSONDictionary())
         case .summary:
             output = project.debugDescription
+        case .graphviz:
+            output = GraphVizGenerator().generateModuleGraphViz(targets: project.targets)
         }
 
         if let file = file {
@@ -58,6 +61,7 @@ private enum DumpType: String, ConvertibleFromString, CaseIterable {
     case parsedJSON = "parsed-json"
     case parsedYaml = "parsed-yaml"
     case summary
+    case graphviz
 
     static var defaultValue: DumpType { .yaml }
 }

--- a/Sources/XcodeGenKit/GraphVizGenerator.swift
+++ b/Sources/XcodeGenKit/GraphVizGenerator.swift
@@ -1,0 +1,27 @@
+import DOT
+import Foundation
+import GraphViz
+import ProjectSpec
+
+public class GraphVizGenerator {
+    
+    public init() {}
+    
+    public func generateModuleGraphViz(targets: [Target]) -> String {
+        return DOTEncoder().encode(generateGraph(targets: targets))
+    }
+    
+    func generateGraph(targets: [Target]) -> Graph {
+        var graph = Graph(directed: true)
+        
+        targets.forEach { target in
+            target.dependencies.forEach { dependency in
+                let from = Node(target.name)
+                let to = Node(dependency.reference)
+                let edge = Edge(from: from, to: to)
+                graph.append(edge)
+            }
+        }
+        return graph
+    }
+}

--- a/Sources/XcodeGenKit/GraphVizGenerator.swift
+++ b/Sources/XcodeGenKit/GraphVizGenerator.swift
@@ -7,9 +7,22 @@ extension Dependency {
     var graphVizName: String {
         switch self.type {
         case .bundle, .package, .sdk, .framework, .carthage:
-            return "<<external>>\\n\(reference)"
+            return "[\(self.type)]\\n\(reference)"
         case .target:
             return reference
+        }
+    }
+}
+
+extension Dependency.DependencyType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .bundle: return "bundle"
+        case .package: return "package"
+        case .framework: return "framework"
+        case .carthage: return "carthage"
+        case .sdk: return "sdk"
+        case .target: return "target"
         }
     }
 }

--- a/Sources/XcodeGenKit/GraphVizGenerator.swift
+++ b/Sources/XcodeGenKit/GraphVizGenerator.swift
@@ -3,6 +3,30 @@ import Foundation
 import GraphViz
 import ProjectSpec
 
+extension Dependency {
+    var graphVizName: String {
+        switch self.type {
+        case .bundle, .package, .sdk, .framework, .carthage:
+            return "<<external>>\\n\(reference)"
+        case .target:
+            return reference
+        }
+    }
+}
+
+extension Node {
+    init(target: Target) {
+        self.init(target.name)
+        self.shape = .box
+    }
+    
+    init(dependency: Dependency) {
+        self.init(dependency.reference)
+        self.shape = .box
+        self.label = dependency.graphVizName
+    }
+}
+
 public class GraphVizGenerator {
     
     public init() {}
@@ -13,12 +37,14 @@ public class GraphVizGenerator {
     
     func generateGraph(targets: [Target]) -> Graph {
         var graph = Graph(directed: true)
-        
         targets.forEach { target in
             target.dependencies.forEach { dependency in
-                let from = Node(target.name)
-                let to = Node(dependency.reference)
-                let edge = Edge(from: from, to: to)
+                let from = Node(target: target)
+                graph.append(from)
+                let to = Node(dependency: dependency)
+                graph.append(to)
+                var edge = Edge(from: from, to: to)
+                edge.style = .dashed
                 graph.append(edge)
             }
         }

--- a/Tests/XcodeGenKitTests/GraphVizGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/GraphVizGeneratorTests.swift
@@ -1,0 +1,51 @@
+import ProjectSpec
+import Spectre
+@testable import XcodeGenKit
+import XCTest
+
+private let app = Target(
+    name: "MyApp",
+    type: .application,
+    platform: .iOS,
+    settings: Settings(buildSettings: ["SETTING_1": "VALUE"]),
+    dependencies: [Dependency(type: .target, reference: "MyFramework")]
+)
+
+private let framework = Target(
+    name: "MyFramework",
+    type: .framework,
+    platform: .iOS,
+    settings: Settings(buildSettings: ["SETTING_2": "VALUE"])
+)
+
+private let uiTest = Target(
+    name: "MyAppUITests",
+    type: .uiTestBundle,
+    platform: .iOS,
+    settings: Settings(buildSettings: ["SETTING_3": "VALUE"]),
+    dependencies: [Dependency(type: .target, reference: "MyApp")]
+)
+
+private let targets = [app, framework, uiTest]
+
+class GraphVizGeneratorTests: XCTestCase {
+
+    func testGraphOutput() throws {
+        describe {
+            $0.it("generates the expected edges") {
+                let graph = GraphVizGenerator().generateGraph(targets: targets)
+                try expect(graph.edges.count) == 2
+            }
+            $0.it("generates the expected output") {
+                let output = GraphVizGenerator().generateModuleGraphViz(targets: targets)
+                try expect(output) == """
+                digraph {
+                  MyApp -> MyFramework
+                  MyAppUITests -> MyApp
+                }
+                """
+            }
+        }
+    }
+}
+

--- a/Tests/XcodeGenKitTests/GraphVizGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/GraphVizGeneratorTests.swift
@@ -48,8 +48,20 @@ class GraphVizGeneratorTests: XCTestCase {
             $0.it("generates box nodes") {
                 try expect(graph.nodes.filter({ $0.shape == .box }).count) == 16
             }
-            $0.it("generates the expected external nodes") {
-                try expect(graph.nodes.filter({ $0.label?.contains("<<external>>") ?? false }).count) == 6
+            $0.it("generates the expected carthage nodes") {
+                try expect(graph.nodes.filter({ $0.label?.contains("[carthage]") ?? false }).count) == 2
+            }
+            $0.it("generates the expected sdk nodes") {
+                try expect(graph.nodes.filter({ $0.label?.contains("[sdk]") ?? false }).count) == 1
+            }
+            $0.it("generates the expected Framework nodes") {
+                try expect(graph.nodes.filter({ $0.label?.contains("[framework]") ?? false }).count) == 1
+            }
+            $0.it("generates the expected package nodes") {
+                try expect(graph.nodes.filter({ $0.label?.contains("[package]") ?? false }).count) == 1
+            }
+            $0.it("generates the expected bundle nodes") {
+                try expect(graph.nodes.filter({ $0.label?.contains("[bundle]") ?? false }).count) == 1
             }
             $0.it("generates the expected edges") {
                 try expect(graph.edges.count) == 8
@@ -64,17 +76,17 @@ class GraphVizGeneratorTests: XCTestCase {
                   MyApp [shape=box]
                   MyInternalFramework [label=MyInternalFramework shape=box]
                   MyApp [shape=box]
-                  Resources [label="<<external>>\\nResources" shape=box]
+                  Resources [label="[bundle]\\nResources" shape=box]
                   MyApp [shape=box]
-                  MyStaticFramework [label="<<external>>\\nMyStaticFramework" shape=box]
+                  MyStaticFramework [label="[carthage]\\nMyStaticFramework" shape=box]
                   MyApp [shape=box]
-                  MyDynamicFramework [label="<<external>>\\nMyDynamicFramework" shape=box]
+                  MyDynamicFramework [label="[carthage]\\nMyDynamicFramework" shape=box]
                   MyApp [shape=box]
-                  MyExternalFramework [label="<<external>>\\nMyExternalFramework" shape=box]
+                  MyExternalFramework [label="[framework]\\nMyExternalFramework" shape=box]
                   MyApp [shape=box]
-                  MyPackage [label="<<external>>\\nMyPackage" shape=box]
+                  MyPackage [label="[package]\\nMyPackage" shape=box]
                   MyApp [shape=box]
-                  MySDK [label="<<external>>\\nMySDK" shape=box]
+                  MySDK [label="[sdk]\\nMySDK" shape=box]
                   MyAppUITests [shape=box]
                   MyApp [label=MyApp shape=box]
                   MyApp -> MyInternalFramework [style=dashed]


### PR DESCRIPTION
Hey there! 👋

## Motivation

I came here looking for the same thing mentioned in #646: a way to output a dependency graph from `xcodegen` project files

## Whats in this PR

I added support, like specified in the linked issue.  

The following will output a Graphviz to stdout:

`xcodegen dump --type graphviz`

And this will output to a file:

`xcodegen dump --type graphviz --file ~/Desktop/output.viz`

When the output is pasted into an [online graphviz tool](https://dreampuf.github.io/GraphvizOnline/) it can produce a target dependency graph based on xcodegen project files.

This was created from the Test Fixture project in `Tests/Fixtures/TestProject/`:

![TestProjectDependencyGraph](https://user-images.githubusercontent.com/2142301/80649586-53ff4600-8a40-11ea-922f-ee5356c68eb8.png)

## What Should We Discuss?

Well, I'm adding a dependency on a [graphviz package](https://github.com/SwiftDocOrg/GraphViz).  It is actively maintained.

Is this worth adding a dependency? 🤷‍♂️
