### PR TITLE
Allow passing a custom executable for schemes

### DIFF
--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -74,18 +74,21 @@ public struct Scheme: Equatable {
         public static let buildImplicitDependenciesDefault = true
 
         public var targets: [BuildTarget]
+        public var executableName: String?
         public var parallelizeBuild: Bool
         public var buildImplicitDependencies: Bool
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
         public init(
             targets: [BuildTarget],
+            executableName: String? = nil,
             parallelizeBuild: Bool = parallelizeBuildDefault,
             buildImplicitDependencies: Bool = buildImplicitDependenciesDefault,
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = []
         ) {
             self.targets = targets
+            self.executableName = executableName
             self.parallelizeBuild = parallelizeBuild
             self.buildImplicitDependencies = buildImplicitDependencies
             self.preActions = preActions
@@ -605,6 +608,7 @@ extension Scheme.Build: JSONObjectConvertible {
             targets.append(Scheme.BuildTarget(target: target, buildTypes: buildTypes))
         }
         self.targets = targets.sorted { $0.target.name < $1.target.name }
+        executableName = jsonDictionary.json(atKeyPath: "executable")
         preActions = try jsonDictionary.json(atKeyPath: "preActions")?.map(Scheme.ExecutionAction.init) ?? []
         postActions = try jsonDictionary.json(atKeyPath: "postActions")?.map(Scheme.ExecutionAction.init) ?? []
         parallelizeBuild = jsonDictionary.json(atKeyPath: "parallelizeBuild") ?? Scheme.Build.parallelizeBuildDefault

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -164,7 +164,19 @@ public class SchemeGenerator {
         let schemeTarget = target ?? project.getTarget(scheme.build.targets.first!.target.name)
         let shouldExecuteOnLaunch = schemeTarget?.shouldExecuteOnLaunch == true
 
-        let buildableReference = buildActionEntries.first!.buildableReference
+        let buildableReference: XCScheme.BuildableReference = {
+            if let executableName = scheme.build.executableName {
+                guard let entry = buildActionEntries.first(where: {
+                    $0.buildableReference.blueprintName == executableName
+                }) else {
+                    fatalError("No such executable \"\(executableName)\" for scheme \"\(scheme.name)\"")
+                }
+                return entry.buildableReference
+            } else {
+                return buildActionEntries.first!.buildableReference
+            }
+        }()
+        
         let runnables = makeProductRunnables(for: schemeTarget, buildableReference: buildableReference)
 
         let buildAction = XCScheme.BuildAction(


### PR DESCRIPTION
Currently scheme targets are being sorted alphabetically and the first target in the list is being chosen as the executable.
I ran into this issue when trying to make a scheme for a Watch target
```
schemes:
  Watch:
    build:
      targets:
        WatchApp: all
        MainApp: all
```
MainApp is being selected as the executable because it comes first alphabetically

This pull request adds the ability to explicitly set which target should be used as the executable by adding a new `executable` key to the spec
```
schemes:
  Watch:
    build:
      targets:
        WatchApp: all
        MainApp: all
      executable: WatchApp
```