### PR TITLE
Optimize simplifying paths for faster project generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix linking of multiple products from the same Swift Package [#830](https://github.com/yonaskolb/XcodeGen/pull/830) @toshi0383
 - Don't deduplicate files in `include` with different path but same name. [#849](https://github.com/yonaskolb/XcodeGen/pull/849) @akkyie
 - Don't link transitive static carthage libraries. [#853](https://github.com/yonaskolb/XcodeGen/pull/853) @akkyie
+- Optimize simplifying paths for faster project generation. [#857](https://github.com/yonaskolb/XcodeGen/pull/857) @akkyie
 
 ## 2.15.1
 

--- a/Sources/Core/PathExtensions.swift
+++ b/Sources/Core/PathExtensions.swift
@@ -11,7 +11,14 @@ extension Path {
     /// - `../a/b` simplifies to `../a/b`
     /// - `a/../../c` simplifies to `../c`
     public func simplifyingParentDirectoryReferences() -> Path {
-        normalize().components.reduce(Path(), +)
+        if !string.contains("..") { // Skip simplifying if its already simple
+            var string = self.string
+            while string.hasSuffix(Path.separator) { // Remove all trailing path separators
+                string.removeLast()
+            }
+            return Path(String(string))
+        }
+        return normalize().components.reduce(Path(), +)
     }
 
     /// Returns the relative path necessary to go from `base` to `self`.


### PR DESCRIPTION
We are using XcodeGen with a ~3000 files project, and the project generation for it takes about 3s.
I wanted to know what's taking time, and Instruments told me that the time of `Path.simplifyingParentDirectoryReferences` calls reaches almost 30% of the whole.
I also found that repeated invocation of `Path.+` is time-consuming as it causes String copying and conversion between NSString.

This looks kind of overkill to me, because most of the paths in our project don't include parent path reference nor have trailing slashes. So, this change avoids `Path.+` when the path does not include `..` in its middle, while manually removing trailing slashes with a simpler way instead.
It cuts off our project generation time down to about 2/3 (2s). I think it's not common case where many paths in a project needs the actual simplification, but the overhead of this change for these cases would be ignorable. 

I didn't completely rewrite the whole function to minimize the possibility of regression for special cases. I want to know if even this fast-path has any patterns to cause regression.

| Before | After |
|-------|-------|
|<img width="300" alt="before" src="https://user-images.githubusercontent.com/1528813/81323648-a8ee2c80-90d0-11ea-83ef-e5ca9b3fbde5.png">|<img width="300" alt="after" src="https://user-images.githubusercontent.com/1528813/81323633-a4297880-90d0-11ea-966c-2d91aff441a6.png">|
|<img width="300" alt="PathKit" src="https://user-images.githubusercontent.com/1528813/81323652-a986c300-90d0-11ea-979e-3d2ac1b0f5fa.png">||
