### PR TITLE
Improve target dependency not found fatalError

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -340,7 +340,7 @@ public class PBXProjGenerator {
 
     func generateTargetDependency(from: String, to target: String) -> PBXTargetDependency {
         guard let targetObject = targetObjects[target] ?? targetAggregateObjects[target] else {
-            fatalError("target not found")
+            fatalError("Target dependency not found: from ( \(from) ) to ( \(target) )")
         }
 
         let targetProxy = addObject(


### PR DESCRIPTION
It's pretty tricky to find out how to fix it otherwise. Hitting this
often when using XcodeGen with XCHammer for Bazel Xcode projects.
XCHammer simply pulls in transitive targets, but users can filter out a
subset of targets based on paths. Both XCHammer and XcodeGen Yaml give
users flexibility for specify what targets are in their Xcode project,
so it's useful to give them a better validation error if they create
one.