### PR TITLE
Preserve ordering of scheme targets as defined in the yml

### DIFF
--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -604,7 +604,7 @@ extension Scheme.Build: JSONObjectConvertible {
             let target = try TargetReference(targetRepr)
             targets.append(Scheme.BuildTarget(target: target, buildTypes: buildTypes))
         }
-        self.targets = targets.sorted { $0.target.name < $1.target.name }
+        self.targets = targets
         preActions = try jsonDictionary.json(atKeyPath: "preActions")?.map(Scheme.ExecutionAction.init) ?? []
         postActions = try jsonDictionary.json(atKeyPath: "postActions")?.map(Scheme.ExecutionAction.init) ?? []
         parallelizeBuild = jsonDictionary.json(atKeyPath: "parallelizeBuild") ?? Scheme.Build.parallelizeBuildDefault


### PR DESCRIPTION
Scheme targets are currently being sorted alphabetically.
Target order matters because the [first entry is grabbed when creating a buildableReference](https://github.com/yonaskolb/XcodeGen/blob/master/Sources/XcodeGenKit/SchemeGenerator.swift#L167)

I ran into this issue when trying to create a scheme for a watch app
```
schemes:
  Watch:
    build:
      targets:
        WatchApp: all
        MainApp: all
```
xcodegen ends up defaulting to my MainApp as the Executable instead of my WatchApp because MainApp comes first alphabetically.