### PR TITLE
Idea - Chaining spec generation using projectReferences

### DIFF
--- a/Sources/ProjectSpec/ProjectReference.swift
+++ b/Sources/ProjectSpec/ProjectReference.swift
@@ -4,10 +4,12 @@ import JSONUtilities
 public struct ProjectReference: Hashable {
     public var name: String
     public var path: String
+    public var spec: String?
 
-    public init(name: String, path: String) {
+    public init(name: String, path: String, spec: String?) {
         self.name = name
         self.path = path
+        self.spec = spec
     }
 }
 
@@ -17,6 +19,7 @@ extension ProjectReference: PathContainer {
         [
             .dictionary([
                 .string("path"),
+                .string("spec")
             ]),
         ]
     }
@@ -26,6 +29,7 @@ extension ProjectReference: NamedJSONDictionaryConvertible {
     public init(name: String, jsonDictionary: JSONDictionary) throws {
         self.name = name
         self.path = try jsonDictionary.json(atKeyPath: "path")
+        self.spec = jsonDictionary.json(atKeyPath: "spec")
     }
 }
 
@@ -33,6 +37,7 @@ extension ProjectReference: JSONEncodable {
     public func toJSONValue() -> Any {
         [
             "path": path,
+            "spec": spec
         ]
     }
 }

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -5,6 +5,19 @@ import XcodeProj
 import Yams
 import Version
 
+private extension Project {
+    func referencesSatisfied(with projects: [Project]) -> Bool {
+        // FIXME: Project.projectReferences do not contain enough information to assess this correclty all the time.
+        // This is because we don't know the references 'correct' output path until we load the spec (and read the real `name`).
+        // To overcome this, we should pass some data from `loadedProjects` that helps better resolve a spec path to a loaded project, that way we can be 100% sure...
+        // we'd also need to be a bit careful about cases where differnet specs reference the same spec to different output directories. This is something we could assess at laod time and error about.
+        let availableProjectPaths = projects.map({ $0.basePath.absolute() })
+        return projectReferences
+            .filter { $0.spec != nil }
+            .allSatisfy { availableProjectPaths.contains((basePath + $0.path).parent().absolute()) }
+    }
+}
+
 public class SpecLoader {
 
     var project: Project!
@@ -13,6 +26,71 @@ public class SpecLoader {
 
     public init(version: Version) {
         self.version = version
+    }
+
+    public func loadProjects(path: Path, projectRoot: Path? = nil, variables: [String: String] = [:]) throws -> [Project] {
+        // 1: Load the root project.
+        let rootProject = try loadProject(path: path, projectRoot: projectRoot, variables: variables)
+
+        // 2: Find references and recursevly load them until we have everything in memory.
+        var loadedProjects: [Path: Project] = [rootProject.defaultProjectPath.absolute(): rootProject]
+        try loadReferencedProjects(in: rootProject, variables: variables, into: &loadedProjects, relativeTo: path.parent())
+
+        // 3: Order the projects to generate without missing references
+        var projects: [Project] = []
+        while !loadedProjects.isEmpty {
+            // 4. Find the first project from `loadedProject` that can be generated with the items currently defined in `projects`. This helps determine the correct order to run the generator command.
+            guard let (key, project) = loadedProjects.first(where: { $0.value.referencesSatisfied(with: projects) }) else {
+                throw NSError(domain: "", code: 0, userInfo: nil) // TODO: Add to GeneratorError with correct order
+            }
+
+            // 5. Remove from `loadedProjects` and insert in `projects` since we've now resolved this project
+            loadedProjects[key] = nil
+            projects.append(project)
+        }
+
+        // 4. Return the projects ready for generating in defined order
+        print("Resolved projects in order:")
+        projects.enumerated().forEach { print("\($0.offset + 1).", $0.element.defaultProjectPath.string) }
+        return projects
+    }
+
+    private func loadReferencedProjects(
+        in project: Project,
+        variables: [String: String],
+        into store: inout [Path: Project],
+        relativeTo relativePath: Path
+    ) throws {
+        // Enumerate dependencies and see if there are other specs to load
+        for projectReference in project.projectReferences {
+            // If the refernece doesn't specify a spec then ignore it since we assume that it's a non-generated project
+            guard let spec = projectReference.spec else { continue }
+
+            // Work out the path to the spec that we need to load
+            let path = (relativePath + spec).absolute()
+
+            // Work out the directory which the project will be generated into, ignore the project name since that will be decided based on the spec once loaded.
+            // We might want to warn or error if there re inconsistencies though.
+            let projectRoot = (relativePath + projectReference.path).parent()
+
+            // Load the project, read the path that it resolved to (this uses the name from inside the spec, rather than the reference name that could be wrong)
+            let project = try loadProject(path: path, projectRoot: projectRoot, variables: variables)
+            let projectPath = project.defaultProjectPath.absolute()
+
+            // TODO: Error if a matching loaded project in the `store` originated from a different spec.
+            // This could be a scenario where two differnet spec files define the same `projectReference.path` but associate the `spec`'s to differnet yaml files.
+
+            // Skip this reference if we've already loaded the project once before, no need to do so twice
+            guard store[projectPath] == nil else {
+                continue
+            }
+
+            // Store the loaded project so that we don't load it again if it's referenced by a different spec
+            store[projectPath] = project
+
+            // Repeat the process for any references in the newly loaded project
+            try loadReferencedProjects(in: project, variables: variables, into: &store, relativeTo: path.parent())
+        }
     }
 
     public func loadProject(path: Path, projectRoot: Path? = nil, variables: [String: String] = [:]) throws -> Project {

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -36,17 +36,19 @@ class ProjectCommand: Command {
         }
 
         let specLoader = SpecLoader(version: version)
-        let project: Project
+        let projects: [Project]
 
         let variables: [String: String] = disableEnvExpansion ? [:] : ProcessInfo.processInfo.environment
 
         do {
-            project = try specLoader.loadProject(path: projectSpecPath, projectRoot: projectRoot, variables: variables)
+            projects = try specLoader.loadProjects(path: projectSpecPath, projectRoot: projectRoot, variables: variables)
         } catch {
             throw GenerationError.projectSpecParsingError(error)
         }
 
-        try execute(specLoader: specLoader, projectSpecPath: projectSpecPath, project: project)
+        for project in projects {
+            try execute(specLoader: specLoader, projectSpecPath: projectSpecPath, project: project)
+        }
     }
 
     func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {}

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -261,7 +261,7 @@ class ProjectSpecTests: XCTestCase {
 
             $0.it("fails with invalid project reference path") {
                 var project = baseProject
-                let reference = ProjectReference(name: "InvalidProj", path: "invalid_path")
+                let reference = ProjectReference(name: "InvalidProj", path: "invalid_path", spec: nil)
                 project.projectReferences = [reference]
                 try expectValidationError(project, .invalidProjectReferencePath(reference))
             }
@@ -283,7 +283,7 @@ class ProjectSpecTests: XCTestCase {
                 var project = baseProject
                 let externalProjectPath = fixturePath + "TestProject/AnotherProject/AnotherProject.xcodeproj"
                 project.projectReferences = [
-                    ProjectReference(name: "validProjectRef", path: externalProjectPath.string)
+                    ProjectReference(name: "validProjectRef", path: externalProjectPath.string, spec: nil)
                 ]
                 project.targets = [
                     Target(

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -59,7 +59,7 @@ class SpecLoadingTests: XCTestCase {
                 )
 
                 try expect(project.projectReferences) == [
-                    ProjectReference(name: "ProjX", path: "TestProject/Project.xcodeproj"),
+                    ProjectReference(name: "ProjX", path: "TestProject/Project.xcodeproj", spec: nil),
                 ]
 
                 try expect(project.aggregateTargets) == [

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -361,7 +361,7 @@ class ProjectGeneratorTests: XCTestCase {
                     subproject = xcodeProject.pbxproj
                 }
                 let externalProjectPath = fixturePath + "TestProject/AnotherProject/AnotherProject.xcodeproj"
-                let projectReference = ProjectReference(name: "AnotherProject", path: externalProjectPath.string)
+                let projectReference = ProjectReference(name: "AnotherProject", path: externalProjectPath.string, spec: nil)
                 var target = app
                 target.dependencies = [
                     Dependency(type: .target, reference: "AnotherProject/ExternalTarget")

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -277,7 +277,7 @@ class SchemeGeneratorTests: XCTestCase {
                     try! writer.writePlists()
                 }
                 let externalProjectPath = fixturePath + "scheme_test/TestProject.xcodeproj"
-                let projectReference = ProjectReference(name: "ExternalProject", path: externalProjectPath.string)
+                let projectReference = ProjectReference(name: "ExternalProject", path: externalProjectPath.string, spec: nil)
                 let target = Scheme.BuildTarget(target: .init(name: "ExternalTarget", location: .project("ExternalProject")))
                 let scheme = Scheme(
                     name: "ExternalProjectScheme",
@@ -326,7 +326,7 @@ class SchemeGeneratorTests: XCTestCase {
                     targets: [framework],
                     schemes: [scheme],
                     projectReferences: [
-                        ProjectReference(name: "TestProject", path: externalProject.string),
+                        ProjectReference(name: "TestProject", path: externalProject.string, spec: nil),
                     ]
                 )
                 let xcodeProject = try project.generateXcodeProject()


### PR DESCRIPTION
👋 I've been spending some time recently working out a plan for modularising our project and have been looking into recent discussions in the issues about how XcodeGen might be able to further help with this. 

It mostly relates to the RFC/thread for workspace generation (#168) back in 2017, however since the original discussion, XcodeGen has grown quite a bit and now has support for things like subprojects using projectReferences that were introduced in #701. 

From my (somewhat limited) understanding of the project, the projectReferences seem like a potentially good candidate for expansion to allow the automatic generation of a number of Xcode Projects so I tried putting some feelers out there in #776 but didn't get much of a response. Since I had some time this weekend, I wanted to give a POC a go to better understand things.

In this draft PR, I've expanded `SpecLoader` to introduce a new method:

```swift
SpecLoader.loadProjects(path:projectRoot:variables:)
```

This method combined with the new optional `spec` property on a `ProjectReference` allows the loader to resolve all dependant specs in order to compute an array of `Project` objects that can then be passed into the generator to generate dependant projects in the correct order.

----

As an example, lets say that I have the following specs in my workspace:

**./Global/project.yml**
```yml
name: Global
projectReferences:
  Frameworks:
    path: ../Frameworks/Frameworks.xcodeproj
    spec: ../Frameworks/project.yml
  GlobalCore:
    path: ../GlobalCore/GlobalCore.xcodeproj
    spec: ../GlobalCore/project.yml
  Settings:
    path: ../GlobalFeatures/Settings/Settings.xcodeproj
    spec: ../GlobalFeatures/Settings/project.yml
# ...
```

**./Frameworks/project.yml**
```yml
name: Frameworks
# ...
```

**./GlobalCore/project.yml***
```yml
name: GlobalCore
projectReferences:
  Frameworks:
    path: ../Frameworks/Frameworks.xcodeproj
    spec: ../Frameworks/project.yml
# ... 
```

**./GlobalFeatures/Settings/project.yml**
```yml
name: Settings
projectReferences:
  Frameworks:
    path: ../Frameworks/Frameworks.xcodeproj
    spec: ../Frameworks/project.yml
  GlobalCore:
    path: ../GlobalCore/GlobalCore.xcodeproj
    spec: ../GlobalCore/project.yml
# ... 
```

I can now run the generator command on my entry project, I'll get the following output:

```
$ xcodegen generate --project ~./Global --spec ~./Global/project.yml 
Resolved projects in order:
1. ./Frameworks/Frameworks.xcodeproj
2. ./GlobalCore/GlobalCore.xcodeproj
3. ./GlobalFeatures/Settings/Settings.xcodeproj
4. ./Global/Global.xcodeproj
⚙️  Generating plists...
⚙️  Generating project...
⚙️  Writing project...
Created project at ./Frameworks/Frameworks.xcodeproj
⚙️  Generating plists...
⚙️  Generating project...
⚙️  Writing project...
Created project at ./GlobalCore/GlobalCore.xcodeproj
⚙️  Generating plists...
⚙️  Generating project...
⚙️  Writing project...
Created project at ./GlobalFeatures/Settings/Settings.xcodeproj
⚙️  Generating plists...
⚙️  Generating project...
⚙️  Writing project...
Created project at ./Global/Global.xcodeproj
```

As a result, I then end up with all four projects generated as I expect! This helps me to avoid having to maintain a wrapping script for XcodeGen that currently consists of me manually invoking the generator a given number of times since all of the specs are detected based on my `projectReferences` that I already have to define anyway 🚀 

---

So, while all of this works, it's far from being correct. I've identified a number of things that would probably need addressing before hand, but before we look into that, I want to get some thoughts on the concept in general 🙏 

Here are a few things to discuss:

1. `xcodegen` the CLI is very tailored to a specific project/spec since both `GenerateCommand` and `DumpCommand` inherit from `ProjectCommand`. Would this still make sense?
2. This approach works by running the generator a number multiple times to keep changes minimal, but if loaded all projects and generated in one go then we could benefit `dump` by being able to visualise the workspace/repo's dependencies cross-projects
3. Because `projectReferences` is keyed by the `name` that is used for reference in the spec, this has the potential to be different to the name of the actual project and this could get confusing but this can't be solved unless we load the referenced specs before resolving the project itself.
4. SpecLoader might need rewriting, I didn't get time to look at why it stores `project` but maybe that breaks things since there are now multiple. Might be better to investigate loading multiple `SpecFile` objects first and resolving them first? 
5. Having to match up `path` and `spec` in `ProjectReference` could lead to misconfigurations where the same spec points to different project paths, or different project paths use the same spec. We can validate against that but maybe there would also be a way to avoid this? 
6. Is building on top of `projectReferences` the right approach to this? By doing so, it means that you can use them both with existing xcodeproj references and also specs to be generated. I think that's a good thing but I might be overlooking something? 

I'm really keen to help out on a feature like this, but I think the idea still needs fleshing out a bit so any input on this would be great! Thanks! 
