### PR TITLE
Allow creating intermediary groups outside of the project directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Add `Scheme.Test.TestTarget.skipped` to allow skipping of an entire test target. [#916](https://github.com/yonaskolb/XcodeGen/pull/916) @codeman9
 
 #### Fixed
-- Allow SDK dependencies to be embedded. [#922](https://github.com/yonaskolb/XcodeGen/pull/922) @k-thorat 
+- Allow SDK dependencies to be embedded. [#922](https://github.com/yonaskolb/XcodeGen/pull/922) @k-thorat
+- Allow creating intermediary groups outside of the project directory. [#892](https://github.com/yonaskolb/XcodeGen/pull/892) @segiddins
 
 ## 2.17.0
 

--- a/Sources/Core/PathExtensions.swift
+++ b/Sources/Core/PathExtensions.swift
@@ -73,4 +73,12 @@ extension Path {
                                                    relativeTo: ArraySlice(base.simplifyingParentDirectoryReferences().components),
                                                    memo: []))
     }
+
+    /// Returns whether `self` is a strict parent of `child`.
+    ///
+    /// Both paths must be asbolute or relative paths.
+    public func isParent(of child: Path) throws -> Bool {
+        let relativePath = try child.relativePath(from: self)
+        return relativePath.components.allSatisfy { $0 != ".." }
+    }
 }

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -492,7 +492,7 @@ class SourceGeneratorTests: XCTestCase {
                 let pbxProj = try project.generatePbxProj()
                 try pbxProj.expectFile(paths: ["Sources", "A", "b.swift"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["Sources", "F", "G", "h.swift"], buildPhase: .sources)
-                try pbxProj.expectFile(paths: ["../OtherDirectory/C/D", "e.swift"], names: ["D", "e.swift"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: ["..", "OtherDirectory", "C", "D", "e.swift"], names: [".", "OtherDirectory", "C", "D", "e.swift"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["Sources/B", "b.swift"], names: ["B", "b.swift"], buildPhase: .sources)
             }
 


### PR DESCRIPTION
Resolves #889 

Putting this out as a potential solution -- I'm new to the codebase, so I'm not sure if there's maybe a better way of doing this, or if there's a reason this is unacceptable. Just wanted to try it out, since it makes the projects we're generating via bazel in a scratch directory nicer to edit