### PR TITLE
Added ability to name the executable target in schemes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 - Add an ability to set an order of groups with `options.groupOrdering` [#613](https://github.com/yonaskolb/XcodeGen/pull/613) @Beniamiiin
 - Add `staticBinary` linkType for Carthage dependency [#847](https://github.com/yonaskolb/XcodeGen/pull/847) @d-date
 - Add the ability to output a dependency graph in graphviz format [#852](https://github.com/yonaskolb/XcodeGen/pull/852) @jeffctown
-- Adds uncluttering the project manifest dumped to YAML from empty values [#858](https://github.com/yonaskolb/XcodeGen/pull/858) @paciej00 
-
+- Adds uncluttering the project manifest dumped to YAML from empty values [#858](https://github.com/yonaskolb/XcodeGen/pull/858) @paciej00
+- Added ability to name the executable target when declaring schemes. [#866](https://github.com/yonaskolb/XcodeGen/pull/866) @elland
 
 
 #### Fixed

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -73,19 +73,23 @@ public struct Scheme: Equatable {
         public static let parallelizeBuildDefault = true
         public static let buildImplicitDependenciesDefault = true
 
+        public var executableName: String?
         public var targets: [BuildTarget]
         public var parallelizeBuild: Bool
         public var buildImplicitDependencies: Bool
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
+
         public init(
             targets: [BuildTarget],
+            executableName: String?,
             parallelizeBuild: Bool = parallelizeBuildDefault,
             buildImplicitDependencies: Bool = buildImplicitDependenciesDefault,
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = []
         ) {
             self.targets = targets
+            self.executableName = executableName
             self.parallelizeBuild = parallelizeBuild
             self.buildImplicitDependencies = buildImplicitDependencies
             self.preActions = preActions
@@ -98,6 +102,7 @@ public struct Scheme: Equatable {
         public static let stopOnEveryMainThreadCheckerIssueDefault = false
         public static let debugEnabledDefault = true
 
+        public var executableName: String?
         public var config: String?
         public var commandLineArguments: [String: Bool]
         public var preActions: [ExecutionAction]
@@ -113,6 +118,7 @@ public struct Scheme: Equatable {
 
         public init(
             config: String,
+            executableName: String?,
             commandLineArguments: [String: Bool] = [:],
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
@@ -126,6 +132,7 @@ public struct Scheme: Equatable {
             simulateLocation: SimulateLocation? = nil
         ) {
             self.config = config
+            self.executableName = executableName
             self.commandLineArguments = commandLineArguments
             self.preActions = preActions
             self.postActions = postActions
@@ -352,6 +359,7 @@ extension Scheme.Run: JSONObjectConvertible {
         region = jsonDictionary.json(atKeyPath: "region")
         debugEnabled = jsonDictionary.json(atKeyPath: "debugEnabled") ?? Scheme.Run.debugEnabledDefault
         simulateLocation = jsonDictionary.json(atKeyPath: "simulateLocation")
+        executableName = jsonDictionary.json(atKeyPath: "executable")
 
         // launchAutomaticallySubstyle is defined as a String in XcodeProj but its value is often
         // an integer. Parse both to be nice.
@@ -605,6 +613,7 @@ extension Scheme.Build: JSONObjectConvertible {
             targets.append(Scheme.BuildTarget(target: target, buildTypes: buildTypes))
         }
         self.targets = targets.sorted { $0.target.name < $1.target.name }
+        self.executableName = jsonDictionary.json(atKeyPath: "executable")
         preActions = try jsonDictionary.json(atKeyPath: "preActions")?.map(Scheme.ExecutionAction.init) ?? []
         postActions = try jsonDictionary.json(atKeyPath: "postActions")?.map(Scheme.ExecutionAction.init) ?? []
         parallelizeBuild = jsonDictionary.json(atKeyPath: "parallelizeBuild") ?? Scheme.Build.parallelizeBuildDefault

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -82,7 +82,7 @@ public struct Scheme: Equatable {
 
         public init(
             targets: [BuildTarget],
-            executableName: String?,
+            executableName: String? = nil,
             parallelizeBuild: Bool = parallelizeBuildDefault,
             buildImplicitDependencies: Bool = buildImplicitDependenciesDefault,
             preActions: [ExecutionAction] = [],
@@ -102,7 +102,6 @@ public struct Scheme: Equatable {
         public static let stopOnEveryMainThreadCheckerIssueDefault = false
         public static let debugEnabledDefault = true
 
-        public var executableName: String?
         public var config: String?
         public var commandLineArguments: [String: Bool]
         public var preActions: [ExecutionAction]
@@ -118,7 +117,6 @@ public struct Scheme: Equatable {
 
         public init(
             config: String,
-            executableName: String?,
             commandLineArguments: [String: Bool] = [:],
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
@@ -132,7 +130,6 @@ public struct Scheme: Equatable {
             simulateLocation: SimulateLocation? = nil
         ) {
             self.config = config
-            self.executableName = executableName
             self.commandLineArguments = commandLineArguments
             self.preActions = preActions
             self.postActions = postActions
@@ -359,7 +356,6 @@ extension Scheme.Run: JSONObjectConvertible {
         region = jsonDictionary.json(atKeyPath: "region")
         debugEnabled = jsonDictionary.json(atKeyPath: "debugEnabled") ?? Scheme.Run.debugEnabledDefault
         simulateLocation = jsonDictionary.json(atKeyPath: "simulateLocation")
-        executableName = jsonDictionary.json(atKeyPath: "executable")
 
         // launchAutomaticallySubstyle is defined as a String in XcodeProj but its value is often
         // an integer. Parse both to be nice.

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -652,7 +652,7 @@ public class PBXProjGenerator {
         var packageDependencies: [XCSwiftPackageProductDependency] = []
         var extensions: [PBXBuildFile] = []
         var carthageFrameworksToEmbed: [String] = []
-        var localPackageReferences: [String] = project.packages.compactMap { $0.value.isLocal ? $0.key : nil }
+        let localPackageReferences: [String] = project.packages.compactMap { $0.value.isLocal ? $0.key : nil }
 
         let targetDependencies = (target.transitivelyLinkDependencies ?? project.options.transitivelyLinkDependencies) ?
             getAllDependenciesPlusTransitiveNeedingEmbedding(target: target) : target.dependencies

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -161,10 +161,17 @@ public class SchemeGenerator {
             return XCScheme.ExecutionAction(scriptText: action.script, title: action.name, environmentBuildable: environmentBuildable)
         }
 
-        let schemeTarget = target ?? project.getTarget(scheme.build.targets.first!.target.name)
+        let schemeTarget: Target?
+
+        if let targetName = scheme.build.executableName {
+            schemeTarget = project.getTarget(targetName)
+        } else {
+            schemeTarget = target ?? project.getTarget(scheme.build.targets.first!.target.name)
+        }
+
         let shouldExecuteOnLaunch = schemeTarget?.shouldExecuteOnLaunch == true
 
-        let buildableReference = buildActionEntries.first!.buildableReference
+        let buildableReference = buildActionEntries.first(where: { $0.buildableReference.blueprintName == schemeTarget?.name })?.buildableReference ?? buildActionEntries.first!.buildableReference
         let runnables = makeProductRunnables(for: schemeTarget, buildableReference: buildableReference)
 
         let buildAction = XCScheme.BuildAction(
@@ -314,12 +321,14 @@ extension Scheme {
             name: name,
             build: .init(
                 targets: Scheme.buildTargets(for: target, project: project),
+                executableName: nil,
                 buildImplicitDependencies: targetScheme.buildImplicitDependencies,
                 preActions: targetScheme.preActions,
                 postActions: targetScheme.postActions
             ),
             run: .init(
                 config: debugConfig,
+                executableName: nil,
                 commandLineArguments: targetScheme.commandLineArguments,
                 environmentVariables: targetScheme.environmentVariables,
                 disableMainThreadChecker: targetScheme.disableMainThreadChecker,

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -321,14 +321,12 @@ extension Scheme {
             name: name,
             build: .init(
                 targets: Scheme.buildTargets(for: target, project: project),
-                executableName: nil,
                 buildImplicitDependencies: targetScheme.buildImplicitDependencies,
                 preActions: targetScheme.preActions,
                 postActions: targetScheme.postActions
             ),
             run: .init(
                 config: debugConfig,
-                executableName: nil,
                 commandLineArguments: targetScheme.commandLineArguments,
                 environmentVariables: targetScheme.environmentVariables,
                 disableMainThreadChecker: targetScheme.disableMainThreadChecker,


### PR DESCRIPTION
Attempting to address #589. I only managed to gather a small understanding of the code base, so please let me know if there's a simpler/better way of doing this. For example, I don't like that I'm using a value from the `build` section to configure something in the `run` section.

It works by adding the `executable` key to the `build` subsection of a scheme:

```
schemes:
  MyScheme:
    build:
      executable: MyExecutable
      targets:
      ...
``` 