### PR TITLE
Fix a bug in computing relative paths.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Treat all directories with known UTI as file wrapper. [#896](https://github.com/yonaskolb/XcodeGen/pull/896) @KhaosT
 - Generated schemes for application extensions now contain `wasCreatedForAppExtension = YES`. [#898](https://github.com/yonaskolb/XcodeGen/issues/898) @muizidn
 - Allow package dependencies to use `link: false` [#920](https://github.com/yonaskolb/XcodeGen/pull/920) @k-thorat   
+- Fixed issue computing relative paths.  [#915](https://github.com/yonaskolb/XcodeGen/pull/915) @andrewreach
 
 #### Internal
 - Updated to XcodeProj 7.13.0 [#908](https://github.com/yonaskolb/XcodeGen/pull/908) @brentleyjones

--- a/Sources/Core/PathExtensions.swift
+++ b/Sources/Core/PathExtensions.swift
@@ -49,7 +49,7 @@ extension Path {
                 return try pathComponents(for: path.dropFirst(), relativeTo: base, memo: memo + [rhs])
 
             // Both sides have a common parent
-            case (.some(let lhs), .some(let rhs)) where lhs == rhs:
+            case (.some(let lhs), .some(let rhs)) where memo.isEmpty && lhs == rhs:
                 return try pathComponents(for: path.dropFirst(), relativeTo: base.dropFirst(), memo: memo)
 
             // `base` has a path to back out of

--- a/Tests/CoreTests/PathExtensionsTests.swift
+++ b/Tests/CoreTests/PathExtensionsTests.swift
@@ -48,6 +48,7 @@ class PathExtensionsTests: XCTestCase {
                 try expect(relativePath(to: "/a/../../b", from: "/b")) == "."
                 try expect(relativePath(to: "a/..", from: "a")) == ".."
                 try expect(relativePath(to: "a/../b", from: "b")) == "."
+                try expect(relativePath(to: "/a/c", from: "/a/b/c")) == "../../c"
             }
 
             $0.it("backtracks on a non-normalized base path") {


### PR DESCRIPTION
Once a difference in path components between base and self has been
encountered, it is no longer valid to skip over common components.