### PR TITLE
Add ability to skip the entire test target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Version
 
+- Add `Scheme.Test.TestTarget.skipped` to allow skipping of an entire test target. [#916](https://github.com/yonaskolb/XcodeGen/pull/916) @codeman9
+
 ## 2.17.0
 
 #### Added

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -793,6 +793,7 @@ A multiline script can be written using the various YAML multiline methods, for 
 - [x] **name**: **String** - The name of the target
 - [ ] **parallelizable**: **Bool** - Whether to run tests in parallel. Defaults to false
 - [ ] **randomExecutionOrder**: **Bool** - Whether to run tests in a random order. Defaults to false
+- [ ] **skipped**: **Bool** - Whether to skip all of the test target tests. Defaults to false
 - [ ] **skippedTests**: **[String]** - List of tests in the test target to skip. Defaults to empty.
 
 ### Archive Action

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -500,6 +500,9 @@ extension Scheme.Test.TestTarget: JSONEncodable {
         if parallelizable != Scheme.Test.TestTarget.parallelizableDefault {
             dict["parallelizable"] = parallelizable
         }
+        if skipped {
+            dict["skipped"] = skipped
+        }
 
         return dict
     }

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -172,17 +172,20 @@ public struct Scheme: Equatable {
             public let targetReference: TargetReference
             public var randomExecutionOrder: Bool
             public var parallelizable: Bool
+            public var skipped: Bool
             public var skippedTests: [String]
 
             public init(
                 targetReference: TargetReference,
                 randomExecutionOrder: Bool = randomExecutionOrderDefault,
                 parallelizable: Bool = parallelizableDefault,
+                skipped: Bool = false,
                 skippedTests: [String] = []
             ) {
                 self.targetReference = targetReference
                 self.randomExecutionOrder = randomExecutionOrder
                 self.parallelizable = parallelizable
+                self.skipped = skipped
                 self.skippedTests = skippedTests
             }
 
@@ -191,6 +194,7 @@ public struct Scheme: Equatable {
                     targetReference = try TargetReference(value)
                     randomExecutionOrder = false
                     parallelizable = false
+                    skipped = false
                     skippedTests = []
                 } catch {
                     fatalError(SpecParsingError.invalidTargetReference(value).description)
@@ -474,6 +478,7 @@ extension Scheme.Test.TestTarget: JSONObjectConvertible {
         targetReference = try TargetReference(jsonDictionary.json(atKeyPath: "name"))
         randomExecutionOrder = jsonDictionary.json(atKeyPath: "randomExecutionOrder") ?? Scheme.Test.TestTarget.randomExecutionOrderDefault
         parallelizable = jsonDictionary.json(atKeyPath: "parallelizable") ?? Scheme.Test.TestTarget.parallelizableDefault
+        skipped = jsonDictionary.json(atKeyPath: "skipped") ?? false
         skippedTests = jsonDictionary.json(atKeyPath: "skippedTests") ?? []
     }
 }

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -183,7 +183,7 @@ public class SchemeGenerator {
 
         let testables = zip(testTargets, testBuildTargetEntries).map { testTarget, testBuilEntries in
             XCScheme.TestableReference(
-                skipped: false,
+                skipped: testTarget.skipped,
                 parallelizable: testTarget.parallelizable,
                 randomExecutionOrdering: testTarget.randomExecutionOrder,
                 buildableReference: testBuilEntries.buildableReference,

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -782,6 +782,7 @@ class SpecLoadingTests: XCTestCase {
                             [
                                 "name": "ExternalProject/Target2",
                                 "parallelizable": true,
+                                "skipped": true,
                                 "randomExecutionOrder": true,
                                 "skippedTests": ["Test/testExample()"],
                             ],
@@ -826,6 +827,7 @@ class SpecLoadingTests: XCTestCase {
                             targetReference: "ExternalProject/Target2",
                             randomExecutionOrder: true,
                             parallelizable: true,
+                            skipped: true,
                             skippedTests: ["Test/testExample()"]
                         ),
                     ]


### PR DESCRIPTION
Simply adds support for skipping the entire test target rather than always defaulting to `false`.