### PR TITLE
Allow skipping compile source build phase for bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Optimize simplifying paths for faster project generation. [#857](https://github.com/yonaskolb/XcodeGen/pull/857) @akkyie
 - Fixed issue where wrapper folders may not include correctly in the generated project. [#862](https://github.com/yonaskolb/XcodeGen/pull/862) @KhaosT
 - Compile `xcmappingmodel` files instead of copying bundle resources. [#834](https://github.com/yonaskolb/XcodeGen/pull/834) @jcolicchio
+- Fixed issue where `Complie Sources` build phase is generated for resource bundles even when they have no files to compile [#878](https://github.com/yonaskolb/XcodeGen/pull/878) @nkukushkin
 
 ## 2.15.1
 

--- a/Sources/ProjectSpec/XCProjExtensions.swift
+++ b/Sources/ProjectSpec/XCProjExtensions.swift
@@ -44,8 +44,8 @@ extension PBXProductType {
 
     public var canSkipCompileSourcesBuildPhase: Bool {
         switch self {
-        case .stickerPack, .messagesApplication:
-            // Sticker packs and simple messages applications without sources should not include a
+        case .bundle, .stickerPack, .messagesApplication:
+            // Bundles, sticker packs and simple messages applications without sources should not include a
             // compile sources build phase. Doing so can cause Xcode to produce an error on build.
             return true
         default:

--- a/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
@@ -46,7 +46,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 32C09717E388BCD9DB9E513C /* Build configuration list for PBXNativeTarget "BundleX" */;
 			buildPhases = (
-				B3BCC260A0A2F2F00458816F /* Sources */,
 			);
 			buildRules = (
 			);
@@ -100,13 +99,6 @@
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		B3BCC260A0A2F2F00458816F /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		F08051CAC5E72EEEB8FB447B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -719,9 +719,11 @@ class ProjectGeneratorTests: XCTestCase {
                     let copyBundlesPhase = copyFilesPhases.first { $0.dstSubfolderSpec == .resources }
 
                     // All targets should have a compile sources phase,
-                    // except for the sticker pack one
+                    // except for the resourceBundle and sticker pack one
+                    let targetsGeneratingSourcePhases = targets
+                        .filter { ![.bundle, .stickerPack].contains($0.type) }
                     let sourcesPhases = pbxProject.sourcesBuildPhases
-                    try expect(sourcesPhases.count) == targets.count - 1
+                    try expect(sourcesPhases.count) == targetsGeneratingSourcePhases.count
 
                     // ensure only the right resources are copied, no more, no less
                     if let expectedResourceFiles = expectedResourceFiles[target.name] {


### PR DESCRIPTION
## Motivation

We've added a resource bundle to our app and this caused the following issue while uploading to the [ASC](https://appstoreconnect.apple.com):
>ERROR ITMS-90171: "Invalid Bundle Structure - The binary file 'XXX.app/YYYY.bundle/YYYY' is not permitted. Your app can't contain standalone executables or libraries, other than a valid CFBundleExecutable of supported bundles. Refer to the Bundle Programming Guide at [https://developer.apple.com/go/?id=bundle-structure](https://developer.apple.com/go/?id=bundle-structure) for information on the iOS app bundle structure."

We solved this by removing `CFBundleExecutable` parameter from the bundle’s Info.plist file (as per default behaviour described in [xcodegen docks](https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#target)) and `Compile Sources` build phase from the its target. However, when we use xcodegen, the `Compile Sources` build phase comes back, even though it’s empty.

Judging by [the source](https://github.com/yonaskolb/XcodeGen/blob/92aaebb9d5f28bc5498bb20ca5d6f9750a14f5f5/Sources/XcodeGenKit/PBXProjGenerator.swift#L985-L990) it seems impossible to make xcodegen skip `Compile Sources` unless the target’s type is hardcoded in [canSkipCompileSourcesBuildPhase](https://github.com/yonaskolb/XcodeGen/blob/0319116f941e081722eadb6264b5d035b2187773/Sources/ProjectSpec/XCProjExtensions.swift#L45-L54).

This issue is very similar to https://github.com/yonaskolb/XcodeGen/pull/149

## Solution

I propose adding `bundle` to the list of types whose `canSkipCompileSourcesBuildPhase` property returns `true`.