### PR TITLE
Support for parallel target generation

### DIFF
--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -101,6 +101,7 @@ class GenerateCommand: ProjectCommand {
         info("⚙️  Generating project...")
         var errors: [Error] = []
         let overallDispatchGroup = DispatchGroup()
+        let startTime = Date()
         overallDispatchGroup.enter()
         let generateAndWriteProject = DispatchWorkItem { [weak self] in
             var xcodeProject: XcodeProj!
@@ -157,6 +158,7 @@ class GenerateCommand: ProjectCommand {
         }
         DispatchQueue.global(qos: .userInitiated).async(execute: generateAndWriteProject)
         overallDispatchGroup.wait()
+        info("Project was generated in \(Int(Date().timeIntervalSince(startTime))) seconds")
     }
 
     func info(_ string: String) {

--- a/Sources/XcodeGenKit/Atomic.swift
+++ b/Sources/XcodeGenKit/Atomic.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+class Atomic<Value> {
+    private let queue = DispatchQueue(label: "com.yonaskolb.xcodegen.atomic")
+    private var value: Value
+
+    init(wrappedValue: Value) {
+        self.value = wrappedValue
+    }
+
+    var wrappedValue: Value {
+        get {
+            return queue.sync { value }
+        }
+        set {
+            queue.sync { value = newValue }
+        }
+    }
+
+    func mutate(_ mutation: (inout Value) -> Void) {
+        return queue.sync {
+            mutation(&value)
+        }
+    }
+}

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -17,14 +17,14 @@ public class PBXProjGenerator {
 
     var sourceGenerator: SourceGenerator!
 
-    var targetObjects: [String: PBXTarget] = [:]
+    var targetObjects: Atomic<[String: PBXTarget]> = Atomic<[String: PBXTarget]>(wrappedValue: [:])
     var targetAggregateObjects: [String: PBXAggregateTarget] = [:]
     var targetFileReferences: [String: PBXFileReference] = [:]
     var sdkFileReferences: [String: PBXFileReference] = [:]
     var packageReferences: [String: XCRemoteSwiftPackageReference] = [:]
 
     var carthageFrameworksByPlatform: [String: Set<PBXFileElement>] = [:]
-    var frameworkFiles: [PBXFileElement] = []
+    var frameworkFiles: Atomic<[PBXFileElement]> = Atomic<[PBXFileElement]>(wrappedValue: [])
     var bundleFiles: [PBXFileElement] = []
 
     var generated = false
@@ -145,7 +145,9 @@ public class PBXProjGenerator {
                 targetObject = PBXNativeTarget(name: target.name, buildPhases: [])
             }
 
-            targetObjects[target.name] = addObject(targetObject)
+            targetObjects.mutate {
+                $0[target.name] = addObject(targetObject)
+            }
 
             var explicitFileType: String?
             var lastKnownFileType: String?
@@ -319,13 +321,15 @@ public class PBXProjGenerator {
                     path: carthageResolver.buildPath
                 )
             )
-            frameworkFiles.append(carthageGroup)
+            frameworkFiles.mutate {
+                $0.append(carthageGroup)
+            }
         }
 
-        if !frameworkFiles.isEmpty {
+        if !frameworkFiles.wrappedValue.isEmpty {
             let group = addObject(
                 PBXGroup(
-                    children: frameworkFiles,
+                    children: frameworkFiles.wrappedValue,
                     sourceTree: .group,
                     name: "Frameworks"
                 )
@@ -344,7 +348,7 @@ public class PBXProjGenerator {
             derivedGroups.append(group)
         }
 
-        mainGroup.children = Array(sourceGenerator.rootGroups)
+        mainGroup.children = Array(sourceGenerator.rootGroups.wrappedValue)
         sortGroups(group: mainGroup)
         setupGroupOrdering(group: mainGroup)
         // add derived groups at the end
@@ -373,7 +377,7 @@ public class PBXProjGenerator {
             projectAttributes["knownAssetTags"] = assetTags
         }
 
-        var knownRegions = Set(sourceGenerator.knownRegions)
+        var knownRegions = Set(sourceGenerator.knownRegions.wrappedValue)
         knownRegions.insert(developmentRegion)
         if project.options.useBaseInternationalization {
             knownRegions.insert("Base")
@@ -382,7 +386,7 @@ public class PBXProjGenerator {
 
         pbxProject.packages = packageReferences.sorted { $0.key < $1.key }.map { $1 }
 
-        let allTargets: [PBXTarget] = targetObjects.valueArray + targetAggregateObjects.valueArray
+        let allTargets: [PBXTarget] = targetObjects.wrappedValue.valueArray + targetAggregateObjects.valueArray
         pbxProject.targets = allTargets
             .sorted { $0.name < $1.name }
         pbxProject.attributes = projectAttributes
@@ -427,7 +431,7 @@ public class PBXProjGenerator {
     }
 
     func generateTargetDependency(from: String, to target: String, platform: String?) -> PBXTargetDependency {
-        guard let targetObject = targetObjects[target] ?? targetAggregateObjects[target] else {
+        guard let targetObject = targetObjects.wrappedValue[target] ?? targetAggregateObjects[target] else {
             fatalError("Target dependency not found: from ( \(from) ) to ( \(target) )")
         }
 
@@ -633,7 +637,7 @@ public class PBXProjGenerator {
         }
 
         for target in project.targets {
-            guard let pbxTarget = targetObjects[target.name] else {
+            guard let pbxTarget = targetObjects.wrappedValue[target.name] else {
                 continue
             }
             generateTargetAttributes(target, pbxTarget: pbxTarget)
@@ -889,8 +893,10 @@ public class PBXProjGenerator {
                     targetFrameworkBuildFiles.append(buildFile)
                 }
 
-                if !frameworkFiles.contains(fileReference) {
-                    frameworkFiles.append(fileReference)
+                if !frameworkFiles.wrappedValue.contains(fileReference) {
+                    frameworkFiles.mutate {
+                        $0.append(fileReference)
+                    }
                 }
 
                 if embed {
@@ -938,7 +944,9 @@ public class PBXProjGenerator {
                         )
                     )
                     sdkFileReferences[dependency.reference] = fileReference
-                    frameworkFiles.append(fileReference)
+                    frameworkFiles.mutate({
+                        $0.append(fileReference)
+                    })
                 }
 
                 let pbxBuildFile = PBXBuildFile(
@@ -1451,7 +1459,7 @@ public class PBXProjGenerator {
             defaultConfigurationName: defaultConfigurationName
         ))
 
-        let targetObject = targetObjects[target.name]!
+        let targetObject = targetObjects.wrappedValue[target.name]!
 
         let targetFileReference = targetFileReferences[target.name]
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -13,6 +13,7 @@ public class PBXProjGenerator {
     let projectDirectory: Path?
     let carthageResolver: CarthageDependencyResolver
     let projGeneratorQueue: DispatchQueue = DispatchQueue(label: "com.yonaskolb.xcodegen.projGeneratorQueue")
+    let childrenUpdateQueue: DispatchQueue = DispatchQueue(label: "com.yonaskolb.xcodegen.projGeneratorChildrenUpdatesQueue")
 
     public static let copyFilesActionMask: UInt = 8
 
@@ -523,7 +524,9 @@ public class PBXProjGenerator {
             )
         )
 
-        productsGroup.children.append(productReferenceProxy)
+        childrenUpdateQueue.sync {
+            productsGroup.children.append(productReferenceProxy)
+        }
 
         let targetDependency = addObject(
             PBXTargetDependency(

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -21,6 +21,8 @@ class SourceGenerator {
     private var localPackageGroup: PBXGroup?
     private let serialQueueForGroupGeneration: DispatchQueue = DispatchQueue(label: "com.yonaskolb.xcodegen.group_generation.serial")
     private let serialQueueForFileGeneration: DispatchQueue = DispatchQueue(label: "com.yonaskolb.xcodegen.file_generation.serial")
+    private let serialQueueForChildGroupUpdates: DispatchQueue = DispatchQueue(label: "com.yonaskolb.xcodegen.source_generator_child_groupupdates.serial")
+
 
     private let project: Project
     let pbxProj: PBXProj
@@ -566,8 +568,10 @@ class SourceGenerator {
                 )
 
                 if let variantGroup = variantGroup {
-                    if !variantGroup.children.contains(fileReference) {
-                        variantGroup.children.append(fileReference)
+                    serialQueueForChildGroupUpdates.sync {
+                        if !variantGroup.children.contains(fileReference) {
+                            variantGroup.children.append(fileReference)
+                        }
                     }
                 } else {
                     // add SourceFile to group if there is no Base.lproj directory

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -91,7 +91,7 @@ class SourceGenerator {
         }
     }
 
-    func getAllSourceFiles(targetType: PBXProductType, sources: [TargetSource], completion: @escaping (([SourceFile]) -> Void), buildPhases: [Path : BuildPhaseSpec]) throws {
+    func getAllSourceFiles(targetType: PBXProductType, sources: [TargetSource], buildPhases: [Path : BuildPhaseSpec], completion: @escaping (([SourceFile]) -> Void)) throws {
         var flattenedSources: [SourceFile] = []
         let group = DispatchGroup()
         try sources.forEach { (source) in
@@ -106,7 +106,7 @@ class SourceGenerator {
     }
 
     // get groups without build files. Use for Project.fileGroups
-    func getFileGroups(path: String, completion: @escaping (() -> ()), buildPhases: [Path : BuildPhaseSpec]) throws {
+    func getFileGroups(path: String, completion: @escaping (() -> ())) throws {
         _ = try getSourceFiles(targetType: .none, targetSource: TargetSource(path: path), buildPhases: [:]) { _ in
             completion()
         }

--- a/Tests/FixtureTests/FixtureTests.swift
+++ b/Tests/FixtureTests/FixtureTests.swift
@@ -28,7 +28,12 @@ private func generateXcodeProject(specPath: Path, file: String = #file, line: In
     let project = try Project(path: specPath)
     let generator = ProjectGenerator(project: project)
     let writer = FileWriter(project: project)
-    let xcodeProject = try generator.generateXcodeProject()
-    try writer.writeXcodeProject(xcodeProject)
-    try writer.writePlists()
+    try generator.generateXcodeProject() { (xcodeProject) in
+        do {
+            try writer.writeXcodeProject(xcodeProject)
+            try writer.writePlists()
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
 }

--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -23,15 +23,25 @@ class GeneratedPerformanceTests: XCTestCase {
     func testGeneration() throws {
         let project = try Project.testProject(basePath: basePath)
         measure {
+            let expectation = XCTestExpectation(description: "Project generation expectation")
             let generator = ProjectGenerator(project: project)
-            _ = try! generator.generateXcodeProject()
+            try! generator.generateXcodeProject { _ in
+                expectation.fulfill()
+            }
+            wait(for: [expectation], timeout: 10)
         }
     }
 
     func testWriting() throws {
         let project = try Project.testProject(basePath: basePath)
         let generator = ProjectGenerator(project: project)
-        let xcodeProject = try generator.generateXcodeProject()
+        let expectation = XCTestExpectation(description: "Project generation expectation")
+        var xcodeProject: XcodeProj!
+        try generator.generateXcodeProject() { (generatedXcodeProj) in
+            xcodeProject = generatedXcodeProj
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 10)
         measure {
             xcodeProject.pbxproj.invalidateUUIDs()
             try! xcodeProject.write(path: project.defaultProjectPath)
@@ -64,14 +74,24 @@ class FixturePerformanceTests: XCTestCase {
         let project = try Project(path: specPath)
         measure {
             let generator = ProjectGenerator(project: project)
-            _ = try! generator.generateXcodeProject()
+            let expectation = XCTestExpectation(description: "Project generation expectation")
+            _ = try! generator.generateXcodeProject() { _ in
+                expectation.fulfill()
+            }
+            wait(for: [expectation], timeout: 30)
         }
     }
 
     func testFixtureWriting() throws {
         let project = try Project(path: specPath)
         let generator = ProjectGenerator(project: project)
-        let xcodeProject = try generator.generateXcodeProject()
+        let expectation = XCTestExpectation(description: "Project generation expectation")
+        var xcodeProject: XcodeProj!
+        try! generator.generateXcodeProject() { (generatedXcodeProj) in
+            xcodeProject = generatedXcodeProj
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 30)
         measure {
             xcodeProject.pbxproj.invalidateUUIDs()
             try! xcodeProject.write(path: project.defaultProjectPath)

--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -75,8 +75,10 @@ class FixturePerformanceTests: XCTestCase {
         measure {
             let generator = ProjectGenerator(project: project)
             let expectation = XCTestExpectation(description: "Project generation expectation")
-            _ = try! generator.generateXcodeProject() { _ in
-                expectation.fulfill()
+            DispatchQueue.global(qos: .userInitiated).async {
+                _ = try! generator.generateXcodeProject() { _ in
+                    expectation.fulfill()
+                }
             }
             wait(for: [expectation], timeout: 30)
         }

--- a/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
@@ -275,8 +275,15 @@ class PBXProjGeneratorTests: XCTestCase {
         let attributes: [String: Any] = [lastUpgradeKey: 1234]
         let project = Project(name: "Test", attributes: attributes)
         let projGenerator = PBXProjGenerator(project: project)
-        
-        let pbxProj = try projGenerator.generate()
+
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+        var pbxProj: PBXProj!
+        try projGenerator.generate { (generatedPbxproj) in
+            pbxProj = generatedPbxproj
+            dispatchGroup.leave()
+        }
+        dispatchGroup.wait()
         
         for pbxProject in pbxProj.projects {
             XCTAssertEqual(pbxProject.attributes[lastUpgradeKey] as? String, project.xcodeVersion)
@@ -290,7 +297,14 @@ class PBXProjGeneratorTests: XCTestCase {
         let project = Project(name: "Test", attributes: attributes)
         let projGenerator = PBXProjGenerator(project: project)
         
-        let pbxProj = try projGenerator.generate()
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+        var pbxProj: PBXProj!
+        try projGenerator.generate { (generatedPbxproj) in
+            pbxProj = generatedPbxproj
+            dispatchGroup.leave()
+        }
+        dispatchGroup.wait()
         
         for pbxProject in pbxProj.projects {
             XCTAssertEqual(pbxProject.attributes[lastUpgradeKey] as? String, lastUpgradeValue)
@@ -302,7 +316,14 @@ class PBXProjGeneratorTests: XCTestCase {
         let project = Project(name: "Test")
         let projGenerator = PBXProjGenerator(project: project)
         
-        let pbxProj = try projGenerator.generate()
+        let dispatchGroup = DispatchGroup()
+        dispatchGroup.enter()
+        var pbxProj: PBXProj!
+        try projGenerator.generate { (generatedPbxproj) in
+            pbxProj = generatedPbxproj
+            dispatchGroup.leave()
+        }
+        dispatchGroup.wait()
         
         for pbxProject in pbxProj.projects {
             XCTAssertEqual(pbxProject.attributes[lastUpgradeKey] as? String, project.xcodeVersion)

--- a/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
@@ -15,7 +15,15 @@ extension Project {
                 try self.validate()
             }
             let generator = ProjectGenerator(project: self)
-            return try generator.generateXcodeProject()
+            let dispatchGroup = DispatchGroup()
+            dispatchGroup.enter()
+            var xcodeproj: XcodeProj!
+            try generator.generateXcodeProject() {
+                xcodeproj = $0
+                dispatchGroup.leave()
+            }
+            dispatchGroup.wait()
+            return xcodeproj
         }
     }
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -355,7 +355,14 @@ class ProjectGeneratorTests: XCTestCase {
                     let project = try! Project(path: fixturePath + "TestProject/AnotherProject/project.yml")
                     let generator = ProjectGenerator(project: project)
                     let writer = FileWriter(project: project)
-                    let xcodeProject = try! generator.generateXcodeProject()
+                    let dispatchGroup = DispatchGroup()
+                    dispatchGroup.enter()
+                    var xcodeProject: XcodeProj!
+                    try! generator.generateXcodeProject() {
+                        xcodeProject = $0
+                        dispatchGroup.leave()
+                    }
+                    dispatchGroup.wait()
                     try! writer.writeXcodeProject(xcodeProject)
                     try! writer.writePlists()
                     subproject = xcodeProject.pbxproj
@@ -1513,7 +1520,14 @@ class ProjectGeneratorTests: XCTestCase {
                 $0.it("generate groups") {
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
-                    let generatedProject = try generator.generateXcodeProject()
+                    let dispatchGroup = DispatchGroup()
+                    dispatchGroup.enter()
+                    var generatedProject: XcodeProj!
+                    try! generator.generateXcodeProject() {
+                        generatedProject = $0
+                        dispatchGroup.leave()
+                    }
+                    dispatchGroup.wait()
                     let group = generatedProject.pbxproj.groups.first(where: { $0.nameOrPath == groupName })
                     try expect(group?.path) == "App_iOS"
                 }
@@ -1524,7 +1538,14 @@ class ProjectGeneratorTests: XCTestCase {
                     let destinationPath = fixturePath
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
-                    let generatedProject = try generator.generateXcodeProject(in: destinationPath)
+                    let dispatchGroup = DispatchGroup()
+                    dispatchGroup.enter()
+                    var generatedProject: XcodeProj!
+                    try! generator.generateXcodeProject(in: destinationPath) {
+                        generatedProject = $0
+                        dispatchGroup.leave()
+                    }
+                    dispatchGroup.wait()
                     let group = generatedProject.pbxproj.groups.first(where: { $0.nameOrPath == groupName })
                     try expect(group?.path) == "TestProject/App_iOS"
                 }
@@ -1533,7 +1554,14 @@ class ProjectGeneratorTests: XCTestCase {
                     let destinationPath = fixturePath
                     let project = Project(name: "test", targets: [frameworkWithSources])
                     let generator = ProjectGenerator(project: project)
-                    let generatedProject = try generator.generateXcodeProject(in: destinationPath)
+                    let dispatchGroup = DispatchGroup()
+                    dispatchGroup.enter()
+                    var generatedProject: XcodeProj!
+                    try! generator.generateXcodeProject(in: destinationPath) {
+                        generatedProject = $0
+                        dispatchGroup.leave()
+                    }
+                    dispatchGroup.wait()
                     let plists = generatedProject.pbxproj.buildConfigurations.compactMap { $0.buildSettings["INFOPLIST_FILE"] as? String }
                     try expect(plists.count) == 2
                     for plist in plists {

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -350,7 +350,14 @@ class SchemeGeneratorTests: XCTestCase {
                     let project = try! Project(path: fixturePath + "scheme_test/test_project.yml")
                     let generator = ProjectGenerator(project: project)
                     let writer = FileWriter(project: project)
-                    let xcodeProject = try! generator.generateXcodeProject()
+                    let dispatchGroup = DispatchGroup()
+                    dispatchGroup.enter()
+                    var xcodeProject: XcodeProj!
+                    try! generator.generateXcodeProject() {
+                        xcodeProject = $0
+                        dispatchGroup.leave()
+                    }
+                    dispatchGroup.wait()
                     try! writer.writeXcodeProject(xcodeProject)
                     try! writer.writePlists()
                 }
@@ -381,7 +388,14 @@ class SchemeGeneratorTests: XCTestCase {
                     let project = try! Project(path: fixturePath + "scheme_test/test_project.yml")
                     let generator = ProjectGenerator(project: project)
                     let writer = FileWriter(project: project)
-                    let xcodeProject = try! generator.generateXcodeProject()
+                    let dispatchGroup = DispatchGroup()
+                    dispatchGroup.enter()
+                    var xcodeProject: XcodeProj!
+                    try! generator.generateXcodeProject() {
+                        xcodeProject = $0
+                        dispatchGroup.leave()
+                    }
+                    dispatchGroup.wait()
                     try! writer.writeXcodeProject(xcodeProject)
                     try! writer.writePlists()
                 }


### PR DESCRIPTION
## Background

- In my current work project, we have around 55 targets being generated using Xcodegen. Out of which 24 targets are targets with no dependency on any other target.
- After running the time profiler using my project.yml and a debug xcodegen binary, I found out that most of the time was being spent in the `Glob.exploreDirectories` section.
- The 55 targets which we have migrated are just approximately 1/3rd of all the targets our app supports today, so the time taken to run Xcodegen would only increase proportionally to the number of targets we have in the future.
- So the motivation was to be able to generate atleast these 24 targets in parallel to get a good speed boost because Glob can be executed in parallel for such targets.

## Overview of changes to code in this PR
- I started from bottom up, so the attempt was to make `getSourceMatches` in SourceGenerator.swift, be able to run asynchronously in multiple threads for each target
  - This required making all the functions in the calling chain accept completion handlers, instead of directly returning the generated result.
- The changes heavily rely on `GCD` to dispatch to global queues, with QOS as `userInitiated`, along with heavy use of `DispatchGroups`, to block queue execution when successive code depend on a result from an async completion handler being executed.
- The main queue does not perform any operations while the targets are being generated but rather is blocked waiting for the targets to be generated before proceeding to the `Writing project` phase. Instead of blocking the main queue, we could probably show progress to the user on how many targets have been generated in a separate PR.
  - Had to block the main queue because:
     - Main queue is serial and we want to generate multiple targets, so we need to use a global async queue.
     - I felt we should keep the main queue clear of any background/processing operations, so everything related to generating the targets, is done in a background thread.
     - The execute function in `GenerateCommand.swift` is a synchronous function, if we return early, the xcodegen command exits as well, so we have to make the main queue wait so that the command thinks, that processing is still going on.
- Introduced the Atomic class inspired from an [objc.io article](https://www.objc.io/blog/2018/12/18/atomic-variables/)
  - These are required to make some of the shared variables such as `rootGroups` in SourceGenerator.swift and more, be thread safe, ie reading and writing happens using a serial queue.
     - A future improvement/refactor would be try and make more and more of these variables independently stored in a struct for each target, have to explore the codebase more to understand if that is possible.
- Moved the `getAllDependenciesPlusTransitiveNeedingEmbedding` from SourceGenerator.swift to `Target.swift`, so that the code in SourceGenerator.swift reduces a bit, and to be able to reuse this function to figure out the order of generating targets, by reusing and calling this function on each target itself, ex: `target.getAllDependencies(usingProject:)`
  - This change required moving `shouldEmbedDependencies` as well and marking it as a public function
   - Let me know if this change can be given in a separate PR to reduce the diff on this PR
- Because of the introduction of dispatch groups, and dispatch queues, there is a lot of diff, with just indentation changes, so apologies for the large diff in advance 🙏 

## Overview of changes related to tests in this PR
- To minimise the amount of code changes in the test targets, the helper functions such as `generateXcodeProject` in `PBXProjGeneratorTests.swift` have been modified to convert the completion handler based functions to be serial functions, which return a single value instead of accepting and calling the completion handlers
- All the existing tests pass, but no new tests have been added yet. Will add new tests, after an initial round of review.

## Results
- For the 55 targets, on my MBP 2018 version, it used to take 14 seconds for the xcodegen command to finish.
- Now after these changes it takes approx 7 seconds, a **50%** improvement in project generation times
- These improvements will vary depending on how many targets you have, and how many of them could be generated in parallel.