### PR TITLE
Update JSON Dictionary parser to look for 'executableName' instead of 'executable'

### DIFF
--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -358,7 +358,7 @@ extension Scheme.Run: JSONObjectConvertible {
         region = jsonDictionary.json(atKeyPath: "region")
         debugEnabled = jsonDictionary.json(atKeyPath: "debugEnabled") ?? Scheme.Run.debugEnabledDefault
         simulateLocation = jsonDictionary.json(atKeyPath: "simulateLocation")
-        executableName = jsonDictionary.json(atKeyPath: "executable")
+        executableName = jsonDictionary.json(atKeyPath: "executableName")
 
         // launchAutomaticallySubstyle is defined as a String in XcodeProj but its value is often
         // an integer. Parse both to be nice.


### PR DESCRIPTION
Related: #869

In the linked PR, the new feature for defining the schemes run action Executable was added. In the ProjectSpec docs, it refers to this property in the yaml as `executableName` but I got stumped because it didn't seem to work.

After digging into the code, it looks like it's referenced everywhere as `executableName` but the JSON decoding was looking for a value under the `executable` key instead. 

I'm not sure what the intention was, but I've updated that key to match the docs in this PR so that it works as described... Or should it have been the other way round? Should I update the docs to mention `executable`? 

Here are the docs - https://github.com/yonaskolb/XcodeGen/blob/f61af8caa9b26ce47814ef6e32402ea99402c208/Docs/ProjectSpec.md#run-action