### PR TITLE
Patch #909 to not fail CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:
-        xcode: ["11"]
+        xcode: ["11"] # TODO: add 12_beta (blocked by https://github.com/kylef/Spectre/issues/41)
     steps:
     - uses: actions/checkout@master
     - name: Set Xcode

--- a/Tests/Fixtures/TestProject/App_Clip/Clip.entitlements
+++ b/Tests/Fixtures/TestProject/App_Clip/Clip.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.parent-application-identifiers</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.project.app</string>
+		<string>$(AppIdentifierPrefix)com.project.appwithclip</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<string>group.com.app</string>

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 			);
 			dependencies = (
 				D19F2660FAD44CCC4390265C /* PBXTargetDependency */,
-				4442DC44AE5021D6F5B39D86 /* PBXTargetDependency */,
 				106CDB4BCFD183241A565E6C /* PBXTargetDependency */,
 			);
 			name = SuperTarget;
@@ -29,20 +28,15 @@
 		0786F9C725AD215C4F915BB5 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		078FAAF5C2B851C7D5EA714F /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE /* Result.framework */; };
 		079B6E02AF21664AB08E621C /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 587B9E9A3533E965CA602B76 /* TestProjectUITests.swift */; };
-		07EDA4085F0E7EE1471DC64F /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		0927149520F12314CE8B4079 /* TestFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E43116070AFEF5D8C3A5A957 /* TestFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		09617AB755651FFEB2564CBC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1A2F579A6F79C62DDA0571 /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		0AB541AE3163B063E7012877 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359F /* StaticLibrary_ObjC.h */; };
 		0BDA156BEBFCB9E65910F838 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0F99AECCB4691803C791CDCE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2FC2A8A829CE71B1CF415FF7 /* Main.storyboard */; };
-		15129B8D9ED000BDA1FEEC27 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A2F16890ECF2EE3FED72AE /* AppDelegate.swift */; };
 		1551370B0ACAC632E15C853B /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF47010E7368583405AA50CB /* SwiftyJSON.framework */; };
 		1BC891D89980D82738D963F3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 74FBDFA5CB063F6001AD8ACD /* Main.storyboard */; };
 		1E03FC7312293997599C6435 /* Empty.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 068EDF47F0B087F6A4052AC0 /* Empty.h */; };
 		1E2A4D61E96521FF7123D7B0 /* XPC Service.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = 22237B8EBD9E6BE8EBC8735F /* XPC Service.xpc */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1E457F55331FD2C3E8E00BE2 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		210B49C23B9717C668B40C8C /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
-		2116F89CF5A04EA0EFA30A89 /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D88C6BF7355702B74396791 /* TestProjectUITests.swift */; };
 		212BCB51DAF3212993DDD49E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D51CC8BCCBD68A90E90A3207 /* Assets.xcassets */; };
 		21425F6DE3D493B6F1E33D21 /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41FC82ED1C4C3B7B3D7B2FB7 /* Framework.framework */; };
 		216B220EC7961DF7CA9188B7 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359F /* StaticLibrary_ObjC.h */; };
@@ -80,25 +74,19 @@
 		5748F702ADFB9D85D0F97862 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		58C18019E71E372F635A3FB4 /* MoreUnder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8718C7CD3BE86D9B1F5120 /* MoreUnder.swift */; };
 		5D10822B0E7C33DD6979F656 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BD97AF0F94A15A5B7DDB7 /* Standalone.swift */; };
-		5E0369B907E239D1E6884ECF /* TestFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E43116070AFEF5D8C3A5A957 /* TestFramework.framework */; };
-		61516CAC12B2843FBC4572E6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59DA55A04FA2366B5D0BEEFF /* Assets.xcassets */; };
 		61601545B6BE00CA74A4E38F /* SceneKitCatalog.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = C9E358FBE2B54D2B5C7FD609 /* SceneKitCatalog.scnassets */; };
 		6241507B4947B0B65429587C /* ExternalTarget.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F6ADE654A3459AFDA2CC0CD3 /* ExternalTarget.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		632774E7F21CCB386A76B2A8 /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B198242976C3395E31FE000A /* MessagesViewController.swift */; };
 		63D8E7F00276736EDA62D227 /* Framework2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3EF21DF245F66BEF5446AAEF /* Framework2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		65B3BAC02D5FAE632719C984 /* Model.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = BF59AC868D227C92CA8B1B57 /* Model.xcmappingmodel */; };
-		65EBD2D87F1F5FDA63F8C027 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; };
 		666AA5F3F63C8FD7C68A6CC5 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		666DEC173BC78C7641AB22EC /* File1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1343F2238429D4DA9D830B /* File1.swift */; };
 		66C3C5E3C13325F351A3008F /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D18 /* module.modulemap */; };
-		6B0BCD3573931F7BE133B301 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D132EA69984F32DA9DC727B6 /* TestProjectTests.swift */; };
 		6E8F8303759824631C8D9DA3 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9E17D598D98065767A04740F /* Localizable.strings */; };
 		7148A4172BFA1CC22E6ED5DB /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 753001CDCEAA4C4E1AFF8E87 /* MainInterface.storyboard */; };
-		71A2AAC5934BDC9EDB6F0D9E /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B221F5A689AD7D3AD52F56B8 /* libStaticLibrary_ObjC.a */; };
 		747CAE14D196F5652E93353C /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 2E1E747C7BC434ADB80CC269 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
 		75F2774F183838AF34CA9B8A /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D0C79A8C750EC0DE748C463 /* StaticLibrary_ObjC.m */; };
 		768648ED7E93B6D888574144 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D18 /* module.modulemap */; };
-		77C3CB285572EA4BB7E201A7 /* App_Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = 38DB679FF1CF4E379D1AB103 /* App_Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7A0DABBEA55B06E148C665A8 /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC91042453E18DF74BA1C0F /* StaticLibrary.swift */; };
 		7A8C78212CEAC6452DFAB00E /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		7C8FF0B857E390417134C10F /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -106,23 +94,19 @@
 		803B7CE086CFBA409F9D1ED7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 108BB29172D27BE3BD1E7F35 /* Assets.xcassets */; };
 		818D448D4DDD6649B5B26098 /* example.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 28360ECA4D727FAA58557A81 /* example.mp4 */; settings = {ASSET_TAGS = (tag1, tag2, ); }; };
 		87927928A8A3460166ACB819 /* SwiftFileInDotPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F430AABE04B7499B458D9DB /* SwiftFileInDotPath.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
-		8C941A6EF08069CB3CB88FC1 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		900CFAD929CAEE3861127627 /* MyBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B5068D64404C61A67A18458 /* MyBundle.bundle */; };
 		95DD9941E1529FD2AE1A191D /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359F /* StaticLibrary_ObjC.h */; };
 		96B55C0F660235FE6BDD8869 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		998CCB995347CBB8EDC95FB5 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		9AB50B81C29243936BB419E4 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
-		9C92B7C89E5F0A10A34F5AA4 /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A9274BE42A03DC5DA1FAD04 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9D80BD5FAE6BE61CFD74CF1B /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		9DF5931DAD58C35B830A0A75 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B76E17CE3574081D5BF45B44 /* Result.framework */; };
-		A1588BF3BFFE1DF7409CBA10 /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8A9274BE42A03DC5DA1FAD04 /* Framework.framework */; };
 		A1AEAAB53EAEDA1C307871FA /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB178D03E75929F3F5B10C56 /* Result.framework */; };
 		A59B3F08914812573AFF6C2D /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = FD4A16C7B8FEB7F97F3CBE3F /* libz.dylib */; };
 		A7D1A9942302569A9515696A /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A9548E5DCFE92236494164DF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CE1F06D99242F4223D081F0D /* LaunchScreen.storyboard */; };
 		AFF19412E9B35635D3AF48CB /* XPC_Service.m in Sources */ = {isa = PBXBuildFile; fileRef = 148B7C933698BCC4F1DBA979 /* XPC_Service.m */; };
 		B142965C5AE9C6200BF65802 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; };
-		B18C121B0A4D43ED8149D8E2 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 79325B44B19B83EC6CEDBCC5 /* LaunchScreen.storyboard */; };
 		B20617116B230DED1F7AF5E5 /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B221F5A689AD7D3AD52F56B8 /* libStaticLibrary_ObjC.a */; };
 		B2D43A31C184E34EF9CB743C /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A9274BE42A03DC5DA1FAD04 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B47F2629BFE5853767C8BB5E /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FDB2B6A77D39CD5602F2125F /* Contacts.framework */; };
@@ -134,7 +118,6 @@
 		BFCCC56337A5D9D513C1C791 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D18 /* module.modulemap */; };
 		C3672B561F456794151C047C /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C3FE6B986506724DAB5D0F /* ViewController.swift */; };
 		C400EBD25886ACB5CD9035EB /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D18 /* module.modulemap */; };
-		C4378E3DAF5E0B2F7AB60E03 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE6A6FAAFF701FE729293DE /* ViewController.swift */; };
 		C836F09B677937EFF69B1FCE /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C934C1F7A68CCD0AB6B38478 /* NotificationController.swift */; };
 		C88598A49087A212990F4E8B /* ResourceFolder in Resources */ = {isa = PBXBuildFile; fileRef = 6B1603BA83AA0C7B94E45168 /* ResourceFolder */; };
 		CCA17097382757012B58C17C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1BC32A813B80A53962A1F365 /* Assets.xcassets */; };
@@ -149,7 +132,6 @@
 		E7B40B34D8807F43A3805381 /* ExternalTarget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6ADE654A3459AFDA2CC0CD3 /* ExternalTarget.framework */; };
 		E8A135F768448632F8D77C8F /* StandaloneAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3571E41E19A5AB8AAAB04109 /* StandaloneAssets.xcassets */; };
 		EDB55692D392FD09C3FCFBF6 /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 86169DEEDEAF09AB89C8A31D /* libStaticLibrary_ObjC.a */; };
-		EDE8DD3CB36D65C300A53D1E /* swift-tagged.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E4841131C451A658AC8596C /* swift-tagged.framework */; };
 		F5D71267BB5A326BDD69D532 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E55F45EACB0F382722D61C8D /* Assets.xcassets */; };
 		F6537CE373C94809E6653758 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 2E1E747C7BC434ADB80CC269 /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
 		F7423E8738EECF04795C7601 /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3F6BCB5FEFB16F1BA368059 /* InterfaceController.swift */; };
@@ -158,33 +140,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		01630C98B755921A79418B08 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 13E8C5AB873CEE21E18E552F;
-			remoteInfo = StaticLibrary_ObjC_iOS;
-		};
 		02FC8A8CFD5676EA402CCCBC /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 13E8C5AB873CEE21E18E552F;
 			remoteInfo = StaticLibrary_ObjC_iOS;
-		};
-		0B37F7A37D610FCFE187A6B7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D137C04B64B7052419A2DF4E;
-			remoteInfo = App_Clip;
-		};
-		25714659454527D9511C6093 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D137C04B64B7052419A2DF4E;
-			remoteInfo = App_Clip;
 		};
 		2CA19347816754250A29DA32 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -214,13 +175,6 @@
 			remoteGlobalIDString = 0867B0DACEF28C11442DE8F7;
 			remoteInfo = App_iOS;
 		};
-		48182DB4A5C2A7F35019AF74 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D137C04B64B7052419A2DF4E;
-			remoteInfo = App_Clip;
-		};
 		57F1BE74D4C4252529F97984 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
@@ -241,27 +195,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 020A320BB3736FCDE6CC4E70;
 			remoteInfo = App_macOS;
-		};
-		69E205A3F578A8FFE3ECF3F9 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0636AAF06498C336E1CEEDE4;
-			remoteInfo = TestFramework;
-		};
-		747773057270E6F58470B5FA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = D137C04B64B7052419A2DF4E;
-			remoteInfo = App_Clip;
-		};
-		7E37A3C0A67C3B6363029A18 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = AE3F93DB94E7208F2F1D9A78;
-			remoteInfo = Framework_iOS;
 		};
 		7F4EAACE4AD6CF285B7D3308 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -364,17 +297,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		05D615CB74F875917AA8C9B0 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				8C941A6EF08069CB3CB88FC1 /* Result.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		06FAE8D6834F982AA934B3E8 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -406,18 +328,6 @@
 				54A255D331B04F08583F5417 /* iMessageExtension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		30A8F3568B05F3DB13D8B466 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				0927149520F12314CE8B4079 /* TestFramework.framework in Embed Frameworks */,
-				07EDA4085F0E7EE1471DC64F /* Result.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		3217EBDE07BBCBDE3C16CEDC /* CopyFiles */ = {
@@ -464,17 +374,6 @@
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		848740AD60C4329197FF876B /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				9C92B7C89E5F0A10A34F5AA4 /* Framework.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		865AAD9909027AC34D1374EA /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -494,17 +393,6 @@
 				0AB541AE3163B063E7012877 /* StaticLibrary_ObjC.h in CopyFiles */,
 				C400EBD25886ACB5CD9035EB /* module.modulemap in CopyFiles */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		94FF9CA021C43301BA069930 /* Embed App Clips */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "$(CONTENTS_FOLDER_PATH)/AppClips";
-			dstSubfolderSpec = 16;
-			files = (
-				77C3CB285572EA4BB7E201A7 /* App_Clip.app in Embed App Clips */,
-			);
-			name = "Embed App Clips";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A8688B5E0D1C2F35AD20BB85 /* Embed Frameworks */ = {
@@ -601,26 +489,20 @@
 		187E665975BB5611AF0F27E1 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		1BC32A813B80A53962A1F365 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1D0C79A8C750EC0DE748C463 /* StaticLibrary_ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticLibrary_ObjC.m; sourceTree = "<group>"; };
-		1FA5E208EC184E3030D2A21D /* Clip.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Clip.entitlements; sourceTree = "<group>"; };
 		22237B8EBD9E6BE8EBC8735F /* XPC Service.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = "XPC Service.xpc"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2233774B86539B1574D206B0 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		23A2F16890ECF2EE3FED72AE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		28360ECA4D727FAA58557A81 /* example.mp4 */ = {isa = PBXFileReference; path = example.mp4; sourceTree = "<group>"; };
 		2A5F527F2590C14956518174 /* FrameworkFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkFile.swift; sourceTree = "<group>"; };
 		2E1E747C7BC434ADB80CC269 /* Headers */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Headers; sourceTree = SOURCE_ROOT; };
 		2F430AABE04B7499B458D9DB /* SwiftFileInDotPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFileInDotPath.swift; sourceTree = "<group>"; };
-		3096A0760969873D46F80A92 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		33F6DCDC37D2E66543D4965D /* App_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		34F13B632328979093CE6056 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3571E41E19A5AB8AAAB04109 /* StandaloneAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = StandaloneAssets.xcassets; sourceTree = "<group>"; };
 		3797E591F302ECC0AA2FC607 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		38DB679FF1CF4E379D1AB103 /* App_Clip.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_Clip.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		38F1191E5B85DC882B8ABE85 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		3A7BEFAB4710735CF169B1E8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3D8A2D4363866877B9140156 /* XPC_ServiceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPC_ServiceProtocol.h; sourceTree = "<group>"; };
 		3ED831531AA349CCC19B258B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3EF21DF245F66BEF5446AAEF /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3FC04772130400920D68A167 /* App_Clip_Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_Clip_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		40863AE6202CFCD0529D8438 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		41FC82ED1C4C3B7B3D7B2FB7 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		45C12576F5AA694DD0CE2132 /* BundleX.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = BundleX.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -631,20 +513,17 @@
 		553D289724905857912C7A1D /* outputList.xcfilelist */ = {isa = PBXFileReference; lastKnownFileType = text.xcfilelist; path = outputList.xcfilelist; sourceTree = "<group>"; };
 		57FF8864B8EBAB5777DC12E6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		587B9E9A3533E965CA602B76 /* TestProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectUITests.swift; sourceTree = "<group>"; };
-		59DA55A04FA2366B5D0BEEFF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5A2B916A11DCC2565241359F /* StaticLibrary_ObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticLibrary_ObjC.h; sourceTree = "<group>"; };
 		6177CC6263783487E93F7F4D /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A58A16491CDDF968B0D56DE /* MyFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyFramework.h; sourceTree = "<group>"; };
 		6AC91042453E18DF74BA1C0F /* StaticLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticLibrary.swift; sourceTree = "<group>"; };
 		6B1603BA83AA0C7B94E45168 /* ResourceFolder */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ResourceFolder; path = Resources/ResourceFolder; sourceTree = SOURCE_ROOT; };
 		6BBE762F36D94AB6FFBFE834 /* SomeFile */ = {isa = PBXFileReference; path = SomeFile; sourceTree = "<group>"; };
-		6F165CDD5BCC13AFF50B65E2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		70A8E15C81E454DC950C59F0 /* SomeXPCService.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; path = SomeXPCService.xpc; sourceTree = "<group>"; };
 		72A14C887EF7E9C8CBE914AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		77C0C341F1865224E0596086 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		7B5068D64404C61A67A18458 /* MyBundle.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = MyBundle.bundle; sourceTree = "<group>"; };
 		7C176A8297AC2F5207352BA8 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
-		7C7EC00B53FF878007F6ECAB /* App_Clip_UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_Clip_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D67F1C1BFBACE101DE7DB51 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D700FA699849D2F95216883 /* EntitledApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = EntitledApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7DE38C10AB71A47B786D5BF2 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
@@ -657,7 +536,6 @@
 		8AF20308873AEEEC4D8C45D1 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		8CAF6C55B555E3E1352645B6 /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
 		8CB86294FB939FE6E90932E1 /* libStaticLibrary_Swift.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libStaticLibrary_Swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8D88C6BF7355702B74396791 /* TestProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectUITests.swift; sourceTree = "<group>"; };
 		93C033648A37D95027845BD3 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		9A87A926D563773658FB87FE /* iMessageApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = iMessageApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F27382DD66E26C059E26EFE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -693,14 +571,12 @@
 		D70BE0C05E5779A077793BE6 /* Model 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 2.xcdatamodel"; sourceTree = "<group>"; };
 		D8A016580A3B8F72B820BFBF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		DAA7880242A9DE61E68026CC /* Folder */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Folder; sourceTree = SOURCE_ROOT; };
-		DFE6A6FAAFF701FE729293DE /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		E42335D1200CB7B8B91E962F /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		E43116070AFEF5D8C3A5A957 /* TestFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TestFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E55F45EACB0F382722D61C8D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E9672EF8FE1DDC8DE0705129 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 		EE1343F2238429D4DA9D830B /* File1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = File1.swift; path = Group/File1.swift; sourceTree = "<group>"; };
 		F0D48A913C087D049C8EDDD7 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
-		F15E5C60B7E05D06B1B8E18E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F192E783CCA898FBAA5C34EA /* AnotherProject */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AnotherProject; path = AnotherProject/AnotherProject.xcodeproj; sourceTree = "<group>"; };
 		F2950763C4C568CC85021D18 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		F2FA55A558627ED576A4AFD6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -743,15 +619,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6D6C0891A16EFF2FDA9D25AF /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5E0369B907E239D1E6884ECF /* TestFramework.framework in Frameworks */,
-				EDE8DD3CB36D65C300A53D1E /* swift-tagged.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		9B861C58E640BD4AD391900C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -787,16 +654,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				307B5322FC5A220652BA6FE0 /* Result.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DFDFD9EDAD45D89D1080FC5D /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				A1588BF3BFFE1DF7409CBA10 /* Framework.framework in Frameworks */,
-				65EBD2D87F1F5FDA63F8C027 /* Result.framework in Frameworks */,
-				71A2AAC5934BDC9EDB6F0D9E /* libStaticLibrary_ObjC.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -888,8 +745,6 @@
 			isa = PBXGroup;
 			children = (
 				1F2DE413CF2CB54988158172 /* App */,
-				C81493FAD71E9A9A19E00AD5 /* App_Clip */,
-				6BD8F0932CCAD4BBE752866B /* App_Clip_UITests */,
 				FC81A3ED177CE9DA68D09941 /* App_iOS_Tests */,
 				0D039F2E62354C7C8E283BE6 /* App_iOS_UITests */,
 				EE78B4FBD0137D1975C47D76 /* App_macOS */,
@@ -980,15 +835,6 @@
 				CA8718C7CD3BE86D9B1F5120 /* MoreUnder.swift */,
 			);
 			path = UnderFileGroup;
-			sourceTree = "<group>";
-		};
-		6BD8F0932CCAD4BBE752866B /* App_Clip_UITests */ = {
-			isa = PBXGroup;
-			children = (
-				3A7BEFAB4710735CF169B1E8 /* Info.plist */,
-				8D88C6BF7355702B74396791 /* TestProjectUITests.swift */,
-			);
-			path = App_Clip_UITests;
 			sourceTree = "<group>";
 		};
 		6DBE0EE90642BB3F6E58AD43 /* Configs */ = {
@@ -1089,9 +935,6 @@
 		AC523591AC7BE9275003D2DB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				3FC04772130400920D68A167 /* App_Clip_Tests.xctest */,
-				7C7EC00B53FF878007F6ECAB /* App_Clip_UITests.xctest */,
-				38DB679FF1CF4E379D1AB103 /* App_Clip.app */,
 				CB77A637470A3CDA2BDDBE99 /* App_iOS_Tests.xctest */,
 				13EEAB58665D79C15184D9D0 /* App_iOS_UITests.xctest */,
 				B1C33BB070583BE3B0EC0E68 /* App_iOS.app */,
@@ -1152,20 +995,6 @@
 				B198242976C3395E31FE000A /* MessagesViewController.swift */,
 			);
 			path = iMessageExtension;
-			sourceTree = "<group>";
-		};
-		C81493FAD71E9A9A19E00AD5 /* App_Clip */ = {
-			isa = PBXGroup;
-			children = (
-				23A2F16890ECF2EE3FED72AE /* AppDelegate.swift */,
-				59DA55A04FA2366B5D0BEEFF /* Assets.xcassets */,
-				1FA5E208EC184E3030D2A21D /* Clip.entitlements */,
-				6F165CDD5BCC13AFF50B65E2 /* Info.plist */,
-				79325B44B19B83EC6CEDBCC5 /* LaunchScreen.storyboard */,
-				2FC2A8A829CE71B1CF415FF7 /* Main.storyboard */,
-				DFE6A6FAAFF701FE729293DE /* ViewController.swift */,
-			);
-			path = App_Clip;
 			sourceTree = "<group>";
 		};
 		CBDAC144248EE9D3838C6AAA /* StaticLibrary_Swift */ = {
@@ -1391,7 +1220,6 @@
 				37182EC208DBF03DB1BAF452 /* Carthage */,
 				117840B4DBC04099F6779D00 /* Frameworks */,
 				E8BC0F358D693454E5027ECC /* Copy Bundle Resources */,
-				94FF9CA021C43301BA069930 /* Embed App Clips */,
 				FE78CC3322C9C2DB1D64EAAA /* Embed Frameworks */,
 				807155B9081529D99AAB4743 /* Embed Watch Content */,
 				71A4CC6ECC8522178F566E7B /* Strip Unused Architectures from Frameworks */,
@@ -1401,7 +1229,6 @@
 			);
 			dependencies = (
 				4FA29DA80DA668224AED741F /* PBXTargetDependency */,
-				8B6243D8D47A6ADA4CA0D7BD /* PBXTargetDependency */,
 				0D33D01C71E8002A07F02122 /* PBXTargetDependency */,
 				A94F38390A74E215EC107BB5 /* PBXTargetDependency */,
 				E84285243DE0BB361A708079 /* PBXTargetDependency */,
@@ -1580,25 +1407,6 @@
 			productReference = 86169DEEDEAF09AB89C8A31D /* libStaticLibrary_ObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		63BFF75AA22335E3DDD5E26A /* App_Clip_Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 498FA7414845B8834E48496F /* Build configuration list for PBXNativeTarget "App_Clip_Tests" */;
-			buildPhases = (
-				F39FAD4CC93306087D129EBD /* Sources */,
-				6D6C0891A16EFF2FDA9D25AF /* Frameworks */,
-				30A8F3568B05F3DB13D8B466 /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				A19BEE3154D879101F865BB2 /* PBXTargetDependency */,
-				2D1B4333107E10912508724E /* PBXTargetDependency */,
-			);
-			name = App_Clip_Tests;
-			productName = App_Clip_Tests;
-			productReference = 3FC04772130400920D68A167 /* App_Clip_Tests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		6ED01BC471A8C3642258E178 /* Framework2_watchOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7E4887637B4FA5B8E2F349CA /* Build configuration list for PBXNativeTarget "Framework2_watchOS" */;
@@ -1700,23 +1508,6 @@
 			productReference = A0DC40025AB59B688E758829 /* Framework2.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		91C3E922A8482E07649971B9 /* App_Clip_UITests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 129D9E77D45A66B1C78578F2 /* Build configuration list for PBXNativeTarget "App_Clip_UITests" */;
-			buildPhases = (
-				2E1429F0FB524A2BCFC61DF1 /* Sources */,
-				05D615CB74F875917AA8C9B0 /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				1341A437B2D0402F4F4CEA51 /* PBXTargetDependency */,
-			);
-			name = App_Clip_UITests;
-			productName = App_Clip_UITests;
-			productReference = 7C7EC00B53FF878007F6ECAB /* App_Clip_UITests.xctest */;
-			productType = "com.apple.product-type.bundle.ui-testing";
-		};
 		93542A75A613F00FDB5C9C63 /* StaticLibrary_ObjC_tvOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 906B8E5233EE4169E84ABAF3 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_tvOS" */;
@@ -1782,27 +1573,6 @@
 			productName = Framework2_iOS;
 			productReference = 3EF21DF245F66BEF5446AAEF /* Framework2.framework */;
 			productType = "com.apple.product-type.framework";
-		};
-		D137C04B64B7052419A2DF4E /* App_Clip */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 07B4E73E56B7C2C80DE2A378 /* Build configuration list for PBXNativeTarget "App_Clip" */;
-			buildPhases = (
-				6F11C066A401E4F02A1188EB /* Sources */,
-				AFA07EE1616E0EE7065760C9 /* Resources */,
-				E5D02C719D4534BBA65A54BE /* Carthage */,
-				DFDFD9EDAD45D89D1080FC5D /* Frameworks */,
-				848740AD60C4329197FF876B /* Embed Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				BE9300E427142E634A8A91B8 /* PBXTargetDependency */,
-				CFEACC1CED73B52EA1CCD054 /* PBXTargetDependency */,
-			);
-			name = App_Clip;
-			productName = App_Clip;
-			productReference = 38DB679FF1CF4E379D1AB103 /* App_Clip.app */;
-			productType = "com.apple.product-type.application.on-demand-install-capable";
 		};
 		DC2F16BAA6E13B44AB62F888 /* App_iOS_Tests */ = {
 			isa = PBXNativeTarget;
@@ -1885,9 +1655,6 @@
 					0867B0DACEF28C11442DE8F7 = {
 						ProvisioningStyle = Automatic;
 					};
-					91C3E922A8482E07649971B9 = {
-						TestTargetID = D137C04B64B7052419A2DF4E;
-					};
 					BF3693DCA6182D7AEC410AFC = {
 						CUSTOM = value;
 					};
@@ -1918,9 +1685,6 @@
 			);
 			projectRoot = "";
 			targets = (
-				D137C04B64B7052419A2DF4E /* App_Clip */,
-				63BFF75AA22335E3DDD5E26A /* App_Clip_Tests */,
-				91C3E922A8482E07649971B9 /* App_Clip_UITests */,
 				0867B0DACEF28C11442DE8F7 /* App_iOS */,
 				DC2F16BAA6E13B44AB62F888 /* App_iOS_Tests */,
 				F674B2CFC4738EEC49BAD0DA /* App_iOS_UITests */,
@@ -2024,16 +1788,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				E1836941C13CC7F13650C317 /* Assets.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		AFA07EE1616E0EE7065760C9 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				61516CAC12B2843FBC4572E6 /* Assets.xcassets in Resources */,
-				B18C121B0A4D43ED8149D8E2 /* LaunchScreen.storyboard in Resources */,
-				0F99AECCB4691803C791CDCE /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2225,22 +1979,6 @@
 			shellPath = /bin/sh;
 			shellScript = "echo \"do the thing\"";
 		};
-		E5D02C719D4534BBA65A54BE /* Carthage */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/Carthage/Build/iOS/Result.framework",
-			);
-			name = Carthage;
-			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "carthage copy-frameworks\n";
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -2285,14 +2023,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2E1429F0FB524A2BCFC61DF1 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				2116F89CF5A04EA0EFA30A89 /* TestProjectUITests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		40A4456A24F99A01E340C032 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2322,15 +2052,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				02F9D686CBA6068A8EE58026 /* StaticLibrary_ObjC.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		6F11C066A401E4F02A1188EB /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				15129B8D9ED000BDA1FEEC27 /* AppDelegate.swift in Sources */,
-				C4378E3DAF5E0B2F7AB60E03 /* ViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2479,14 +2200,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F39FAD4CC93306087D129EBD /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6B0BCD3573931F7BE133B301 /* TestProjectTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -2505,16 +2218,6 @@
 			target = AE3F93DB94E7208F2F1D9A78 /* Framework_iOS */;
 			targetProxy = 2FA0A954833DB0981CDE58E1 /* PBXContainerItemProxy */;
 		};
-		1341A437B2D0402F4F4CEA51 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D137C04B64B7052419A2DF4E /* App_Clip */;
-			targetProxy = 0B37F7A37D610FCFE187A6B7 /* PBXContainerItemProxy */;
-		};
-		2D1B4333107E10912508724E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 0636AAF06498C336E1CEEDE4 /* TestFramework */;
-			targetProxy = 69E205A3F578A8FFE3ECF3F9 /* PBXContainerItemProxy */;
-		};
 		35DF16CA4A1F88140CF69620 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 7D3D92034F4F203C140574F0 /* StaticLibrary_ObjC_watchOS */;
@@ -2524,11 +2227,6 @@
 			isa = PBXTargetDependency;
 			target = 0867B0DACEF28C11442DE8F7 /* App_iOS */;
 			targetProxy = C9947CF0A436FC6113FC0837 /* PBXContainerItemProxy */;
-		};
-		4442DC44AE5021D6F5B39D86 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D137C04B64B7052419A2DF4E /* App_Clip */;
-			targetProxy = 48182DB4A5C2A7F35019AF74 /* PBXContainerItemProxy */;
 		};
 		486D84E583999BAA22C679EC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2565,20 +2263,10 @@
 			target = 020A320BB3736FCDE6CC4E70 /* App_macOS */;
 			targetProxy = 610412261F48A0A36C32FC5C /* PBXContainerItemProxy */;
 		};
-		8B6243D8D47A6ADA4CA0D7BD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D137C04B64B7052419A2DF4E /* App_Clip */;
-			targetProxy = 25714659454527D9511C6093 /* PBXContainerItemProxy */;
-		};
 		981D116D40DBA0407D0E0E94 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 834F55973F05AC8A18144DB0 /* iMessageApp */;
 			targetProxy = 57F1BE74D4C4252529F97984 /* PBXContainerItemProxy */;
-		};
-		A19BEE3154D879101F865BB2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = D137C04B64B7052419A2DF4E /* App_Clip */;
-			targetProxy = 747773057270E6F58470B5FA /* PBXContainerItemProxy */;
 		};
 		A94F38390A74E215EC107BB5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2595,20 +2283,10 @@
 			target = E7815F2F0D9CDECF9185AAF3 /* XPC Service */;
 			targetProxy = 8BAA7F3717FCBE0B8D6669B3 /* PBXContainerItemProxy */;
 		};
-		BE9300E427142E634A8A91B8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = AE3F93DB94E7208F2F1D9A78 /* Framework_iOS */;
-			targetProxy = 7E37A3C0A67C3B6363029A18 /* PBXContainerItemProxy */;
-		};
 		CE96B0951433713033A03DCD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 93542A75A613F00FDB5C9C63 /* StaticLibrary_ObjC_tvOS */;
 			targetProxy = CB8F4B3FDD84A2A6F3CA7F4C /* PBXContainerItemProxy */;
-		};
-		CFEACC1CED73B52EA1CCD054 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 13E8C5AB873CEE21E18E552F /* StaticLibrary_ObjC_iOS */;
-			targetProxy = 01630C98B755921A79418B08 /* PBXContainerItemProxy */;
 		};
 		D19F2660FAD44CCC4390265C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2642,14 +2320,6 @@
 			name = LocalizedStoryboard.storyboard;
 			sourceTree = "<group>";
 		};
-		2FC2A8A829CE71B1CF415FF7 /* Main.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				3096A0760969873D46F80A92 /* Base */,
-			);
-			name = Main.storyboard;
-			sourceTree = "<group>";
-		};
 		65C8D6D1DDC1512D396C07B7 /* Localizable.stringsdict */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -2673,14 +2343,6 @@
 				FA86D418796C1A6864414460 /* Base */,
 			);
 			name = MainInterface.storyboard;
-			sourceTree = "<group>";
-		};
-		79325B44B19B83EC6CEDBCC5 /* LaunchScreen.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				F15E5C60B7E05D06B1B8E18E /* Base */,
-			);
-			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
 		814D72C2B921F60B759C2D4B /* Main.storyboard */ = {
@@ -2835,29 +2497,6 @@
 			};
 			name = "Staging Release";
 		};
-		0579BA94EA238151DAFC2FFC /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Release";
-		};
 		058734C3B593A26E24211133 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2911,27 +2550,6 @@
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Production Debug";
-		};
-		07DF024D82D64A8D76209B90 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_Clip;
 			};
 			name = "Production Debug";
 		};
@@ -3389,28 +3007,6 @@
 			};
 			name = "Production Release";
 		};
-		2E5159957368A9CF77A3C9FC /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
-			};
-			name = "Test Debug";
-		};
 		2F1CDD64CD0684A2B09D6ED3 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3455,27 +3051,6 @@
 			};
 			name = "Test Debug";
 		};
-		3236B7B20520584116A96C0D /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_Clip;
-			};
-			name = "Production Release";
-		};
 		366C92A637FDA940E6BCB591 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3517,50 +3092,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Release";
-		};
-		3BDE7967B50F4358BD4702AD /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_Clip;
-			};
-			name = "Test Debug";
-		};
-		3BE60579CA725E23659AEA80 /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
-				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Production Release";
@@ -3767,27 +3298,6 @@
 			};
 			name = "Test Debug";
 		};
-		498F2DC7204423CCCABAEE80 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_Clip;
-			};
-			name = "Test Release";
-		};
 		4A0624A4FC88A7E232411C95 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3891,29 +3401,6 @@
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = "Production Debug";
-		};
-		4EDC77FA8569D4AB3135780D /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Staging Release";
 		};
 		4F029A78B7BAB85B1E284798 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
@@ -4056,27 +3543,6 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Production Release";
-		};
-		554E51BF9C8020AFC98E2EEF /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_Clip;
-			};
-			name = "Staging Release";
 		};
 		55DA94C85E0E63D3AD593A08 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
@@ -4604,29 +4070,6 @@
 			};
 			name = "Staging Release";
 		};
-		7C9FE720B05E0120F78B81AF /* Test Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Debug";
-		};
 		7E101F97604A0990174A46CD /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4727,29 +4170,6 @@
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";
-			};
-			name = "Staging Debug";
-		};
-		84404129017F8D027A24136A /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Staging Debug";
 		};
@@ -5101,28 +4521,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Test Release";
-		};
-		A0CBB78FB8E4FB0004B05DE0 /* Test Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
 			};
 			name = "Test Release";
 		};
@@ -5592,28 +4990,6 @@
 			};
 			name = "Test Release";
 		};
-		C0BE0797A2AD213D59FF13F8 /* Staging Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
-			};
-			name = "Staging Release";
-		};
 		C0D5765142C68AF68B954B3F /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5756,29 +5132,6 @@
 			};
 			name = "Test Debug";
 		};
-		C734956B0E352751B5DA14A6 /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-ObjC",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Production Debug";
-		};
 		C7EF8D96FA7893ADD61CF4C0 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -5913,28 +5266,6 @@
 				MY_SETTING = hello;
 			};
 			name = "Test Release";
-		};
-		D70B7AB6D219453ABF475EED /* Production Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
-			};
-			name = "Production Debug";
 		};
 		D8267FD376089FF4497ED3F1 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
@@ -6304,50 +5635,6 @@
 			};
 			name = "Production Debug";
 		};
-		E7E05E5BC42C73136CDC5CFE /* Production Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
-			};
-			name = "Production Release";
-		};
-		E8F5F216BCFE54CB22B80237 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
-				);
-				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
-			};
-			name = "Staging Debug";
-		};
 		E95B2CE470959F04BE6AACA9 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 16D662EE577E4CD6AFF39D66 /* config.xcconfig */;
@@ -6537,27 +5824,6 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Staging Release";
-		};
-		F48A0BCE0F515E3472B34F66 /* Staging Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
-				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_TARGET_NAME = App_Clip;
-			};
-			name = "Staging Debug";
 		};
 		F75CC02D1BB9B39C329A9B43 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
@@ -6779,32 +6045,6 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
 		};
-		07B4E73E56B7C2C80DE2A378 /* Build configuration list for PBXNativeTarget "App_Clip" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C734956B0E352751B5DA14A6 /* Production Debug */,
-				3BE60579CA725E23659AEA80 /* Production Release */,
-				84404129017F8D027A24136A /* Staging Debug */,
-				4EDC77FA8569D4AB3135780D /* Staging Release */,
-				7C9FE720B05E0120F78B81AF /* Test Debug */,
-				0579BA94EA238151DAFC2FFC /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "Production Debug";
-		};
-		129D9E77D45A66B1C78578F2 /* Build configuration list for PBXNativeTarget "App_Clip_UITests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				07DF024D82D64A8D76209B90 /* Production Debug */,
-				3236B7B20520584116A96C0D /* Production Release */,
-				F48A0BCE0F515E3472B34F66 /* Staging Debug */,
-				554E51BF9C8020AFC98E2EEF /* Staging Release */,
-				3BDE7967B50F4358BD4702AD /* Test Debug */,
-				498F2DC7204423CCCABAEE80 /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "Production Debug";
-		};
 		1FC6945BE13C2202A2BCA3BC /* Build configuration list for PBXNativeTarget "iMessageApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6827,19 +6067,6 @@
 				F75CC02D1BB9B39C329A9B43 /* Staging Release */,
 				5FAA92426D53E239CDB39102 /* Test Debug */,
 				0C66F8A2D0CB0D802A327EB4 /* Test Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "Production Debug";
-		};
-		498FA7414845B8834E48496F /* Build configuration list for PBXNativeTarget "App_Clip_Tests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				D70B7AB6D219453ABF475EED /* Production Debug */,
-				E7E05E5BC42C73136CDC5CFE /* Production Release */,
-				E8F5F216BCFE54CB22B80237 /* Staging Debug */,
-				C0BE0797A2AD213D59FF13F8 /* Staging Release */,
-				2E5159957368A9CF77A3C9FC /* Test Debug */,
-				A0CBB78FB8E4FB0004B05DE0 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/project.pbxproj
@@ -1,0 +1,3205 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 51;
+	objects = {
+
+/* Begin PBXAggregateTarget section */
+		9C27C8C394ADD16FDCF6E624 /* SuperTarget */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 70FED818DB797FCDC7929DBC /* Build configuration list for PBXAggregateTarget "SuperTarget" */;
+			buildPhases = (
+			);
+			dependencies = (
+				8DF064FE23E39B733B75994D /* PBXTargetDependency */,
+				5D8D142415461F41AAF64E5B /* PBXTargetDependency */,
+			);
+			name = SuperTarget;
+			productName = SuperTarget;
+		};
+/* End PBXAggregateTarget section */
+
+/* Begin PBXBuildFile section */
+		04141410CA15B3FBC091FFEE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE31326E32ED51CB02C58E9D /* AppDelegate.swift */; };
+		0A6862249B5F9D544A774770 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98B17D464B46DAC8911014D5 /* module.modulemap */; };
+		0C7A6D06465E72F6D4DDA65B /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 574D072C770BAE53531249CF /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+		0CD02F062979E2FD36D8D524 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */; };
+		129640F84D0905CE479FF083 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 329A12107D19B52E1F8554B4 /* Assets.xcassets */; };
+		18666A1E5DE5F5B2D48ED872 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F0ED24C994FE9945337388B /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; };
+		24FD80AC771EAD5DEA2FB43F /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		26170D4BBCBE25B7ADB6C3C9 /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */; };
+		2778626BA6AC7257203DFA47 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */; };
+		29C5F4E429F4826AC299988F /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */; };
+		2CBE0DC8AC249AD1E42DC593 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 574D072C770BAE53531249CF /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+		35E3C0F60528783F7A6BFF9A /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		36FEB01A03A566B43A2C2434 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2986C19C8498CDE44CFDAD /* ViewController.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		37EDF33D6B4105F07070FB56 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA405DFE01301A4B8BA9027 /* Standalone.swift */; };
+		38C639CCE01DB1DC4C2A7101 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F6813B4F70D433054D0C8FB8 /* Assets.xcassets */; };
+		3D8580B33361272D45C61A85 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 431156B967A9DF0995682D7C /* Model.xcdatamodeld */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		4D67F7E55015EFBDA73E307F /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4FE6138F5867CA1D93C6EA04 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 556DA72EFDDD94E4E49C0754 /* Main.storyboard */; };
+		5F930EEC8C575CB59EC11435 /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		60B0A79EF778752B7F574D8A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5A391BB5F85ECBA78F808646 /* LaunchScreen.storyboard */; };
+		66ED5AE47EDD03A3DBBDF552 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F988879F73866310CE43F37 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B18235C78A3D3E84F2508B /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		74E1D133AB01AA3424C6C540 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DB5DD67A1E835227FE0397 /* TestProjectTests.swift */; };
+		7A218049DED8B2CD3D8AD8B6 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */; };
+		7CB6A442EEFD3DAA5298FA6C /* TestFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */; };
+		81724CEEA748160B950C85B5 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6C287801C7F7F97451C89F23 /* Settings.bundle */; };
+		83A04F08119B1A648940B631 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		89D00F3D1A87503F10AE7432 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 917AA3E4306C1A12FCC17994 /* Main.storyboard */; };
+		8B078640745463EC45519361 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8F4FEE199C8E1C4B89B927F4 /* App_Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = C22BEDE0B2217312642FADA2 /* App_Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		966364F9A5B152ED9292B335 /* LocalizedStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EE817D9DBEBA01EC4FFCED25 /* LocalizedStoryboard.storyboard */; };
+		99FD6FC149E2753DD75BA792 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */; };
+		9A8AB7DE8957C82A8807559F /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 4AE9A9C885258BF807598F5E /* Localizable.stringsdict */; };
+		A795886DF55D0AF370692AAB /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98B17D464B46DAC8911014D5 /* module.modulemap */; };
+		AC800EB90200F927CE8ADC17 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 21AA0A827D6C74A605DEE03E /* Localizable.strings */; };
+		AF734D3BF6BA8808A2F1916C /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */; };
+		B07763BBA6FC4AB9D65BE390 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */; };
+		BDEE0F3F67B9EA52B04CC2C6 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98B17D464B46DAC8911014D5 /* module.modulemap */; };
+		BE8E9F3E79C62F56F889E7A6 /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */; };
+		BFD9082EF681F00F1EB86044 /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; };
+		C715C98D479D3832005E622B /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98B17D464B46DAC8911014D5 /* module.modulemap */; };
+		D6A9F9FE464839B860307F97 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B274B43FDC5E8E1FEF7E9FA /* ViewController.swift */; };
+		D94D5D2D9EF9B359DEE438F6 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 574D072C770BAE53531249CF /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+		E267E405615EF1727C3D49C7 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		E9AB59E760C7776384AC7E32 /* SwiftFileInDotPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9327B50C4B0BDF4A252CB2A /* SwiftFileInDotPath.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		EC9566B5691051C716BCF88D /* swift-tagged.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8905BD70AC0E549E6C5E267A /* swift-tagged.framework */; };
+		F316B77453C5A4A9692166AF /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4A6FE2AF37CDDD3A0D1D6B /* TestProjectUITests.swift */; };
+		F415FFDA9CCF0237B5C0D7A5 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24562B158AF232E893E63362 /* Contacts.framework */; };
+		F6BD1D30F6F6E5809B4CF709 /* TestFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F7A0142071C8301E99C11E3A /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		FA7F5B42ACAEA016400A195A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 28193039398EB7872CD19490 /* LaunchScreen.storyboard */; };
+		FAD05AB024D2E3CB4EDBFAF4 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		FE6A3F3C7247CD2294753909 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		FECBF2C1DD2D1B8BBD7DA7DF /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */; };
+		FFFAEFA20D72082E2888D56D /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 574D072C770BAE53531249CF /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		0335EDE25056C73A036FE356 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 559F6E334A370096461729A9;
+			remoteInfo = App_Clip;
+		};
+		0FA2870744F254DD5E3D8374 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 991BCE8E861305DE596EACFE;
+			remoteInfo = App_iOS;
+		};
+		12A939B349AFA0D4B2A270EA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8507B864DA27764F1EA6962C;
+			remoteInfo = StaticLibrary_ObjC_tvOS;
+		};
+		2EAC3D4B05A43768279E03B7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 242476187403208F30D3219F;
+			remoteInfo = Framework_iOS;
+		};
+		4D8A3B8387E29C006CC9AD78 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 559F6E334A370096461729A9;
+			remoteInfo = App_Clip;
+		};
+		5CFE6D622751CA41654F4B00 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5239298BB84B4FDDFD84469E;
+			remoteInfo = StaticLibrary_ObjC_watchOS;
+		};
+		6D2993924DD47F80ACB3567E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 559F6E334A370096461729A9;
+			remoteInfo = App_Clip;
+		};
+		6DEB235CE85E75F90EC6175D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 559F6E334A370096461729A9;
+			remoteInfo = App_Clip;
+		};
+		98E077CD4918FF68662C4337 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 63EAAEAE0535C975295781D4;
+			remoteInfo = TestFramework;
+		};
+		9C7FA5CABE5A0EC3D5C4055B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3DBB411AF8D365588E21D8CA;
+			remoteInfo = StaticLibrary_ObjC_iOS;
+		};
+		C0408FA85DFD7E9F59541D2E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3FCF5A083151C7E22B24E807;
+			remoteInfo = StaticLibrary_ObjC_macOS;
+		};
+		D51CBCA8454A129B3F1C0629 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 242476187403208F30D3219F;
+			remoteInfo = Framework_iOS;
+		};
+		F7BDEB5E84BA34C6E32E8C1F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3DBB411AF8D365588E21D8CA;
+			remoteInfo = StaticLibrary_ObjC_iOS;
+		};
+		F8D2CC44BE471C9C41F5B1E6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3DBB411AF8D365588E21D8CA;
+			remoteInfo = StaticLibrary_ObjC_iOS;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		1C41E253B853711670514ECC /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				29C5F4E429F4826AC299988F /* StaticLibrary_ObjC.h in CopyFiles */,
+				BDEE0F3F67B9EA52B04CC2C6 /* module.modulemap in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		39EF6E709D5336CB216DC2FB /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				99FD6FC149E2753DD75BA792 /* StaticLibrary_ObjC.h in CopyFiles */,
+				0A6862249B5F9D544A774770 /* module.modulemap in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		456284554D1A6C53EB39BA4B /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F6BD1D30F6F6E5809B4CF709 /* TestFramework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5FF5F332311FF39E3B020BD9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				5F930EEC8C575CB59EC11435 /* Framework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		883C11C8EE5A3B03232F4D48 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				B07763BBA6FC4AB9D65BE390 /* StaticLibrary_ObjC.h in CopyFiles */,
+				A795886DF55D0AF370692AAB /* module.modulemap in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1B97A1B112643A756935FA5 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F7A0142071C8301E99C11E3A /* Framework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D76EC4273D7E9C453072365B /* Embed App Clips */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/AppClips";
+			dstSubfolderSpec = 16;
+			files = (
+				8F4FEE199C8E1C4B89B927F4 /* App_Clip.app in Embed App Clips */,
+			);
+			name = "Embed App Clips";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F0CE57DCC7A58AFEA0EB1EF5 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				FECBF2C1DD2D1B8BBD7DA7DF /* StaticLibrary_ObjC.h in CopyFiles */,
+				C715C98D479D3832005E622B /* module.modulemap in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		0751ACA46EF394AF3E358E48 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TestFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0B2986C19C8498CDE44CFDAD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		115047E35C1A4697DEC6D83F /* App_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		160628D3BF533455BA779575 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		1B4D9FADD8956DC163813272 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		20B4D4D4A77434FA5593E35D /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		24562B158AF232E893E63362 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
+		28B6600F3CDA6F15633D2134 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = config.xcconfig; sourceTree = "<group>"; };
+		2D3BE7580CC3D623991914A4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		329A12107D19B52E1F8554B4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		3469B706C364CC07AAEF298A /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
+		34E069C383E5121BD428C2D7 /* Clip.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Clip.entitlements; sourceTree = "<group>"; };
+		376BA5774B91C2D6DA8F6C39 /* libStaticLibrary_ObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3B4590226C49347F4BC18782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticLibrary_ObjC.m; sourceTree = "<group>"; };
+		4711AC75927A510DEB4FCC31 /* MyFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyFramework.h; sourceTree = "<group>"; };
+		4D770C47456D076025DD7A51 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		4FFF3A7EBB86F6500589ABDD /* libStaticLibrary_ObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		574D072C770BAE53531249CF /* Headers */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Headers; sourceTree = SOURCE_ROOT; };
+		5DB17246AF97AF5311C1CB7B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		5FF83941D764AEB361249B72 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
+		610AD86B5088E07993870579 /* Model 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 3.xcdatamodel"; sourceTree = "<group>"; };
+		6170A2CAD1ABE59888B1F95E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LocalizedStoryboard.strings; sourceTree = "<group>"; };
+		6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libStaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C287801C7F7F97451C89F23 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
+		775BF5CB0D9F73D43A7A617A /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7B274B43FDC5E8E1FEF7E9FA /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		7E6075D44DFAA43C62CED79D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		80490871D5D4676E77EA80E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		8905BD70AC0E549E6C5E267A /* swift-tagged.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = "swift-tagged.framework"; sourceTree = "<group>"; };
+		948E174040217FD36F14BCF6 /* outputList.xcfilelist */ = {isa = PBXFileReference; lastKnownFileType = text.xcfilelist; path = outputList.xcfilelist; sourceTree = "<group>"; };
+		9759A19BAD2C50FCECF7D3C1 /* App_Clip_UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_Clip_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		98B17D464B46DAC8911014D5 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		A89D9F16591C365D568A0BA4 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A9327B50C4B0BDF4A252CB2A /* SwiftFileInDotPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFileInDotPath.swift; sourceTree = "<group>"; };
+		AE98EBB8C701BCA1BF478547 /* inputList.xcfilelist */ = {isa = PBXFileReference; lastKnownFileType = text.xcfilelist; path = inputList.xcfilelist; sourceTree = "<group>"; };
+		B945C628ACCF26FC51594160 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		C0B18235C78A3D3E84F2508B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		C0F698427B31A67B1541925E /* FrameworkFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkFile.swift; sourceTree = "<group>"; };
+		C16F953828BFF71DEB579075 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		C22BEDE0B2217312642FADA2 /* App_Clip.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_Clip.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C4AF74FB9AB607DFA9E07A4E /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		D80E621293876A18B051299F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		D998E6204320A2092F9327FA /* Model 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 2.xcdatamodel"; sourceTree = "<group>"; };
+		E4FBD31453FD26F4C7ABD5F9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E83A520CAE8A4BCF6578C2A9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		ED4A6FE2AF37CDDD3A0D1D6B /* TestProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectUITests.swift; sourceTree = "<group>"; };
+		EE31326E32ED51CB02C58E9D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		F1188E378718785171F293B6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LocalizedStoryboard.storyboard; sourceTree = "<group>"; };
+		F18408A818972A0675B115E4 /* App_Clip_Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_Clip_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F1DB5DD67A1E835227FE0397 /* TestProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectTests.swift; sourceTree = "<group>"; };
+		F55FFC5DC497CF889F859496 /* libStaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libStaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		F6813B4F70D433054D0C8FB8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticLibrary_ObjC.h; sourceTree = "<group>"; };
+		FFA405DFE01301A4B8BA9027 /* Standalone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Standalone.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		43C5260C6E5332D5E733D85E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7CB6A442EEFD3DAA5298FA6C /* TestFramework.framework in Frameworks */,
+				EC9566B5691051C716BCF88D /* swift-tagged.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		817E815A267F7A93B27C28C1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F415FFDA9CCF0237B5C0D7A5 /* Contacts.framework in Frameworks */,
+				BFD9082EF681F00F1EB86044 /* Framework.framework in Frameworks */,
+				26170D4BBCBE25B7ADB6C3C9 /* libStaticLibrary_ObjC.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		941526D5A3C922259CA39CB6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F0ED24C994FE9945337388B /* Framework.framework in Frameworks */,
+				BE8E9F3E79C62F56F889E7A6 /* libStaticLibrary_ObjC.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		02BC5C3C2EFC35F602940195 /* FolderWithDot2.0 */ = {
+			isa = PBXGroup;
+			children = (
+				A9327B50C4B0BDF4A252CB2A /* SwiftFileInDotPath.swift */,
+			);
+			path = FolderWithDot2.0;
+			sourceTree = "<group>";
+		};
+		032B95A6C88F143883A20612 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				8905BD70AC0E549E6C5E267A /* swift-tagged.framework */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		43472DDB7FC544B77A4B9308 /* Carthage */ = {
+			isa = PBXGroup;
+			children = (
+				032B95A6C88F143883A20612 /* iOS */,
+			);
+			name = Carthage;
+			path = Carthage/Build;
+			sourceTree = "<group>";
+		};
+		5017C17F6AC357F6128D719C /* App_Clip_UITests */ = {
+			isa = PBXGroup;
+			children = (
+				2D3BE7580CC3D623991914A4 /* Info.plist */,
+				ED4A6FE2AF37CDDD3A0D1D6B /* TestProjectUITests.swift */,
+			);
+			path = App_Clip_UITests;
+			sourceTree = "<group>";
+		};
+		504A23A54D051DF5E8D1C9D5 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				43472DDB7FC544B77A4B9308 /* Carthage */,
+				24562B158AF232E893E63362 /* Contacts.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		53FBB4268BA34C04D5E32FB1 /* Module */ = {
+			isa = PBXGroup;
+			children = (
+				98B17D464B46DAC8911014D5 /* module.modulemap */,
+			);
+			path = Module;
+			sourceTree = "<group>";
+		};
+		54E9E53007DE91CA40153A40 = {
+			isa = PBXGroup;
+			children = (
+				A62B59FAE6F412F87AA9802C /* App */,
+				57879A6554A581D1AB431C97 /* App_Clip */,
+				5017C17F6AC357F6128D719C /* App_Clip_UITests */,
+				89D980E845C2940109EB1A0E /* App_iOS_Tests */,
+				D5532FE12C5B6CC1A7F3E3D1 /* Configs */,
+				77F94B3D3772A24BC26FCE1A /* Framework */,
+				C6B85E6F88CE3EE3727FF514 /* StandaloneFiles */,
+				D313CB5937567576F546F007 /* StaticLibrary_ObjC */,
+				574D072C770BAE53531249CF /* Headers */,
+				504A23A54D051DF5E8D1C9D5 /* Frameworks */,
+				E8A7C596497AB5EFE54C4C67 /* Products */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		57879A6554A581D1AB431C97 /* App_Clip */ = {
+			isa = PBXGroup;
+			children = (
+				EE31326E32ED51CB02C58E9D /* AppDelegate.swift */,
+				329A12107D19B52E1F8554B4 /* Assets.xcassets */,
+				34E069C383E5121BD428C2D7 /* Clip.entitlements */,
+				80490871D5D4676E77EA80E9 /* Info.plist */,
+				5A391BB5F85ECBA78F808646 /* LaunchScreen.storyboard */,
+				556DA72EFDDD94E4E49C0754 /* Main.storyboard */,
+				7B274B43FDC5E8E1FEF7E9FA /* ViewController.swift */,
+			);
+			path = App_Clip;
+			sourceTree = "<group>";
+		};
+		77F94B3D3772A24BC26FCE1A /* Framework */ = {
+			isa = PBXGroup;
+			children = (
+				C0F698427B31A67B1541925E /* FrameworkFile.swift */,
+				4D770C47456D076025DD7A51 /* Info.plist */,
+				4711AC75927A510DEB4FCC31 /* MyFramework.h */,
+			);
+			path = Framework;
+			sourceTree = "<group>";
+		};
+		89D980E845C2940109EB1A0E /* App_iOS_Tests */ = {
+			isa = PBXGroup;
+			children = (
+				0751ACA46EF394AF3E358E48 /* Info.plist */,
+				F1DB5DD67A1E835227FE0397 /* TestProjectTests.swift */,
+			);
+			path = App_iOS_Tests;
+			sourceTree = "<group>";
+		};
+		A62B59FAE6F412F87AA9802C /* App */ = {
+			isa = PBXGroup;
+			children = (
+				02BC5C3C2EFC35F602940195 /* FolderWithDot2.0 */,
+				3469B706C364CC07AAEF298A /* App.entitlements */,
+				C0B18235C78A3D3E84F2508B /* AppDelegate.swift */,
+				F6813B4F70D433054D0C8FB8 /* Assets.xcassets */,
+				160628D3BF533455BA779575 /* Info.plist */,
+				AE98EBB8C701BCA1BF478547 /* inputList.xcfilelist */,
+				28193039398EB7872CD19490 /* LaunchScreen.storyboard */,
+				21AA0A827D6C74A605DEE03E /* Localizable.strings */,
+				4AE9A9C885258BF807598F5E /* Localizable.stringsdict */,
+				EE817D9DBEBA01EC4FFCED25 /* LocalizedStoryboard.storyboard */,
+				917AA3E4306C1A12FCC17994 /* Main.storyboard */,
+				431156B967A9DF0995682D7C /* Model.xcdatamodeld */,
+				7E6075D44DFAA43C62CED79D /* module.modulemap */,
+				948E174040217FD36F14BCF6 /* outputList.xcfilelist */,
+				6C287801C7F7F97451C89F23 /* Settings.bundle */,
+				0B2986C19C8498CDE44CFDAD /* ViewController.swift */,
+			);
+			name = App;
+			path = App_iOS;
+			sourceTree = "<group>";
+		};
+		C6B85E6F88CE3EE3727FF514 /* StandaloneFiles */ = {
+			isa = PBXGroup;
+			children = (
+				FFA405DFE01301A4B8BA9027 /* Standalone.swift */,
+			);
+			path = StandaloneFiles;
+			sourceTree = "<group>";
+		};
+		D313CB5937567576F546F007 /* StaticLibrary_ObjC */ = {
+			isa = PBXGroup;
+			children = (
+				53FBB4268BA34C04D5E32FB1 /* Module */,
+				F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */,
+				3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */,
+			);
+			path = StaticLibrary_ObjC;
+			sourceTree = "<group>";
+		};
+		D5532FE12C5B6CC1A7F3E3D1 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				28B6600F3CDA6F15633D2134 /* config.xcconfig */,
+			);
+			path = Configs;
+			sourceTree = "<group>";
+		};
+		E8A7C596497AB5EFE54C4C67 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F18408A818972A0675B115E4 /* App_Clip_Tests.xctest */,
+				9759A19BAD2C50FCECF7D3C1 /* App_Clip_UITests.xctest */,
+				C22BEDE0B2217312642FADA2 /* App_Clip.app */,
+				115047E35C1A4697DEC6D83F /* App_iOS.app */,
+				1B4D9FADD8956DC163813272 /* Framework.framework */,
+				775BF5CB0D9F73D43A7A617A /* Framework.framework */,
+				20B4D4D4A77434FA5593E35D /* Framework.framework */,
+				A89D9F16591C365D568A0BA4 /* Framework.framework */,
+				6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */,
+				376BA5774B91C2D6DA8F6C39 /* libStaticLibrary_ObjC.a */,
+				F55FFC5DC497CF889F859496 /* libStaticLibrary_ObjC.a */,
+				4FFF3A7EBB86F6500589ABDD /* libStaticLibrary_ObjC.a */,
+				0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		42B63956FC51459D9C131348 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0C7A6D06465E72F6D4DDA65B /* Headers in Headers */,
+				66ED5AE47EDD03A3DBBDF552 /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5A1839273A285D74BB199B27 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2CBE0DC8AC249AD1E42DC593 /* Headers in Headers */,
+				18666A1E5DE5F5B2D48ED872 /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D8324BF10D443128242BFBF1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D94D5D2D9EF9B359DEE438F6 /* Headers in Headers */,
+				24FD80AC771EAD5DEA2FB43F /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA5B84262385E32108A96880 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FFFAEFA20D72082E2888D56D /* Headers in Headers */,
+				8B078640745463EC45519361 /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F065DD45D12B8EB011254C45 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4D67F7E55015EFBDA73E307F /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		242476187403208F30D3219F /* Framework_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6107B10D2E2D953A15120917 /* Build configuration list for PBXNativeTarget "Framework_iOS" */;
+			buildPhases = (
+				DA5B84262385E32108A96880 /* Headers */,
+				F26C0DA46E6368299CB30667 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4772363EE5B936288A33F247 /* PBXTargetDependency */,
+			);
+			name = Framework_iOS;
+			productName = Framework_iOS;
+			productReference = 1B4D9FADD8956DC163813272 /* Framework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BCC8658A349BEF8B35DCEE45 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_iOS" */;
+			buildPhases = (
+				1C41E253B853711670514ECC /* CopyFiles */,
+				07D5C6D7C8F6A3942C2254AB /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StaticLibrary_ObjC_iOS;
+			productName = StaticLibrary_ObjC_iOS;
+			productReference = 6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		3FCF5A083151C7E22B24E807 /* StaticLibrary_ObjC_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8ABE44BA99ABFD6518573B75 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_macOS" */;
+			buildPhases = (
+				883C11C8EE5A3B03232F4D48 /* CopyFiles */,
+				B41D9338CACB491A234DE462 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StaticLibrary_ObjC_macOS;
+			productName = StaticLibrary_ObjC_macOS;
+			productReference = 376BA5774B91C2D6DA8F6C39 /* libStaticLibrary_ObjC.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		5239298BB84B4FDDFD84469E /* StaticLibrary_ObjC_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BDE5A3172EAD9560272E40D5 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_watchOS" */;
+			buildPhases = (
+				39EF6E709D5336CB216DC2FB /* CopyFiles */,
+				F1AE193E80AAC8D74BB27FBD /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StaticLibrary_ObjC_watchOS;
+			productName = StaticLibrary_ObjC_watchOS;
+			productReference = 4FFF3A7EBB86F6500589ABDD /* libStaticLibrary_ObjC.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		559F6E334A370096461729A9 /* App_Clip */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 29ED792F76D3712D856082B4 /* Build configuration list for PBXNativeTarget "App_Clip" */;
+			buildPhases = (
+				B6030D15F063E956298EFD4C /* Sources */,
+				56A55A3C072A3ABD19F022C6 /* Resources */,
+				941526D5A3C922259CA39CB6 /* Frameworks */,
+				D1B97A1B112643A756935FA5 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				418D7F4A4C25F618DBC96B1A /* PBXTargetDependency */,
+				8186C6B9309CD38A38413754 /* PBXTargetDependency */,
+			);
+			name = App_Clip;
+			productName = App_Clip;
+			productReference = C22BEDE0B2217312642FADA2 /* App_Clip.app */;
+			productType = "com.apple.product-type.application.on-demand-install-capable";
+		};
+		63EAAEAE0535C975295781D4 /* TestFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2FB1406136BDEE50410D00FE /* Build configuration list for PBXNativeTarget "TestFramework" */;
+			buildPhases = (
+				F065DD45D12B8EB011254C45 /* Headers */,
+				29C8264BCBD504223E822F37 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TestFramework;
+			productName = TestFramework;
+			productReference = 0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		672091195E5FD01EDDFB6714 /* App_Clip_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 25A6BD812166D38412B7D296 /* Build configuration list for PBXNativeTarget "App_Clip_Tests" */;
+			buildPhases = (
+				10E58CDB673A71DD896DE793 /* Sources */,
+				43C5260C6E5332D5E733D85E /* Frameworks */,
+				456284554D1A6C53EB39BA4B /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B0BF35FE3796D451CA095789 /* PBXTargetDependency */,
+				1A8C378E7A510A6E0772386F /* PBXTargetDependency */,
+			);
+			name = App_Clip_Tests;
+			productName = App_Clip_Tests;
+			productReference = F18408A818972A0675B115E4 /* App_Clip_Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		6BBA6FB48BEE245ED177B75E /* App_Clip_UITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 154811E763287E0982E4010C /* Build configuration list for PBXNativeTarget "App_Clip_UITests" */;
+			buildPhases = (
+				C7C8DBC92C9E0658B7D9EE40 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				789CE321F7B8ECC624741135 /* PBXTargetDependency */,
+			);
+			name = App_Clip_UITests;
+			productName = App_Clip_UITests;
+			productReference = 9759A19BAD2C50FCECF7D3C1 /* App_Clip_UITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+		786AB2F08EC86516E5EA092F /* Framework_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA4742F9D7A73F3DB2B4AC87 /* Build configuration list for PBXNativeTarget "Framework_watchOS" */;
+			buildPhases = (
+				42B63956FC51459D9C131348 /* Headers */,
+				2C73503B473B56249F74023D /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B2F2BF8FB4CBBFE658694D3E /* PBXTargetDependency */,
+			);
+			name = Framework_watchOS;
+			productName = Framework_watchOS;
+			productReference = A89D9F16591C365D568A0BA4 /* Framework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		8507B864DA27764F1EA6962C /* StaticLibrary_ObjC_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A664263A7E39D94679AD5F74 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_tvOS" */;
+			buildPhases = (
+				F0CE57DCC7A58AFEA0EB1EF5 /* CopyFiles */,
+				5AC22827901924EE4C7D2EE4 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StaticLibrary_ObjC_tvOS;
+			productName = StaticLibrary_ObjC_tvOS;
+			productReference = F55FFC5DC497CF889F859496 /* libStaticLibrary_ObjC.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		974B3EC2FF4FBAA1513A2950 /* Framework_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FECC727EC6A1CBB859258849 /* Build configuration list for PBXNativeTarget "Framework_macOS" */;
+			buildPhases = (
+				5A1839273A285D74BB199B27 /* Headers */,
+				220AD6BBDDF25CEF7C6FB356 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				219E518662CD7D0BA64246D9 /* PBXTargetDependency */,
+			);
+			name = Framework_macOS;
+			productName = Framework_macOS;
+			productReference = 775BF5CB0D9F73D43A7A617A /* Framework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		991BCE8E861305DE596EACFE /* App_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9EDED21A0C3AD1691C58401D /* Build configuration list for PBXNativeTarget "App_iOS" */;
+			buildPhases = (
+				F6445A97D8E8467AFCE9F0B6 /* Sources */,
+				21BCDA8027E0DED5FD1F46B2 /* Resources */,
+				817E815A267F7A93B27C28C1 /* Frameworks */,
+				D76EC4273D7E9C453072365B /* Embed App Clips */,
+				5FF5F332311FF39E3B020BD9 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1BB7E24BD9F5BA34E14CC594 /* PBXTargetDependency */,
+				F637B36CED5B903A9B1EEAE4 /* PBXTargetDependency */,
+				C1F2B62314C8601132D452FE /* PBXTargetDependency */,
+			);
+			name = App_iOS;
+			productName = App_iOS;
+			productReference = 115047E35C1A4697DEC6D83F /* App_iOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		D691B96B3888D27A6050EF10 /* Framework_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D5A2344247FF33D62704E2C2 /* Build configuration list for PBXNativeTarget "Framework_tvOS" */;
+			buildPhases = (
+				D8324BF10D443128242BFBF1 /* Headers */,
+				BEE11A37E1AD9A0DFE7376FA /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F70C9C12AA4664B4AA83B89D /* PBXTargetDependency */,
+			);
+			name = Framework_tvOS;
+			productName = Framework_tvOS;
+			productReference = 20B4D4D4A77434FA5593E35D /* Framework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7467FBF059DC784B5601CA7E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1020;
+				TargetAttributes = {
+					6BBA6FB48BEE245ED177B75E = {
+						TestTargetID = 559F6E334A370096461729A9;
+					};
+					991BCE8E861305DE596EACFE = {
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 2961C7042EE5F08A22AAF183 /* Build configuration list for PBXProject "ProjectXcode12" */;
+			compatibilityVersion = "Xcode 10.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 54E9E53007DE91CA40153A40;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				559F6E334A370096461729A9 /* App_Clip */,
+				672091195E5FD01EDDFB6714 /* App_Clip_Tests */,
+				6BBA6FB48BEE245ED177B75E /* App_Clip_UITests */,
+				991BCE8E861305DE596EACFE /* App_iOS */,
+				242476187403208F30D3219F /* Framework_iOS */,
+				974B3EC2FF4FBAA1513A2950 /* Framework_macOS */,
+				D691B96B3888D27A6050EF10 /* Framework_tvOS */,
+				786AB2F08EC86516E5EA092F /* Framework_watchOS */,
+				3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */,
+				3FCF5A083151C7E22B24E807 /* StaticLibrary_ObjC_macOS */,
+				8507B864DA27764F1EA6962C /* StaticLibrary_ObjC_tvOS */,
+				5239298BB84B4FDDFD84469E /* StaticLibrary_ObjC_watchOS */,
+				9C27C8C394ADD16FDCF6E624 /* SuperTarget */,
+				63EAAEAE0535C975295781D4 /* TestFramework */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		21BCDA8027E0DED5FD1F46B2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				38C639CCE01DB1DC4C2A7101 /* Assets.xcassets in Resources */,
+				FA7F5B42ACAEA016400A195A /* LaunchScreen.storyboard in Resources */,
+				AC800EB90200F927CE8ADC17 /* Localizable.strings in Resources */,
+				9A8AB7DE8957C82A8807559F /* Localizable.stringsdict in Resources */,
+				966364F9A5B152ED9292B335 /* LocalizedStoryboard.storyboard in Resources */,
+				89D00F3D1A87503F10AE7432 /* Main.storyboard in Resources */,
+				81724CEEA748160B950C85B5 /* Settings.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		56A55A3C072A3ABD19F022C6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				129640F84D0905CE479FF083 /* Assets.xcassets in Resources */,
+				60B0A79EF778752B7F574D8A /* LaunchScreen.storyboard in Resources */,
+				4FE6138F5867CA1D93C6EA04 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		07D5C6D7C8F6A3942C2254AB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0CD02F062979E2FD36D8D524 /* StaticLibrary_ObjC.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		10E58CDB673A71DD896DE793 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				74E1D133AB01AA3424C6C540 /* TestProjectTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		220AD6BBDDF25CEF7C6FB356 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				83A04F08119B1A648940B631 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		29C8264BCBD504223E822F37 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				35E3C0F60528783F7A6BFF9A /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2C73503B473B56249F74023D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E267E405615EF1727C3D49C7 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5AC22827901924EE4C7D2EE4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2778626BA6AC7257203DFA47 /* StaticLibrary_ObjC.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B41D9338CACB491A234DE462 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AF734D3BF6BA8808A2F1916C /* StaticLibrary_ObjC.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B6030D15F063E956298EFD4C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				04141410CA15B3FBC091FFEE /* AppDelegate.swift in Sources */,
+				D6A9F9FE464839B860307F97 /* ViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BEE11A37E1AD9A0DFE7376FA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FAD05AB024D2E3CB4EDBFAF4 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C7C8DBC92C9E0658B7D9EE40 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F316B77453C5A4A9692166AF /* TestProjectUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F1AE193E80AAC8D74BB27FBD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7A218049DED8B2CD3D8AD8B6 /* StaticLibrary_ObjC.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F26C0DA46E6368299CB30667 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FE6A3F3C7247CD2294753909 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F6445A97D8E8467AFCE9F0B6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F988879F73866310CE43F37 /* AppDelegate.swift in Sources */,
+				3D8580B33361272D45C61A85 /* Model.xcdatamodeld in Sources */,
+				37EDF33D6B4105F07070FB56 /* Standalone.swift in Sources */,
+				E9AB59E760C7776384AC7E32 /* SwiftFileInDotPath.swift in Sources */,
+				36FEB01A03A566B43A2C2434 /* ViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		1A8C378E7A510A6E0772386F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 63EAAEAE0535C975295781D4 /* TestFramework */;
+			targetProxy = 98E077CD4918FF68662C4337 /* PBXContainerItemProxy */;
+		};
+		1BB7E24BD9F5BA34E14CC594 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 559F6E334A370096461729A9 /* App_Clip */;
+			targetProxy = 0335EDE25056C73A036FE356 /* PBXContainerItemProxy */;
+		};
+		219E518662CD7D0BA64246D9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3FCF5A083151C7E22B24E807 /* StaticLibrary_ObjC_macOS */;
+			targetProxy = C0408FA85DFD7E9F59541D2E /* PBXContainerItemProxy */;
+		};
+		418D7F4A4C25F618DBC96B1A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 242476187403208F30D3219F /* Framework_iOS */;
+			targetProxy = D51CBCA8454A129B3F1C0629 /* PBXContainerItemProxy */;
+		};
+		4772363EE5B936288A33F247 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */;
+			targetProxy = F8D2CC44BE471C9C41F5B1E6 /* PBXContainerItemProxy */;
+		};
+		5D8D142415461F41AAF64E5B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 559F6E334A370096461729A9 /* App_Clip */;
+			targetProxy = 4D8A3B8387E29C006CC9AD78 /* PBXContainerItemProxy */;
+		};
+		789CE321F7B8ECC624741135 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 559F6E334A370096461729A9 /* App_Clip */;
+			targetProxy = 6DEB235CE85E75F90EC6175D /* PBXContainerItemProxy */;
+		};
+		8186C6B9309CD38A38413754 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */;
+			targetProxy = 9C7FA5CABE5A0EC3D5C4055B /* PBXContainerItemProxy */;
+		};
+		8DF064FE23E39B733B75994D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 991BCE8E861305DE596EACFE /* App_iOS */;
+			targetProxy = 0FA2870744F254DD5E3D8374 /* PBXContainerItemProxy */;
+		};
+		B0BF35FE3796D451CA095789 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 559F6E334A370096461729A9 /* App_Clip */;
+			targetProxy = 6D2993924DD47F80ACB3567E /* PBXContainerItemProxy */;
+		};
+		B2F2BF8FB4CBBFE658694D3E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5239298BB84B4FDDFD84469E /* StaticLibrary_ObjC_watchOS */;
+			targetProxy = 5CFE6D622751CA41654F4B00 /* PBXContainerItemProxy */;
+		};
+		C1F2B62314C8601132D452FE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */;
+			targetProxy = F7BDEB5E84BA34C6E32E8C1F /* PBXContainerItemProxy */;
+		};
+		F637B36CED5B903A9B1EEAE4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 242476187403208F30D3219F /* Framework_iOS */;
+			targetProxy = 2EAC3D4B05A43768279E03B7 /* PBXContainerItemProxy */;
+		};
+		F70C9C12AA4664B4AA83B89D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8507B864DA27764F1EA6962C /* StaticLibrary_ObjC_tvOS */;
+			targetProxy = 12A939B349AFA0D4B2A270EA /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		21AA0A827D6C74A605DEE03E /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E4FBD31453FD26F4C7ABD5F9 /* Base */,
+				C16F953828BFF71DEB579075 /* en */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
+		};
+		28193039398EB7872CD19490 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				3B4590226C49347F4BC18782 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		4AE9A9C885258BF807598F5E /* Localizable.stringsdict */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C4AF74FB9AB607DFA9E07A4E /* Base */,
+				D80E621293876A18B051299F /* en */,
+			);
+			name = Localizable.stringsdict;
+			sourceTree = "<group>";
+		};
+		556DA72EFDDD94E4E49C0754 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B945C628ACCF26FC51594160 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		5A391BB5F85ECBA78F808646 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E83A520CAE8A4BCF6578C2A9 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		917AA3E4306C1A12FCC17994 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				5DB17246AF97AF5311C1CB7B /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		EE817D9DBEBA01EC4FFCED25 /* LocalizedStoryboard.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F1188E378718785171F293B6 /* Base */,
+				6170A2CAD1ABE59888B1F95E /* en */,
+			);
+			name = LocalizedStoryboard.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		0359995ADD0BFA44E9905752 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = "Production Release";
+		};
+		04A44577D412ADA4AF40B0CF /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.TestFramework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		053EAED64FF4B9A3B4F86991 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Production Debug";
+		};
+		0C7B61BCB19F18E1CAFA9B02 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
+			};
+			name = "Staging Debug";
+		};
+		167CE7ABBB81B98E243004BF /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_Clip;
+			};
+			name = "Staging Debug";
+		};
+		16C3E5AA32E607CF8AE94952 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		172635BE151671235582D608 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				INFOPLIST_FILE = App_Clip/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		17DF05C2E3715A65EA214144 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		198A1841A62FDD2285BE1DEC /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Production Release";
+		};
+		1B2F2C5941E877806806E44C /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Test Release";
+		};
+		1D9C86CF49283D1F266E73A9 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		23235B1E6CC12E9F18293EC7 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Test Debug";
+		};
+		255923867BD8E40496573826 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		31C024516D94D042748F457B /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.TestFramework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		32AC37B65B0AD18D0BF30034 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = "Staging Release";
+		};
+		3AAD22CDEC8A1FDDB8A2708D /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Staging Release";
+		};
+		3CD4C8467FE69F1D2092CE66 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Production Release";
+		};
+		3E1E6EF943CEAE3F81929C96 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		485C71D2CEF34712CE8813C8 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		48FC7D687BB13EE23518E1FC /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = "Production Debug";
+		};
+		4B4702B2F362DA39717BC0CC /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		4FA21CDBD95C8B64FED4FD1F /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = "Production Debug";
+		};
+		541AF6B4C6B5311D339FF3ED /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = "Test Release";
+		};
+		5728D851D92C8BA0550695BA /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_ID_SUFFIX = .staging;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = "Staging Debug";
+		};
+		5804A4BD222650F5C32F6825 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
+			};
+			name = "Test Debug";
+		};
+		5924F68913C8A193D4081E97 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		5A63CA9A024A7C2091BC8A65 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		5D37F8F1E8C7B174E2BCDBAF /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		61401F625B86180823D74815 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.TestFramework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		624FDC440AC60A1426188430 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		63B8C37C32DB75550B534E3F /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.TestFramework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		67DEEE053A621B66857F9803 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_Clip;
+			};
+			name = "Test Debug";
+		};
+		6F20523C3582CFAD67FF337B /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				INFOPLIST_FILE = App_Clip/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		6FE62E88CE8995B6B09EA0C8 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		71A3AC6722DE3CBD99092E8C /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Staging Release";
+		};
+		721DE2AAC1D8788D496342D5 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				INFOPLIST_FILE = App_Clip/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		73F0DB076A5FCED1A4D04930 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_ID_SUFFIX = .staging;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Staging Release";
+		};
+		74ED626BC2054224876550EE /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Test Debug";
+		};
+		751BB7D52B5275C48FA8561B /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		77FF85B1482FA6B1F5C7464D /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		797B3A734448D220FC75A683 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		7CBE3B17DB26AE387A5182D9 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.TestFramework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		7FB7D3D5582FEBF67168A7FE /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		83369794BD5F599701ECCCAB /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		838050FA296DBA072BFBDAC6 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = "Test Release";
+		};
+		8480F258F8BB72C9E64251D2 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		851A57DE0FE85BF757688ED2 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_Clip;
+			};
+			name = "Staging Release";
+		};
+		89AF7A6AD1A97A3595BE385D /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		8E57FECDCAC83BC80F2950B1 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		8E88FBD6519BC82A07713AEA /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		8E96D4EBF49E14AF234B6211 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		90B900384791067500B135B7 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				INFOPLIST_FILE = App_Clip/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		96EBFB5B0E95829CA24B888F /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_ID_SUFFIX = .test;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = "Test Release";
+		};
+		978F2FF834AB6B8DFA16158F /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Staging Debug";
+		};
+		983179BB00CE13590396D418 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = "Staging Debug";
+		};
+		9851DE9B03B3F61BE95059CD /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Production Debug";
+		};
+		98C2E2329E5338479C21FCB3 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_Clip;
+			};
+			name = "Production Debug";
+		};
+		98C2F16400F0BB2EF4D96C01 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
+		A3FA0FDB6F5345F5DC6FAF6A /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				INFOPLIST_FILE = App_Clip/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
+		A50C9533122E6AD686BBD105 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 28B6600F3CDA6F15633D2134 /* config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_ID_SUFFIX = .test;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = "Test Debug";
+		};
+		AB794EA9075BC2B2E1D742DB /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		AE10B9A8DD8696989527226F /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Production Release";
+		};
+		B34E6EA38DD860CEECFB2DAB /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		B63AEDBE2CAF03E47A42EFBB /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
+			};
+			name = "Production Release";
+		};
+		BCD6DAE84F6D39A359582F34 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		C0E6F72AC67FDABEC3DA0F56 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		C348EEA27988050B1A7E44CF /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
+			};
+			name = "Test Release";
+		};
+		C914FA6353BCB691D4770A79 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		CB42404875DC01211537EBC0 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = "Test Debug";
+		};
+		CED7E259E7C0F45F2011E81C /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		CF10817F3ECC67C1E02FCB49 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_Clip;
+			};
+			name = "Test Release";
+		};
+		CF210234FD3BAEE7A36DD67A /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = "Production Debug";
+		};
+		D4EA5ACE61DD1FF1759A15F9 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.TestFramework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		D7EF4B53953AC7DBC16BF5CC /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
+		DE81F17DA26F80B807A0ECB4 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-macOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		DEB610ED8F66FE30A09B28FB /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
+			};
+			name = "Production Debug";
+		};
+		E0C7BB51B137528004C6D05B /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = "Test Debug";
+		};
+		E1BDBEB4922DC3ADA85FCB45 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-tvOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		E1F957C21FA9E788F3AA9A55 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-watchOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Staging Debug";
+		};
+		EB341083488EA6F9A7B09376 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = "Staging Debug";
+		};
+		EDA66845ACB2EC1E2D02DBCE /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_Clip.app/App_Clip";
+			};
+			name = "Staging Release";
+		};
+		EF12A546F36561AD22ABE953 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		F3605B5D6C4420A1213360A8 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		F60F56A09B66D2E156A6BE9B /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		F6979D0393CC0D4FB9CA9877 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = "Production Release";
+		};
+		F742C8CFE1D42CD709113154 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-tvOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+			};
+			name = "Staging Release";
+		};
+		F77B428B65F1468434D6801A /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-Clip-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_Clip;
+			};
+			name = "Production Release";
+		};
+		F94FDBEFBDAC270102F161C3 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
+				PRODUCT_NAME = Framework;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		F990CC508784D61CF58463E6 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-macOS";
+				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = "Test Release";
+		};
+		F9AE99185A585F0E5FC18494 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				INFOPLIST_FILE = App_Clip/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		154811E763287E0982E4010C /* Build configuration list for PBXNativeTarget "App_Clip_UITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				98C2E2329E5338479C21FCB3 /* Production Debug */,
+				F77B428B65F1468434D6801A /* Production Release */,
+				167CE7ABBB81B98E243004BF /* Staging Debug */,
+				851A57DE0FE85BF757688ED2 /* Staging Release */,
+				67DEEE053A621B66857F9803 /* Test Debug */,
+				CF10817F3ECC67C1E02FCB49 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		25A6BD812166D38412B7D296 /* Build configuration list for PBXNativeTarget "App_Clip_Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DEB610ED8F66FE30A09B28FB /* Production Debug */,
+				B63AEDBE2CAF03E47A42EFBB /* Production Release */,
+				0C7B61BCB19F18E1CAFA9B02 /* Staging Debug */,
+				EDA66845ACB2EC1E2D02DBCE /* Staging Release */,
+				5804A4BD222650F5C32F6825 /* Test Debug */,
+				C348EEA27988050B1A7E44CF /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		2961C7042EE5F08A22AAF183 /* Build configuration list for PBXProject "ProjectXcode12" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				48FC7D687BB13EE23518E1FC /* Production Debug */,
+				198A1841A62FDD2285BE1DEC /* Production Release */,
+				5728D851D92C8BA0550695BA /* Staging Debug */,
+				73F0DB076A5FCED1A4D04930 /* Staging Release */,
+				A50C9533122E6AD686BBD105 /* Test Debug */,
+				96EBFB5B0E95829CA24B888F /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		29ED792F76D3712D856082B4 /* Build configuration list for PBXNativeTarget "App_Clip" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F9AE99185A585F0E5FC18494 /* Production Debug */,
+				172635BE151671235582D608 /* Production Release */,
+				90B900384791067500B135B7 /* Staging Debug */,
+				721DE2AAC1D8788D496342D5 /* Staging Release */,
+				6F20523C3582CFAD67FF337B /* Test Debug */,
+				A3FA0FDB6F5345F5DC6FAF6A /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		2FB1406136BDEE50410D00FE /* Build configuration list for PBXNativeTarget "TestFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D4EA5ACE61DD1FF1759A15F9 /* Production Debug */,
+				31C024516D94D042748F457B /* Production Release */,
+				04A44577D412ADA4AF40B0CF /* Staging Debug */,
+				7CBE3B17DB26AE387A5182D9 /* Staging Release */,
+				63B8C37C32DB75550B534E3F /* Test Debug */,
+				61401F625B86180823D74815 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		6107B10D2E2D953A15120917 /* Build configuration list for PBXNativeTarget "Framework_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				89AF7A6AD1A97A3595BE385D /* Production Debug */,
+				B34E6EA38DD860CEECFB2DAB /* Production Release */,
+				F3605B5D6C4420A1213360A8 /* Staging Debug */,
+				C914FA6353BCB691D4770A79 /* Staging Release */,
+				C0E6F72AC67FDABEC3DA0F56 /* Test Debug */,
+				751BB7D52B5275C48FA8561B /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		70FED818DB797FCDC7929DBC /* Build configuration list for PBXAggregateTarget "SuperTarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CF210234FD3BAEE7A36DD67A /* Production Debug */,
+				F6979D0393CC0D4FB9CA9877 /* Production Release */,
+				983179BB00CE13590396D418 /* Staging Debug */,
+				32AC37B65B0AD18D0BF30034 /* Staging Release */,
+				E0C7BB51B137528004C6D05B /* Test Debug */,
+				838050FA296DBA072BFBDAC6 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		8ABE44BA99ABFD6518573B75 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				053EAED64FF4B9A3B4F86991 /* Production Debug */,
+				3CD4C8467FE69F1D2092CE66 /* Production Release */,
+				978F2FF834AB6B8DFA16158F /* Staging Debug */,
+				71A3AC6722DE3CBD99092E8C /* Staging Release */,
+				23235B1E6CC12E9F18293EC7 /* Test Debug */,
+				F990CC508784D61CF58463E6 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		9EDED21A0C3AD1691C58401D /* Build configuration list for PBXNativeTarget "App_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BCD6DAE84F6D39A359582F34 /* Production Debug */,
+				EF12A546F36561AD22ABE953 /* Production Release */,
+				797B3A734448D220FC75A683 /* Staging Debug */,
+				5A63CA9A024A7C2091BC8A65 /* Staging Release */,
+				8E88FBD6519BC82A07713AEA /* Test Debug */,
+				98C2F16400F0BB2EF4D96C01 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		A664263A7E39D94679AD5F74 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4FA21CDBD95C8B64FED4FD1F /* Production Debug */,
+				0359995ADD0BFA44E9905752 /* Production Release */,
+				EB341083488EA6F9A7B09376 /* Staging Debug */,
+				F742C8CFE1D42CD709113154 /* Staging Release */,
+				CB42404875DC01211537EBC0 /* Test Debug */,
+				541AF6B4C6B5311D339FF3ED /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		BCC8658A349BEF8B35DCEE45 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7FB7D3D5582FEBF67168A7FE /* Production Debug */,
+				F60F56A09B66D2E156A6BE9B /* Production Release */,
+				255923867BD8E40496573826 /* Staging Debug */,
+				485C71D2CEF34712CE8813C8 /* Staging Release */,
+				5D37F8F1E8C7B174E2BCDBAF /* Test Debug */,
+				D7EF4B53953AC7DBC16BF5CC /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		BDE5A3172EAD9560272E40D5 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9851DE9B03B3F61BE95059CD /* Production Debug */,
+				AE10B9A8DD8696989527226F /* Production Release */,
+				E1F957C21FA9E788F3AA9A55 /* Staging Debug */,
+				3AAD22CDEC8A1FDDB8A2708D /* Staging Release */,
+				74ED626BC2054224876550EE /* Test Debug */,
+				1B2F2C5941E877806806E44C /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		D5A2344247FF33D62704E2C2 /* Build configuration list for PBXNativeTarget "Framework_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1BDBEB4922DC3ADA85FCB45 /* Production Debug */,
+				17DF05C2E3715A65EA214144 /* Production Release */,
+				8480F258F8BB72C9E64251D2 /* Staging Debug */,
+				1D9C86CF49283D1F266E73A9 /* Staging Release */,
+				77FF85B1482FA6B1F5C7464D /* Test Debug */,
+				3E1E6EF943CEAE3F81929C96 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		DA4742F9D7A73F3DB2B4AC87 /* Build configuration list for PBXNativeTarget "Framework_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F94FDBEFBDAC270102F161C3 /* Production Debug */,
+				5924F68913C8A193D4081E97 /* Production Release */,
+				624FDC440AC60A1426188430 /* Staging Debug */,
+				8E96D4EBF49E14AF234B6211 /* Staging Release */,
+				CED7E259E7C0F45F2011E81C /* Test Debug */,
+				16C3E5AA32E607CF8AE94952 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		FECC727EC6A1CBB859258849 /* Build configuration list for PBXNativeTarget "Framework_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4B4702B2F362DA39717BC0CC /* Production Debug */,
+				AB794EA9075BC2B2E1D742DB /* Production Release */,
+				6FE62E88CE8995B6B09EA0C8 /* Staging Debug */,
+				8E57FECDCAC83BC80F2950B1 /* Staging Release */,
+				83369794BD5F599701ECCCAB /* Test Debug */,
+				DE81F17DA26F80B807A0ECB4 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCVersionGroup section */
+		431156B967A9DF0995682D7C /* Model.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				D998E6204320A2092F9327FA /* Model 2.xcdatamodel */,
+				610AD86B5088E07993870579 /* Model 3.xcdatamodel */,
+				5FF83941D764AEB361249B72 /* Model.xcdatamodel */,
+			);
+			currentVersion = D998E6204320A2092F9327FA /* Model 2.xcdatamodel */;
+			path = Model.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
+	};
+	rootObject = 7467FBF059DC784B5601CA7E /* Project object */;
+}

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/project.pbxproj
@@ -11,10 +11,11 @@
 			isa = PBXAggregateTarget;
 			buildConfigurationList = 70FED818DB797FCDC7929DBC /* Build configuration list for PBXAggregateTarget "SuperTarget" */;
 			buildPhases = (
+				D4BA2D61D3DC727DA6E90F7E /* MyScript */,
 			);
 			dependencies = (
 				8DF064FE23E39B733B75994D /* PBXTargetDependency */,
-				5D8D142415461F41AAF64E5B /* PBXTargetDependency */,
+				53E5D1FE14ECF98F9F9729CF /* PBXTargetDependency */,
 			);
 			name = SuperTarget;
 			productName = SuperTarget;
@@ -22,72 +23,157 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		0035E2ED473E71B573FA73CF /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021F11A2B76A01ED4113286B /* ViewController.swift */; };
+		00412000C589181F73BB9C88 /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1342A225B1FB5CCDE2D8C511 /* StaticLibrary.swift */; };
+		0060461B613150BA7D9CAF95 /* MyBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = F24135F7E2026D8D80F8B919 /* MyBundle.bundle */; };
 		04141410CA15B3FBC091FFEE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE31326E32ED51CB02C58E9D /* AppDelegate.swift */; };
+		064BCA54DD18E6F5EAFE5C1C /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7E1427FBA94B073C3FD2830A /* Interface.storyboard */; };
+		068A307AAD3FDB71E245CF4B /* App_Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = C22BEDE0B2217312642FADA2 /* App_Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		078DC5844DEA2DB6F020D455 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		092201CC0E7C18615C0B212A /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC670E53BFAA6F61C02BE82 /* main.swift */; };
+		0A14BD0F9B22C84677FD7D6F /* XPC Service.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = 51E2D479CB960CB44EB545C6 /* XPC Service.xpc */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0A6862249B5F9D544A774770 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98B17D464B46DAC8911014D5 /* module.modulemap */; };
 		0C7A6D06465E72F6D4DDA65B /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 574D072C770BAE53531249CF /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
 		0CD02F062979E2FD36D8D524 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */; };
+		0DC0E4339EBAB04754837F50 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC10D740EAC35BF970A7327A /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		0EDE93FD1B8EEA5E757A3EE1 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		1081606EF3D131248CC46BD6 /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */; };
+		11B2B5EF7172B6B837D951AA /* StandaloneAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 68D8757F885CE1C02514845C /* StandaloneAssets.xcassets */; };
 		129640F84D0905CE479FF083 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 329A12107D19B52E1F8554B4 /* Assets.xcassets */; };
+		16B6081EBDCE7DDBC89DDFEE /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA405DFE01301A4B8BA9027 /* Standalone.swift */; };
+		16BD7E732A3294D973E79337 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 95933688FAC17B9E7752CB4F /* MainInterface.storyboard */; };
 		18666A1E5DE5F5B2D48ED872 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1870224DAA5300F2EEB5C728 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55DF3F01BB8698E8226D05A0 /* Assets.xcassets */; };
 		1F0ED24C994FE9945337388B /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; };
+		22E1EE394E24667C942CAFC4 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC10D740EAC35BF970A7327A /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		24FD80AC771EAD5DEA2FB43F /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2514149FFB3E6498D579DBBB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F3EA429799FBBE247A2D82 /* AppDelegate.swift */; };
 		26170D4BBCBE25B7ADB6C3C9 /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */; };
 		2778626BA6AC7257203DFA47 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */; };
 		29C5F4E429F4826AC299988F /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */; };
+		2A39623B596284EC9DCDAE1D /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68F16F683711ECD7CC9C43EC /* TestProjectTests.swift */; };
+		2B74F88A338EE674477351B1 /* TestFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2CBE0DC8AC249AD1E42DC593 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 574D072C770BAE53531249CF /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+		2F0E1973A958FCDE8CE09F5E /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		2FB0D86C27098550FAFB4164 /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0C6EA871817E3A864FDE5DA1 /* Framework2.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		30E0C7F5317477917CFFCE52 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 21AA0A827D6C74A605DEE03E /* Localizable.strings */; };
+		329F958FE3152A51D6DBDC4F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 917AA3E4306C1A12FCC17994 /* Main.storyboard */; };
+		35AA463863F88CB6290C264D /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC10D740EAC35BF970A7327A /* Result.framework */; };
 		35E3C0F60528783F7A6BFF9A /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
 		36FEB01A03A566B43A2C2434 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2986C19C8498CDE44CFDAD /* ViewController.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		37556609B05600FC511F540B /* SwiftFileInDotPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9327B50C4B0BDF4A252CB2A /* SwiftFileInDotPath.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		37EDF33D6B4105F07070FB56 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA405DFE01301A4B8BA9027 /* Standalone.swift */; };
 		38C639CCE01DB1DC4C2A7101 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F6813B4F70D433054D0C8FB8 /* Assets.xcassets */; };
+		3A0A1B20E2149C6B53848EAC /* LocalizedStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EE817D9DBEBA01EC4FFCED25 /* LocalizedStoryboard.storyboard */; };
 		3D8580B33361272D45C61A85 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 431156B967A9DF0995682D7C /* Model.xcdatamodeld */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		3EC2758239D6659E4D35DFD9 /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; };
+		40906CFD3662304ACD172B5C /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 4AE9A9C885258BF807598F5E /* Localizable.stringsdict */; };
+		448A2FB5230855C2A68C8960 /* App_watchOS.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = BB4C1F0CB031F894B46533E0 /* App_watchOS.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		48B822DF3314CCF76EE74D6D /* File2.swift in Sources */ = {isa = PBXBuildFile; fileRef = D358C9F4D4F2D97C148913CF /* File2.swift */; };
+		4A1F587B61D4D2EE6833C281 /* App_watchOS Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 02C5C670B0624A007BCB341D /* App_watchOS Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4BC91284F91B188CBBEBA38C /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
 		4D67F7E55015EFBDA73E307F /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FE6138F5867CA1D93C6EA04 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 556DA72EFDDD94E4E49C0754 /* Main.storyboard */; };
+		50E29FF7B2936111F9189780 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6C287801C7F7F97451C89F23 /* Settings.bundle */; };
+		53AC4E3D64CC954A74A6BF51 /* iMessageExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 6C14AF20FB1E07BF9D32937E /* iMessageExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		557415FFAD88A691DF87B917 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5986EF99D2CDEE9EBC4B2AF1 /* TestFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */; };
+		5B6902E1019616CCCC8C84D7 /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13B7C799370862813D8FE163 /* TestProjectUITests.swift */; };
+		5F3CD9C98D6FCF78A371850F /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 431156B967A9DF0995682D7C /* Model.xcdatamodeld */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		5F930EEC8C575CB59EC11435 /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		60B0A79EF778752B7F574D8A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5A391BB5F85ECBA78F808646 /* LaunchScreen.storyboard */; };
+		618C6FCD590D09819BF3CA2B /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7601CC56C42BD6A1D4A75AEA /* Result.framework */; };
+		6236A088DDF97D457194A2FD /* ExternalTarget.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FF10A8919F65E6609784780A /* ExternalTarget.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		66ED5AE47EDD03A3DBBDF552 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6A779DFBEA9BC9A301F7B410 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E9E5D8F0132EBAFE6703730 /* libz.dylib */; };
+		6B0FF0DA562C828135741257 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24562B158AF232E893E63362 /* Contacts.framework */; };
+		6CA40F7223581AF6628DB4DE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4402963B58134A6066B9E943 /* Assets.xcassets */; };
 		6F988879F73866310CE43F37 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B18235C78A3D3E84F2508B /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		712E73B032F6905D77A9AF29 /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 775BF5CB0D9F73D43A7A617A /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		74E1D133AB01AA3424C6C540 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DB5DD67A1E835227FE0397 /* TestProjectTests.swift */; };
+		751D7A8B90209DDAAB9EB73E /* File1.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFC3D1BD85132F4625B4B231 /* File1.swift */; };
+		76EFFFE1C3073348E70FAD17 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB002AF7692C5A6F71304272 /* Result.framework */; };
+		793BD03EDB3A072945B82C27 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 201AC416366CB5F5B305E883 /* Assets.xcassets */; };
 		7A218049DED8B2CD3D8AD8B6 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */; };
+		7AD5DA085B8A8182D006BF97 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7CB6A442EEFD3DAA5298FA6C /* TestFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */; };
 		81724CEEA748160B950C85B5 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 6C287801C7F7F97451C89F23 /* Settings.bundle */; };
+		820158D082BDA00E14BD61E2 /* MessagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6027424389D202122B079A42 /* MessagesViewController.swift */; };
 		83A04F08119B1A648940B631 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		84A839AF00AB269416E54CD4 /* Empty.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 241982105A45A78DDE5AE195 /* Empty.h */; };
+		85332C85D63B652CAB836FB9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 78B81AD14AB1A48CFA916FB2 /* Assets.xcassets */; };
+		866974B9FCB26B1FEB2B66AF /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC10D740EAC35BF970A7327A /* Result.framework */; };
 		89D00F3D1A87503F10AE7432 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 917AA3E4306C1A12FCC17994 /* Main.storyboard */; };
 		8B078640745463EC45519361 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8F4FEE199C8E1C4B89B927F4 /* App_Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = C22BEDE0B2217312642FADA2 /* App_Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		8F2C2446CC90D71637CA98DE /* Model.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = C68273268C686B59A290EEF3 /* Model.xcmappingmodel */; };
+		8F64F92EA2ADCED7258DFB50 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7601CC56C42BD6A1D4A75AEA /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		922FA3335972E2600AD9C68D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 5304167A195992C7D3D8F373 /* main.m */; };
 		966364F9A5B152ED9292B335 /* LocalizedStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EE817D9DBEBA01EC4FFCED25 /* LocalizedStoryboard.storyboard */; };
+		981AB81EA8094B072BAE125F /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB9233C31FD59CF515FC7414 /* SwiftyJSON.framework */; };
 		99FD6FC149E2753DD75BA792 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */; };
+		9A61DB3A89D0636D62F6134C /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CED83F810BD91A053B98A /* ExtensionDelegate.swift */; };
 		9A8AB7DE8957C82A8807559F /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 4AE9A9C885258BF807598F5E /* Localizable.stringsdict */; };
+		9ABB0EF3A6513E47AF06FA56 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC10D740EAC35BF970A7327A /* Result.framework */; };
+		9BE414C2C4CE2BA52F20E38D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E835E43770D77649C766CD28 /* Assets.xcassets */; };
+		9E605FE85BFDA54EDB3AC0F0 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7A79640DB3BA2B340CCEAF0 /* Result.framework */; };
+		A4F2F9AC7C204B67DFDE0991 /* swift-tagged.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8905BD70AC0E549E6C5E267A /* swift-tagged.framework */; };
+		A5850DA4EB6491F7B3588832 /* SceneKitCatalog.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = A2CBBF04CBB716C4BF958A99 /* SceneKitCatalog.scnassets */; };
 		A795886DF55D0AF370692AAB /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98B17D464B46DAC8911014D5 /* module.modulemap */; };
 		AC800EB90200F927CE8ADC17 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 21AA0A827D6C74A605DEE03E /* Localizable.strings */; };
 		AF734D3BF6BA8808A2F1916C /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */; };
+		B04F45480A1578BF58E692C6 /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 376BA5774B91C2D6DA8F6C39 /* libStaticLibrary_ObjC.a */; };
 		B07763BBA6FC4AB9D65BE390 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */; };
+		B09EE60448F8EBD4546D3C41 /* TestProjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1DB5DD67A1E835227FE0397 /* TestProjectTests.swift */; };
+		B3863DD3BC5038A7987B495F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B18235C78A3D3E84F2508B /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		B5B0D4EAB3B78D5CE452E100 /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E889D8B5524C64ED5CF252D0 /* InterfaceController.swift */; };
+		B5BD65590F7EE7C3963B5122 /* MoreUnder.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7EC60A15CCEC05897CEFC34 /* MoreUnder.swift */; };
 		BDEE0F3F67B9EA52B04CC2C6 /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98B17D464B46DAC8911014D5 /* module.modulemap */; };
 		BE8E9F3E79C62F56F889E7A6 /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */; };
+		BF1837BBD7E8DA1998C80F7A /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8F914F7847A9FB2BDBA73C /* NotificationController.swift */; };
+		BF7D701BA63380CE76046BDB /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA405DFE01301A4B8BA9027 /* Standalone.swift */; };
 		BFD9082EF681F00F1EB86044 /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; };
+		C42838B5395A013CF38EA48E /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		C57A966770059A0014B3326D /* example.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 149F3970E2BE9F35231FC34D /* example.mp4 */; settings = {ASSET_TAGS = (tag1, tag2, ); }; };
+		C6F8661462BC2CADFBF59851 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7601CC56C42BD6A1D4A75AEA /* Result.framework */; };
 		C715C98D479D3832005E622B /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = 98B17D464B46DAC8911014D5 /* module.modulemap */; };
+		C875EA6DE9F7090BDB27D6B9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 28193039398EB7872CD19490 /* LaunchScreen.storyboard */; };
+		C8A63AB7A95D10D5430D3AD2 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24562B158AF232E893E63362 /* Contacts.framework */; };
+		C9EE684BC0637F26CCB5DB98 /* SomeXPCService.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = BB1FE6F7B1E431337B051320 /* SomeXPCService.xpc */; };
+		CC3D560B3E97CAAAC8B6076E /* iMessageApp.app in Resources */ = {isa = PBXBuildFile; fileRef = 239041E1C2665F9EB8AEB019 /* iMessageApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		CD55F1F95D9B020253935924 /* BundleX.bundle in Copy Bundle Resources */ = {isa = PBXBuildFile; fileRef = C2669AB60DB45D52E58D5A6D /* BundleX.bundle */; };
+		D584474E14DF674265501DA7 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 4711AC75927A510DEB4FCC31 /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D6A9F9FE464839B860307F97 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B274B43FDC5E8E1FEF7E9FA /* ViewController.swift */; };
+		D6E1725E31FE9D8D8B0075AD /* XPC_Service.m in Sources */ = {isa = PBXBuildFile; fileRef = A2D7192D099F88F92AC33C9A /* XPC_Service.m */; };
+		D6F1CE68BD0D773AF8FB5166 /* Framework2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C6EA871817E3A864FDE5DA1 /* Framework2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D94D5D2D9EF9B359DEE438F6 /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 574D072C770BAE53531249CF /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCFAD099E6E129BDE43E1B79 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F6813B4F70D433054D0C8FB8 /* Assets.xcassets */; };
+		E013E10B776DC6DD0956F20E /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC10D740EAC35BF970A7327A /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E0976466478FACCA962CD09F /* Framework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 775BF5CB0D9F73D43A7A617A /* Framework.framework */; };
+		E1B953AB2F713D5D6AAF5A72 /* ExternalTarget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF10A8919F65E6609784780A /* ExternalTarget.framework */; };
 		E267E405615EF1727C3D49C7 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		E347C6740A9E3D8C9BF87A26 /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E4D57896F90E7AEC6FED0634 /* ResourceFolder in Resources */ = {isa = PBXBuildFile; fileRef = B787DC6505E0F15C5C4975E3 /* ResourceFolder */; };
 		E9AB59E760C7776384AC7E32 /* SwiftFileInDotPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9327B50C4B0BDF4A252CB2A /* SwiftFileInDotPath.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		EC9566B5691051C716BCF88D /* swift-tagged.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8905BD70AC0E549E6C5E267A /* swift-tagged.framework */; };
+		ED7050A16D1A986B9F47AC43 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C552EC308B5274F2B6AC53B5 /* Assets.xcassets */; };
+		F01287B5AA79506789A98FBF /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = F7692A9E8CAA5A4B12FE633B /* libc++.tbd */; };
+		F0610A6808224739266D81D6 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7601CC56C42BD6A1D4A75AEA /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F189C2A0350D2BF0DE9861E7 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = EC10D740EAC35BF970A7327A /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F316B77453C5A4A9692166AF /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED4A6FE2AF37CDDD3A0D1D6B /* TestProjectUITests.swift */; };
 		F415FFDA9CCF0237B5C0D7A5 /* Contacts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24562B158AF232E893E63362 /* Contacts.framework */; };
 		F6BD1D30F6F6E5809B4CF709 /* TestFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F7A0142071C8301E99C11E3A /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B4D9FADD8956DC163813272 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F94B7016C76FC0A6B74111B3 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 214F642E7193A3E608845F4B /* Main.storyboard */; };
+		FA39577CB6231B24C47E828D /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EC10D740EAC35BF970A7327A /* Result.framework */; };
 		FA7F5B42ACAEA016400A195A /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 28193039398EB7872CD19490 /* LaunchScreen.storyboard */; };
 		FAD05AB024D2E3CB4EDBFAF4 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
+		FB753FD180515AE293B2485C /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2986C19C8498CDE44CFDAD /* ViewController.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		FE6A3F3C7247CD2294753909 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0F698427B31A67B1541925E /* FrameworkFile.swift */; };
 		FECBF2C1DD2D1B8BBD7DA7DF /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */; };
 		FFFAEFA20D72082E2888D56D /* Headers in Headers */ = {isa = PBXBuildFile; fileRef = 574D072C770BAE53531249CF /* Headers */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		0335EDE25056C73A036FE356 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 559F6E334A370096461729A9;
-			remoteInfo = App_Clip;
-		};
 		0FA2870744F254DD5E3D8374 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
@@ -102,6 +188,20 @@
 			remoteGlobalIDString = 8507B864DA27764F1EA6962C;
 			remoteInfo = StaticLibrary_ObjC_tvOS;
 		};
+		193DD9683611F943D58ADCC6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 242476187403208F30D3219F;
+			remoteInfo = Framework_iOS;
+		};
+		1BC468AB18D1F023019F1FBA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = D8592DE6C0BC77BE0D4A2FAB;
+			remoteInfo = "XPC Service";
+		};
 		2EAC3D4B05A43768279E03B7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
@@ -109,12 +209,40 @@
 			remoteGlobalIDString = 242476187403208F30D3219F;
 			remoteInfo = Framework_iOS;
 		};
-		4D8A3B8387E29C006CC9AD78 /* PBXContainerItemProxy */ = {
+		2F6AB4DC84D6D8156D9743ED /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 559F6E334A370096461729A9;
-			remoteInfo = App_Clip;
+			remoteGlobalIDString = 5C6E1548456BE821C90E23F0;
+			remoteInfo = Framework2_iOS;
+		};
+		3BFFB177BC0E51F54F902AE2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E8BDC848AB4F8D5927ADB55B;
+			remoteInfo = App_macOS;
+		};
+		4CA2280DE705720E8B851B8E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 242476187403208F30D3219F;
+			remoteInfo = Framework_iOS;
+		};
+		4DB3B584A41D1D19DE1B39E1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 974B3EC2FF4FBAA1513A2950;
+			remoteInfo = Framework_macOS;
+		};
+		5A3133C260AB0B2EE767880A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3DBB411AF8D365588E21D8CA;
+			remoteInfo = StaticLibrary_ObjC_iOS;
 		};
 		5CFE6D622751CA41654F4B00 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -137,6 +265,20 @@
 			remoteGlobalIDString = 559F6E334A370096461729A9;
 			remoteInfo = App_Clip;
 		};
+		8C53BD3BF1B5227C831355F9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 43EA7AFC9AC8E9116A228613 /* AnotherProject */;
+			proxyType = 1;
+			remoteGlobalIDString = E76A5F5E363E470416D3B487;
+			remoteInfo = ExternalTarget;
+		};
+		913CC94BAD23FF3E3636E8E5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 991BCE8E861305DE596EACFE;
+			remoteInfo = App_iOS;
+		};
 		98E077CD4918FF68662C4337 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
@@ -151,6 +293,27 @@
 			remoteGlobalIDString = 3DBB411AF8D365588E21D8CA;
 			remoteInfo = StaticLibrary_ObjC_iOS;
 		};
+		9D69D471B06AE37AEA2D84E3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 991BCE8E861305DE596EACFE;
+			remoteInfo = App_iOS;
+		};
+		9F4AAED22329F820EA5DB2F7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3FCF5A083151C7E22B24E807;
+			remoteInfo = StaticLibrary_ObjC_macOS;
+		};
+		BB3B4DE7EE8CEE505BBC6DF4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 63EAAEAE0535C975295781D4;
+			remoteInfo = TestFramework;
+		};
 		C0408FA85DFD7E9F59541D2E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
@@ -158,12 +321,47 @@
 			remoteGlobalIDString = 3FCF5A083151C7E22B24E807;
 			remoteInfo = StaticLibrary_ObjC_macOS;
 		};
+		C68FFE66E063CA163CE1D68B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DAF9935ECEC17AA561D28998;
+			remoteInfo = "App_watchOS Extension";
+		};
 		D51CBCA8454A129B3F1C0629 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 242476187403208F30D3219F;
 			remoteInfo = Framework_iOS;
+		};
+		D65DFD803579AB5662714F99 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 43EA7AFC9AC8E9116A228613 /* AnotherProject */;
+			proxyType = 2;
+			remoteGlobalIDString = D6340FC7DEBC81E0127BAFD6;
+			remoteInfo = ExternalTarget;
+		};
+		D7FD49F1E9A4B29D528D18A5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FF3DC3DF2AA3AE02377647C9;
+			remoteInfo = iMessageApp;
+		};
+		F2FCFF0F2338D8316F9D8D47 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = EDE7907E34D077B346FC4CF1;
+			remoteInfo = iMessageExtension;
+		};
+		F52878EB4A2F3E2E1F89036F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 559F6E334A370096461729A9;
+			remoteInfo = App_Clip;
 		};
 		F7BDEB5E84BA34C6E32E8C1F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -179,9 +377,27 @@
 			remoteGlobalIDString = 3DBB411AF8D365588E21D8CA;
 			remoteInfo = StaticLibrary_ObjC_iOS;
 		};
+		FF4780B89575C7C171A9B401 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7467FBF059DC784B5601CA7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 15A12B9A8B7A477CF2D4ABEF;
+			remoteInfo = App_watchOS;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		108FC2F1B37B100230F6C0C5 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				E347C6740A9E3D8C9BF87A26 /* Framework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1C41E253B853711670514ECC /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -191,6 +407,17 @@
 				29C5F4E429F4826AC299988F /* StaticLibrary_ObjC.h in CopyFiles */,
 				BDEE0F3F67B9EA52B04CC2C6 /* module.modulemap in CopyFiles */,
 			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		29EAAC76E47D07B8D8F50262 /* Embed App Clips */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/AppClips";
+			dstSubfolderSpec = 16;
+			files = (
+				068A307AAD3FDB71E245CF4B /* App_Clip.app in Embed App Clips */,
+			);
+			name = "Embed App Clips";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		39EF6E709D5336CB216DC2FB /* CopyFiles */ = {
@@ -204,6 +431,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3FE33BF71F952904B55B2C67 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				22E1EE394E24667C942CAFC4 /* Result.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		456284554D1A6C53EB39BA4B /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -211,6 +449,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				F6BD1D30F6F6E5809B4CF709 /* TestFramework.framework in Embed Frameworks */,
+				E013E10B776DC6DD0956F20E /* Result.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -221,7 +460,32 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				6236A088DDF97D457194A2FD /* ExternalTarget.framework in Embed Frameworks */,
+				D6F1CE68BD0D773AF8FB5166 /* Framework2.framework in Embed Frameworks */,
 				5F930EEC8C575CB59EC11435 /* Framework.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		779219E7849466ABE0506B3A /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F189C2A0350D2BF0DE9861E7 /* Result.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		807E1CB99AAD2470DC373BC0 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				2B74F88A338EE674477351B1 /* TestFramework.framework in Embed Frameworks */,
+				0DC0E4339EBAB04754837F50 /* Result.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -237,6 +501,72 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		89F3F9E096C5559317B37165 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				4A1F587B61D4D2EE6833C281 /* App_watchOS Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		93EF9E66AA5ED7DE1C6A6FAD /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				53AC4E3D64CC954A74A6BF51 /* iMessageExtension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9830A88A58F9591CFE7662C9 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+				0A14BD0F9B22C84677FD7D6F /* XPC Service.xpc in CopyFiles */,
+				C9EE684BC0637F26CCB5DB98 /* SomeXPCService.xpc in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9DEE5A10D294FF2BD9A5233C /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				8F64F92EA2ADCED7258DFB50 /* Result.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A603A9260F95BC8B6B945B34 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				84A839AF00AB269416E54CD4 /* Empty.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B4F76A1390264F5E325C3C1E /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				712E73B032F6905D77A9AF29 /* Framework.framework in Embed Frameworks */,
+				F0610A6808224739266D81D6 /* Result.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D1B97A1B112643A756935FA5 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -248,15 +578,25 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D76EC4273D7E9C453072365B /* Embed App Clips */ = {
+		E0B58B04AD09D3B4B1486315 /* Copy Bundle Resources */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = "$(CONTENTS_FOLDER_PATH)/AppClips";
+			dstSubfolderSpec = 7;
+			files = (
+				CD55F1F95D9B020253935924 /* BundleX.bundle in Copy Bundle Resources */,
+			);
+			name = "Copy Bundle Resources";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EC033AB632FAAA03F670D215 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
 			dstSubfolderSpec = 16;
 			files = (
-				8F4FEE199C8E1C4B89B927F4 /* App_Clip.app in Embed App Clips */,
+				448A2FB5230855C2A68C8960 /* App_watchOS.app in Embed Watch Content */,
 			);
-			name = "Embed App Clips";
+			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F0CE57DCC7A58AFEA0EB1EF5 /* CopyFiles */ = {
@@ -273,65 +613,149 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		021F11A2B76A01ED4113286B /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		026CED83F810BD91A053B98A /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
+		02C5C670B0624A007BCB341D /* App_watchOS Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "App_watchOS Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0751ACA46EF394AF3E358E48 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TestFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B2986C19C8498CDE44CFDAD /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		0C6EA871817E3A864FDE5DA1 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E9E5D8F0132EBAFE6703730 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = usr/lib/libz.dylib; sourceTree = SDKROOT; };
 		115047E35C1A4697DEC6D83F /* App_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		1342A225B1FB5CCDE2D8C511 /* StaticLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticLibrary.swift; sourceTree = "<group>"; };
+		13B7C799370862813D8FE163 /* TestProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectUITests.swift; sourceTree = "<group>"; };
+		149F3970E2BE9F35231FC34D /* example.mp4 */ = {isa = PBXFileReference; path = example.mp4; sourceTree = "<group>"; };
 		160628D3BF533455BA779575 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		18232E5A7F3528FA1193CC79 /* XPC_Service.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPC_Service.h; sourceTree = "<group>"; };
 		1B4D9FADD8956DC163813272 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		201AC416366CB5F5B305E883 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		20B4D4D4A77434FA5593E35D /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		239041E1C2665F9EB8AEB019 /* iMessageApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = iMessageApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		241982105A45A78DDE5AE195 /* Empty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Empty.h; sourceTree = "<group>"; };
 		24562B158AF232E893E63362 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = System/Library/Frameworks/Contacts.framework; sourceTree = SDKROOT; };
+		26A55238739205BF9ECD6A0B /* XPC_ServiceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XPC_ServiceProtocol.h; sourceTree = "<group>"; };
 		28B6600F3CDA6F15633D2134 /* config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = config.xcconfig; sourceTree = "<group>"; };
 		2D3BE7580CC3D623991914A4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		31BC9A6E8D133DF950755A82 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		329A12107D19B52E1F8554B4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		334F263B3704264D929F4414 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3469B706C364CC07AAEF298A /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		34E069C383E5121BD428C2D7 /* Clip.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Clip.entitlements; sourceTree = "<group>"; };
 		376BA5774B91C2D6DA8F6C39 /* libStaticLibrary_ObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		377DF5A1EB742CEF829A9A75 /* SomeFile */ = {isa = PBXFileReference; path = SomeFile; sourceTree = "<group>"; };
 		3B4590226C49347F4BC18782 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		3BAAEBEC8B795DCF1C9C5ADE /* Tool */ = {isa = PBXFileReference; includeInIndex = 0; path = Tool; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BE447BCB0528DE1776DE2F0 /* StaticLibrary_ObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StaticLibrary_ObjC.m; sourceTree = "<group>"; };
+		43EA7AFC9AC8E9116A228613 /* AnotherProject */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AnotherProject; path = AnotherProject/AnotherProject.xcodeproj; sourceTree = "<group>"; };
+		4402963B58134A6066B9E943 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4590EBD0480830F80EDC182E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		4711AC75927A510DEB4FCC31 /* MyFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MyFramework.h; sourceTree = "<group>"; };
+		4A8F914F7847A9FB2BDBA73C /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
 		4D770C47456D076025DD7A51 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		4EC670E53BFAA6F61C02BE82 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		4FFF3A7EBB86F6500589ABDD /* libStaticLibrary_ObjC.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libStaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		51E2D479CB960CB44EB545C6 /* XPC Service.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = "XPC Service.xpc"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5249EE07991C4370C3F2ED16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		5304167A195992C7D3D8F373 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		55DF3F01BB8698E8226D05A0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		574D072C770BAE53531249CF /* Headers */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Headers; sourceTree = SOURCE_ROOT; };
+		5C383DB670761F227610EDB0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		5DB17246AF97AF5311C1CB7B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		5FF83941D764AEB361249B72 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
+		6027424389D202122B079A42 /* MessagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
 		610AD86B5088E07993870579 /* Model 3.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 3.xcdatamodel"; sourceTree = "<group>"; };
 		6170A2CAD1ABE59888B1F95E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LocalizedStoryboard.strings; sourceTree = "<group>"; };
+		618546FAE1D216BFFA06DE35 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		63FC1CBFB0F9A0C43B5A58DE /* MyPlayground.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = MyPlayground.playground; sourceTree = "<group>"; };
+		68D8757F885CE1C02514845C /* StandaloneAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = StandaloneAssets.xcassets; sourceTree = "<group>"; };
+		68F16F683711ECD7CC9C43EC /* TestProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectTests.swift; sourceTree = "<group>"; };
 		6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libStaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		6C14AF20FB1E07BF9D32937E /* iMessageExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = iMessageExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C287801C7F7F97451C89F23 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
+		6F98C5891F0CE8C0DEF57B40 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		70AF281B672F71A33256F70E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		7601CC56C42BD6A1D4A75AEA /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
+		76A87BB63618846E0E0F363F /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 		775BF5CB0D9F73D43A7A617A /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		78B81AD14AB1A48CFA916FB2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		797FC015E4199F24EE43C159 /* base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = base.xcconfig; sourceTree = "<group>"; };
+		7ACB8439596DD7A77FD11AFD /* App_iOS_Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_iOS_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B274B43FDC5E8E1FEF7E9FA /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		7CBC1BDF40FEDAC0DB9ACFFD /* iMessageStickersExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = iMessageStickersExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E6075D44DFAA43C62CED79D /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		80490871D5D4676E77EA80E9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		80F3EA429799FBBE247A2D82 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		81EEE090725ECD1354287E74 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8905BD70AC0E549E6C5E267A /* swift-tagged.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = "swift-tagged.framework"; sourceTree = "<group>"; };
+		8D1E74E40BA947CAF2DA087F /* Mintfile */ = {isa = PBXFileReference; path = Mintfile; sourceTree = "<group>"; };
 		948E174040217FD36F14BCF6 /* outputList.xcfilelist */ = {isa = PBXFileReference; lastKnownFileType = text.xcfilelist; path = outputList.xcfilelist; sourceTree = "<group>"; };
 		9759A19BAD2C50FCECF7D3C1 /* App_Clip_UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_Clip_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		98B17D464B46DAC8911014D5 /* module.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
+		A2CBBF04CBB716C4BF958A99 /* SceneKitCatalog.scnassets */ = {isa = PBXFileReference; lastKnownFileType = wrapper.scnassets; path = SceneKitCatalog.scnassets; sourceTree = "<group>"; };
+		A2D7192D099F88F92AC33C9A /* XPC_Service.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = XPC_Service.m; sourceTree = "<group>"; };
+		A74AC60A5F465A6542431675 /* libStaticLibrary_Swift.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libStaticLibrary_Swift.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A89D9F16591C365D568A0BA4 /* Framework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9327B50C4B0BDF4A252CB2A /* SwiftFileInDotPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftFileInDotPath.swift; sourceTree = "<group>"; };
+		AB002AF7692C5A6F71304272 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
 		AE98EBB8C701BCA1BF478547 /* inputList.xcfilelist */ = {isa = PBXFileReference; lastKnownFileType = text.xcfilelist; path = inputList.xcfilelist; sourceTree = "<group>"; };
+		B787DC6505E0F15C5C4975E3 /* ResourceFolder */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ResourceFolder; path = Resources/ResourceFolder; sourceTree = SOURCE_ROOT; };
 		B945C628ACCF26FC51594160 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		BB1FE6F7B1E431337B051320 /* SomeXPCService.xpc */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.xpc-service"; path = SomeXPCService.xpc; sourceTree = "<group>"; };
+		BB4C1F0CB031F894B46533E0 /* App_watchOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_watchOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		BE9FDD096DC947BCB58D7B08 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		C0ACDDAF456079BA0099BFCE /* App_macOS_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = App_macOS_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C0B18235C78A3D3E84F2508B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		C0F698427B31A67B1541925E /* FrameworkFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkFile.swift; sourceTree = "<group>"; };
 		C16F953828BFF71DEB579075 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		C22BEDE0B2217312642FADA2 /* App_Clip.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_Clip.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C2669AB60DB45D52E58D5A6D /* BundleX.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = BundleX.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		C4AF74FB9AB607DFA9E07A4E /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		C552EC308B5274F2B6AC53B5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		C68273268C686B59A290EEF3 /* Model.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = Model.xcmappingmodel; sourceTree = "<group>"; };
+		C782AA5939417FFD3CF8EB52 /* App_iOS_UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_iOS_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CFC3D1BD85132F4625B4B231 /* File1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = File1.swift; path = Group/File1.swift; sourceTree = "<group>"; };
+		D358C9F4D4F2D97C148913CF /* File2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = File2.swift; path = Group2/File2.swift; sourceTree = "<group>"; };
+		D7FDE08353EF6730CA4E6F32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D80E621293876A18B051299F /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		D88BF5054CA820ED443AC1F9 /* EntitledApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = EntitledApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D998E6204320A2092F9327FA /* Model 2.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 2.xcdatamodel"; sourceTree = "<group>"; };
+		DAC130416836C31B7A63DD0C /* Folder */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Folder; sourceTree = SOURCE_ROOT; };
+		DB9233C31FD59CF515FC7414 /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftyJSON.framework; sourceTree = "<group>"; };
+		DEC53DADDC767F9AE310B83E /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
+		DF3C1E903F8399E193F3B4BA /* App_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DF5EEB3171D1A7722CD9413A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		E2A15F2C8142988473574022 /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E4FBD31453FD26F4C7ABD5F9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E7A79640DB3BA2B340CCEAF0 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
+		E7EC60A15CCEC05897CEFC34 /* MoreUnder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreUnder.swift; sourceTree = "<group>"; };
+		E835E43770D77649C766CD28 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E83A520CAE8A4BCF6578C2A9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		E889D8B5524C64ED5CF252D0 /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
+		E94FA789791614CFD0F98C26 /* App_iOS_With_Clip.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_iOS_With_Clip.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		EADBB714A4B3D4F89D79419E /* Framework2.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Framework2.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC10D740EAC35BF970A7327A /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
 		ED4A6FE2AF37CDDD3A0D1D6B /* TestProjectUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectUITests.swift; sourceTree = "<group>"; };
 		EE31326E32ED51CB02C58E9D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F1188E378718785171F293B6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LocalizedStoryboard.storyboard; sourceTree = "<group>"; };
 		F18408A818972A0675B115E4 /* App_Clip_Tests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = App_Clip_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F1DB5DD67A1E835227FE0397 /* TestProjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProjectTests.swift; sourceTree = "<group>"; };
+		F24135F7E2026D8D80F8B919 /* MyBundle.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = MyBundle.bundle; sourceTree = "<group>"; };
 		F55FFC5DC497CF889F859496 /* libStaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libStaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		F6813B4F70D433054D0C8FB8 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		F7692A9E8CAA5A4B12FE633B /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		F853E823D826B2DCA407AEA1 /* StaticLibrary_ObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StaticLibrary_ObjC.h; sourceTree = "<group>"; };
 		FFA405DFE01301A4B8BA9027 /* Standalone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Standalone.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		286A764EB49712A6BE938CD9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C6F8661462BC2CADFBF59851 /* Result.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		43C5260C6E5332D5E733D85E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -341,13 +765,66 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57AAA51FE44B9280D0F3C9F6 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6B0FF0DA562C828135741257 /* Contacts.framework in Frameworks */,
+				3EC2758239D6659E4D35DFD9 /* Framework.framework in Frameworks */,
+				9ABB0EF3A6513E47AF06FA56 /* Result.framework in Frameworks */,
+				1081606EF3D131248CC46BD6 /* libStaticLibrary_ObjC.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5A2BDC62A00DF008470998CA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C8A63AB7A95D10D5430D3AD2 /* Contacts.framework in Frameworks */,
+				E0976466478FACCA962CD09F /* Framework.framework in Frameworks */,
+				618C6FCD590D09819BF3CA2B /* Result.framework in Frameworks */,
+				B04F45480A1578BF58E692C6 /* libStaticLibrary_ObjC.a in Frameworks */,
+				F01287B5AA79506789A98FBF /* libc++.tbd in Frameworks */,
+				6A779DFBEA9BC9A301F7B410 /* libz.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		6DE5ACEB01740726A5F7FE20 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				76EFFFE1C3073348E70FAD17 /* Result.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		817E815A267F7A93B27C28C1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1B953AB2F713D5D6AAF5A72 /* ExternalTarget.framework in Frameworks */,
 				F415FFDA9CCF0237B5C0D7A5 /* Contacts.framework in Frameworks */,
+				2FB0D86C27098550FAFB4164 /* Framework2.framework in Frameworks */,
 				BFD9082EF681F00F1EB86044 /* Framework.framework in Frameworks */,
+				866974B9FCB26B1FEB2B66AF /* Result.framework in Frameworks */,
 				26170D4BBCBE25B7ADB6C3C9 /* libStaticLibrary_ObjC.a in Frameworks */,
+				981AB81EA8094B072BAE125F /* SwiftyJSON.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8425BF17AF010D7E10061AB3 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FA39577CB6231B24C47E828D /* Result.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		93C6B66FB2295D9FE2D068F0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5986EF99D2CDEE9EBC4B2AF1 /* TestFramework.framework in Frameworks */,
+				A4F2F9AC7C204B67DFDE0991 /* swift-tagged.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -356,7 +833,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				1F0ED24C994FE9945337388B /* Framework.framework in Frameworks */,
+				35AA463863F88CB6290C264D /* Result.framework in Frameworks */,
 				BE8E9F3E79C62F56F889E7A6 /* libStaticLibrary_ObjC.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F3D411695D4C043FEF3265B7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9E605FE85BFDA54EDB3AC0F0 /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -374,18 +860,90 @@
 		032B95A6C88F143883A20612 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				EC10D740EAC35BF970A7327A /* Result.framework */,
 				8905BD70AC0E549E6C5E267A /* swift-tagged.framework */,
+				DB9233C31FD59CF515FC7414 /* SwiftyJSON.framework */,
 			);
 			path = iOS;
+			sourceTree = "<group>";
+		};
+		06D66F6012249ADB6930674D /* StaticLibrary_Swift */ = {
+			isa = PBXGroup;
+			children = (
+				1342A225B1FB5CCDE2D8C511 /* StaticLibrary.swift */,
+			);
+			path = StaticLibrary_Swift;
+			sourceTree = "<group>";
+		};
+		0B61C4DD7507DBE79AB464C1 /* App_watchOS Extension */ = {
+			isa = PBXGroup;
+			children = (
+				E835E43770D77649C766CD28 /* Assets.xcassets */,
+				026CED83F810BD91A053B98A /* ExtensionDelegate.swift */,
+				70AF281B672F71A33256F70E /* Info.plist */,
+				E889D8B5524C64ED5CF252D0 /* InterfaceController.swift */,
+				4A8F914F7847A9FB2BDBA73C /* NotificationController.swift */,
+				76A87BB63618846E0E0F363F /* PushNotificationPayload.apns */,
+			);
+			path = "App_watchOS Extension";
+			sourceTree = "<group>";
+		};
+		3A1FEE49143420BD1A65448C /* iMessageApp */ = {
+			isa = PBXGroup;
+			children = (
+				C552EC308B5274F2B6AC53B5 /* Assets.xcassets */,
+				BE9FDD096DC947BCB58D7B08 /* Info.plist */,
+			);
+			path = iMessageApp;
+			sourceTree = "<group>";
+		};
+		3E1C0D21208BF097D3194956 /* CustomGroup */ = {
+			isa = PBXGroup;
+			children = (
+				CFC3D1BD85132F4625B4B231 /* File1.swift */,
+				D358C9F4D4F2D97C148913CF /* File2.swift */,
+				DAC130416836C31B7A63DD0C /* Folder */,
+				8D1E74E40BA947CAF2DA087F /* Mintfile */,
+			);
+			name = CustomGroup;
 			sourceTree = "<group>";
 		};
 		43472DDB7FC544B77A4B9308 /* Carthage */ = {
 			isa = PBXGroup;
 			children = (
 				032B95A6C88F143883A20612 /* iOS */,
+				D42109390CD998BAF417FEF7 /* Mac */,
+				C134B9E65FCA5003ADEE5928 /* tvOS */,
+				460758AB62AF78ABF609D4BE /* watchOS */,
 			);
 			name = Carthage;
 			path = Carthage/Build;
+			sourceTree = "<group>";
+		};
+		460758AB62AF78ABF609D4BE /* watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				E7A79640DB3BA2B340CCEAF0 /* Result.framework */,
+			);
+			path = watchOS;
+			sourceTree = "<group>";
+		};
+		4692C54657FAA38490642A5A /* CopyFiles */ = {
+			isa = PBXGroup;
+			children = (
+				241982105A45A78DDE5AE195 /* Empty.h */,
+			);
+			path = CopyFiles;
+			sourceTree = "<group>";
+		};
+		4E9E62860C6D8F33A5D1A476 /* App_watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				55DF3F01BB8698E8226D05A0 /* Assets.xcassets */,
+				4590EBD0480830F80EDC182E /* Info.plist */,
+				7E1427FBA94B073C3FD2830A /* Interface.storyboard */,
+			);
+			path = App_watchOS;
 			sourceTree = "<group>";
 		};
 		5017C17F6AC357F6128D719C /* App_Clip_UITests */ = {
@@ -402,6 +960,8 @@
 			children = (
 				43472DDB7FC544B77A4B9308 /* Carthage */,
 				24562B158AF232E893E63362 /* Contacts.framework */,
+				F7692A9E8CAA5A4B12FE633B /* libc++.tbd */,
+				0E9E5D8F0132EBAFE6703730 /* libz.dylib */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -421,13 +981,35 @@
 				57879A6554A581D1AB431C97 /* App_Clip */,
 				5017C17F6AC357F6128D719C /* App_Clip_UITests */,
 				89D980E845C2940109EB1A0E /* App_iOS_Tests */,
+				6690EF741BA765F2C6812BA8 /* App_iOS_UITests */,
+				B95B6603AA3915022CEA4E81 /* App_macOS */,
+				E983D6835D9460CCFC7E53C2 /* App_macOS_Tests */,
+				4E9E62860C6D8F33A5D1A476 /* App_watchOS */,
+				0B61C4DD7507DBE79AB464C1 /* App_watchOS Extension */,
 				D5532FE12C5B6CC1A7F3E3D1 /* Configs */,
+				4692C54657FAA38490642A5A /* CopyFiles */,
+				3E1C0D21208BF097D3194956 /* CustomGroup */,
+				8851333DB3B77DCB07BEBA8A /* FileGroup */,
 				77F94B3D3772A24BC26FCE1A /* Framework */,
+				3A1FEE49143420BD1A65448C /* iMessageApp */,
+				8D3D464FADE45CD5CFD0CD2D /* iMessageExtension */,
+				EFF9DC82C1B9EA1B47804816 /* iMessageStickers */,
+				D297C054132559DEEE78A28D /* Resources */,
 				C6B85E6F88CE3EE3727FF514 /* StandaloneFiles */,
 				D313CB5937567576F546F007 /* StaticLibrary_ObjC */,
+				06D66F6012249ADB6930674D /* StaticLibrary_Swift */,
+				5BE9DC0E1ACDDD73F7409C8B /* Tool */,
+				9E4CAECCD14E742E6E6F8700 /* Utilities */,
+				83B6B878B045BA77C258A0A2 /* Vendor */,
+				7A40E7C16A3AB0A95669A2A8 /* XPC Service */,
+				DAC130416836C31B7A63DD0C /* Folder */,
 				574D072C770BAE53531249CF /* Headers */,
+				B787DC6505E0F15C5C4975E3 /* ResourceFolder */,
+				377DF5A1EB742CEF829A9A75 /* SomeFile */,
+				C4DD1C7F5C7097CA81DB3FE8 /* Bundles */,
 				504A23A54D051DF5E8D1C9D5 /* Frameworks */,
 				E8A7C596497AB5EFE54C4C67 /* Products */,
+				C0F6DA034785945B03CC8273 /* Projects */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -448,6 +1030,31 @@
 			path = App_Clip;
 			sourceTree = "<group>";
 		};
+		5BE9DC0E1ACDDD73F7409C8B /* Tool */ = {
+			isa = PBXGroup;
+			children = (
+				4EC670E53BFAA6F61C02BE82 /* main.swift */,
+			);
+			path = Tool;
+			sourceTree = "<group>";
+		};
+		63CA1B81E0D9E4D5F1683D64 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FF10A8919F65E6609784780A /* ExternalTarget.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6690EF741BA765F2C6812BA8 /* App_iOS_UITests */ = {
+			isa = PBXGroup;
+			children = (
+				31BC9A6E8D133DF950755A82 /* Info.plist */,
+				13B7C799370862813D8FE163 /* TestProjectUITests.swift */,
+			);
+			path = App_iOS_UITests;
+			sourceTree = "<group>";
+		};
 		77F94B3D3772A24BC26FCE1A /* Framework */ = {
 			isa = PBXGroup;
 			children = (
@@ -458,6 +1065,34 @@
 			path = Framework;
 			sourceTree = "<group>";
 		};
+		7A40E7C16A3AB0A95669A2A8 /* XPC Service */ = {
+			isa = PBXGroup;
+			children = (
+				5C383DB670761F227610EDB0 /* Info.plist */,
+				5304167A195992C7D3D8F373 /* main.m */,
+				18232E5A7F3528FA1193CC79 /* XPC_Service.h */,
+				A2D7192D099F88F92AC33C9A /* XPC_Service.m */,
+				26A55238739205BF9ECD6A0B /* XPC_ServiceProtocol.h */,
+			);
+			path = "XPC Service";
+			sourceTree = "<group>";
+		};
+		83B6B878B045BA77C258A0A2 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				BB1FE6F7B1E431337B051320 /* SomeXPCService.xpc */,
+			);
+			path = Vendor;
+			sourceTree = "<group>";
+		};
+		8851333DB3B77DCB07BEBA8A /* FileGroup */ = {
+			isa = PBXGroup;
+			children = (
+				AE521ABD892103D1D989D151 /* UnderFileGroup */,
+			);
+			path = FileGroup;
+			sourceTree = "<group>";
+		};
 		89D980E845C2940109EB1A0E /* App_iOS_Tests */ = {
 			isa = PBXGroup;
 			children = (
@@ -465,6 +1100,25 @@
 				F1DB5DD67A1E835227FE0397 /* TestProjectTests.swift */,
 			);
 			path = App_iOS_Tests;
+			sourceTree = "<group>";
+		};
+		8D3D464FADE45CD5CFD0CD2D /* iMessageExtension */ = {
+			isa = PBXGroup;
+			children = (
+				78B81AD14AB1A48CFA916FB2 /* Assets.xcassets */,
+				D7FDE08353EF6730CA4E6F32 /* Info.plist */,
+				95933688FAC17B9E7752CB4F /* MainInterface.storyboard */,
+				6027424389D202122B079A42 /* MessagesViewController.swift */,
+			);
+			path = iMessageExtension;
+			sourceTree = "<group>";
+		};
+		9E4CAECCD14E742E6E6F8700 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				63FC1CBFB0F9A0C43B5A58DE /* MyPlayground.playground */,
+			);
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 		A62B59FAE6F412F87AA9802C /* App */ = {
@@ -482,6 +1136,7 @@
 				EE817D9DBEBA01EC4FFCED25 /* LocalizedStoryboard.storyboard */,
 				917AA3E4306C1A12FCC17994 /* Main.storyboard */,
 				431156B967A9DF0995682D7C /* Model.xcdatamodeld */,
+				C68273268C686B59A290EEF3 /* Model.xcmappingmodel */,
 				7E6075D44DFAA43C62CED79D /* module.modulemap */,
 				948E174040217FD36F14BCF6 /* outputList.xcfilelist */,
 				6C287801C7F7F97451C89F23 /* Settings.bundle */,
@@ -491,12 +1146,67 @@
 			path = App_iOS;
 			sourceTree = "<group>";
 		};
+		AE521ABD892103D1D989D151 /* UnderFileGroup */ = {
+			isa = PBXGroup;
+			children = (
+				E7EC60A15CCEC05897CEFC34 /* MoreUnder.swift */,
+			);
+			path = UnderFileGroup;
+			sourceTree = "<group>";
+		};
+		B95B6603AA3915022CEA4E81 /* App_macOS */ = {
+			isa = PBXGroup;
+			children = (
+				80F3EA429799FBBE247A2D82 /* AppDelegate.swift */,
+				201AC416366CB5F5B305E883 /* Assets.xcassets */,
+				5249EE07991C4370C3F2ED16 /* Info.plist */,
+				214F642E7193A3E608845F4B /* Main.storyboard */,
+				021F11A2B76A01ED4113286B /* ViewController.swift */,
+			);
+			path = App_macOS;
+			sourceTree = "<group>";
+		};
+		C0F6DA034785945B03CC8273 /* Projects */ = {
+			isa = PBXGroup;
+			children = (
+				43EA7AFC9AC8E9116A228613 /* AnotherProject */,
+			);
+			name = Projects;
+			sourceTree = "<group>";
+		};
+		C134B9E65FCA5003ADEE5928 /* tvOS */ = {
+			isa = PBXGroup;
+			children = (
+				AB002AF7692C5A6F71304272 /* Result.framework */,
+			);
+			path = tvOS;
+			sourceTree = "<group>";
+		};
+		C4DD1C7F5C7097CA81DB3FE8 /* Bundles */ = {
+			isa = PBXGroup;
+			children = (
+				C2669AB60DB45D52E58D5A6D /* BundleX.bundle */,
+			);
+			name = Bundles;
+			sourceTree = "<group>";
+		};
 		C6B85E6F88CE3EE3727FF514 /* StandaloneFiles */ = {
 			isa = PBXGroup;
 			children = (
 				FFA405DFE01301A4B8BA9027 /* Standalone.swift */,
+				68D8757F885CE1C02514845C /* StandaloneAssets.xcassets */,
 			);
 			path = StandaloneFiles;
+			sourceTree = "<group>";
+		};
+		D297C054132559DEEE78A28D /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				149F3970E2BE9F35231FC34D /* example.mp4 */,
+				F24135F7E2026D8D80F8B919 /* MyBundle.bundle */,
+				A2CBBF04CBB716C4BF958A99 /* SceneKitCatalog.scnassets */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 		D313CB5937567576F546F007 /* StaticLibrary_ObjC */ = {
@@ -509,9 +1219,18 @@
 			path = StaticLibrary_ObjC;
 			sourceTree = "<group>";
 		};
+		D42109390CD998BAF417FEF7 /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				7601CC56C42BD6A1D4A75AEA /* Result.framework */,
+			);
+			path = Mac;
+			sourceTree = "<group>";
+		};
 		D5532FE12C5B6CC1A7F3E3D1 /* Configs */ = {
 			isa = PBXGroup;
 			children = (
+				797FC015E4199F24EE43C159 /* base.xcconfig */,
 				28B6600F3CDA6F15633D2134 /* config.xcconfig */,
 			);
 			path = Configs;
@@ -523,23 +1242,75 @@
 				F18408A818972A0675B115E4 /* App_Clip_Tests.xctest */,
 				9759A19BAD2C50FCECF7D3C1 /* App_Clip_UITests.xctest */,
 				C22BEDE0B2217312642FADA2 /* App_Clip.app */,
+				7ACB8439596DD7A77FD11AFD /* App_iOS_Tests.xctest */,
+				C782AA5939417FFD3CF8EB52 /* App_iOS_UITests.xctest */,
+				E94FA789791614CFD0F98C26 /* App_iOS_With_Clip.app */,
 				115047E35C1A4697DEC6D83F /* App_iOS.app */,
+				C0ACDDAF456079BA0099BFCE /* App_macOS_Tests.xctest */,
+				DF3C1E903F8399E193F3B4BA /* App_macOS.app */,
+				02C5C670B0624A007BCB341D /* App_watchOS Extension.appex */,
+				BB4C1F0CB031F894B46533E0 /* App_watchOS.app */,
+				D88BF5054CA820ED443AC1F9 /* EntitledApp.app */,
 				1B4D9FADD8956DC163813272 /* Framework.framework */,
 				775BF5CB0D9F73D43A7A617A /* Framework.framework */,
 				20B4D4D4A77434FA5593E35D /* Framework.framework */,
 				A89D9F16591C365D568A0BA4 /* Framework.framework */,
+				0C6EA871817E3A864FDE5DA1 /* Framework2.framework */,
+				81EEE090725ECD1354287E74 /* Framework2.framework */,
+				E2A15F2C8142988473574022 /* Framework2.framework */,
+				EADBB714A4B3D4F89D79419E /* Framework2.framework */,
+				239041E1C2665F9EB8AEB019 /* iMessageApp.app */,
+				6C14AF20FB1E07BF9D32937E /* iMessageExtension.appex */,
+				7CBC1BDF40FEDAC0DB9ACFFD /* iMessageStickersExtension.appex */,
 				6BAFC2D775612C35F4F1897F /* libStaticLibrary_ObjC.a */,
 				376BA5774B91C2D6DA8F6C39 /* libStaticLibrary_ObjC.a */,
 				F55FFC5DC497CF889F859496 /* libStaticLibrary_ObjC.a */,
 				4FFF3A7EBB86F6500589ABDD /* libStaticLibrary_ObjC.a */,
+				A74AC60A5F465A6542431675 /* libStaticLibrary_Swift.a */,
 				0838859105FF7ECEE5F2B6E5 /* TestFramework.framework */,
+				3BAAEBEC8B795DCF1C9C5ADE /* Tool */,
+				51E2D479CB960CB44EB545C6 /* XPC Service.xpc */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		E983D6835D9460CCFC7E53C2 /* App_macOS_Tests */ = {
+			isa = PBXGroup;
+			children = (
+				618546FAE1D216BFFA06DE35 /* Info.plist */,
+				68F16F683711ECD7CC9C43EC /* TestProjectTests.swift */,
+			);
+			path = App_macOS_Tests;
+			sourceTree = "<group>";
+		};
+		EFF9DC82C1B9EA1B47804816 /* iMessageStickers */ = {
+			isa = PBXGroup;
+			children = (
+				4402963B58134A6066B9E943 /* Assets.xcassets */,
+				334F263B3704264D929F4414 /* Info.plist */,
+			);
+			path = iMessageStickers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		2F621E72C41C6F0E359F1CA5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7AD5DA085B8A8182D006BF97 /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		35F48F6942C6603620B5272D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D584474E14DF674265501DA7 /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		42B63956FC51459D9C131348 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -549,12 +1320,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		55057164007640AC701A07CE /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2F0E1973A958FCDE8CE09F5E /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5A1839273A285D74BB199B27 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				2CBE0DC8AC249AD1E42DC593 /* Headers in Headers */,
 				18666A1E5DE5F5B2D48ED872 /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5E8065203C5738ACE91D4D4C /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				557415FFAD88A691DF87B917 /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -586,13 +1373,88 @@
 		};
 /* End PBXHeadersBuildPhase section */
 
+/* Begin PBXLegacyTarget section */
+		1765579FCB7609C001BB1488 /* Legacy */ = {
+			isa = PBXLegacyTarget;
+			buildConfigurationList = 12219412F67F790403913F07 /* Build configuration list for PBXLegacyTarget "Legacy" */;
+			buildPhases = (
+				CDD0499E6DAD48E8BC32C503 /* Sources */,
+			);
+			buildToolPath = /usr/bin/true;
+			dependencies = (
+			);
+			name = Legacy;
+			passBuildSettingsInEnvironment = 1;
+			productName = Legacy;
+		};
+/* End PBXLegacyTarget section */
+
 /* Begin PBXNativeTarget section */
+		15A12B9A8B7A477CF2D4ABEF /* App_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D8F179BDF8E4EF8A9DF9D8B7 /* Build configuration list for PBXNativeTarget "App_watchOS" */;
+			buildPhases = (
+				B771A52C53992E86CC375F81 /* Sources */,
+				541E93B3FAC6738328D848A9 /* Resources */,
+				89F3F9E096C5559317B37165 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				6F2B0CFA463F069B3F4857EF /* PBXTargetDependency */,
+			);
+			name = App_watchOS;
+			productName = App_watchOS;
+			productReference = BB4C1F0CB031F894B46533E0 /* App_watchOS.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		1DD1EB52ED39F468AF836C80 /* Framework2_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6BB95AFCC887A7C884112DCD /* Build configuration list for PBXNativeTarget "Framework2_tvOS" */;
+			buildPhases = (
+				2F621E72C41C6F0E359F1CA5 /* Headers */,
+				F35CD0E35C79019C8412A011 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Framework2_tvOS;
+			productName = Framework2_tvOS;
+			productReference = E2A15F2C8142988473574022 /* Framework2.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		21D7F6A04EF6BA1329685C17 /* App_iOS_With_Clip */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1245739E28D036CED2FF55C1 /* Build configuration list for PBXNativeTarget "App_iOS_With_Clip" */;
+			buildPhases = (
+				3153BE680CE6A42770AA895C /* Sources */,
+				BBAF3F5A94735C7DE2A6A827 /* Resources */,
+				1C42D5F7BAE0F2979CC08ED8 /* Carthage */,
+				57AAA51FE44B9280D0F3C9F6 /* Frameworks */,
+				29EAAC76E47D07B8D8F50262 /* Embed App Clips */,
+				108FC2F1B37B100230F6C0C5 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D8B398F93CADCBB7ACF6CD9B /* PBXTargetDependency */,
+				A9BCB911887308296B1CA4F7 /* PBXTargetDependency */,
+				63AA55FB95FBE6655AF2BC44 /* PBXTargetDependency */,
+			);
+			name = App_iOS_With_Clip;
+			productName = App_iOS_With_Clip;
+			productReference = E94FA789791614CFD0F98C26 /* App_iOS_With_Clip.app */;
+			productType = "com.apple.product-type.application";
+		};
 		242476187403208F30D3219F /* Framework_iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6107B10D2E2D953A15120917 /* Build configuration list for PBXNativeTarget "Framework_iOS" */;
 			buildPhases = (
 				DA5B84262385E32108A96880 /* Headers */,
 				F26C0DA46E6368299CB30667 /* Sources */,
+				8425BF17AF010D7E10061AB3 /* Frameworks */,
+				5EC541AC97EEFAF38B3C1C17 /* MyScript */,
 			);
 			buildRules = (
 			);
@@ -603,6 +1465,23 @@
 			productName = Framework_iOS;
 			productReference = 1B4D9FADD8956DC163813272 /* Framework.framework */;
 			productType = "com.apple.product-type.framework";
+		};
+		34EF687C75C46BA8E8701BAB /* App_macOS_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C7E8A05AB55B088CE727B579 /* Build configuration list for PBXNativeTarget "App_macOS_Tests" */;
+			buildPhases = (
+				65BD1A9FF4490B11C263E501 /* Sources */,
+				9DEE5A10D294FF2BD9A5233C /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CFA15A6B9BBC6ABEA148E61B /* PBXTargetDependency */,
+			);
+			name = App_macOS_Tests;
+			productName = App_macOS_Tests;
+			productReference = C0ACDDAF456079BA0099BFCE /* App_macOS_Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */ = {
 			isa = PBXNativeTarget;
@@ -636,6 +1515,21 @@
 			productReference = 376BA5774B91C2D6DA8F6C39 /* libStaticLibrary_ObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		4D1BB58561A59EB6850A2D6D /* EntitledApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FBA5F15A7524F82764D43342 /* Build configuration list for PBXNativeTarget "EntitledApp" */;
+			buildPhases = (
+				50E46638726052318507CD67 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = EntitledApp;
+			productName = EntitledApp;
+			productReference = D88BF5054CA820ED443AC1F9 /* EntitledApp.app */;
+			productType = "com.apple.product-type.application";
+		};
 		5239298BB84B4FDDFD84469E /* StaticLibrary_ObjC_watchOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = BDE5A3172EAD9560272E40D5 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_watchOS" */;
@@ -658,6 +1552,7 @@
 			buildPhases = (
 				B6030D15F063E956298EFD4C /* Sources */,
 				56A55A3C072A3ABD19F022C6 /* Resources */,
+				AC27EC6D44E51A1CB441A72E /* Carthage */,
 				941526D5A3C922259CA39CB6 /* Frameworks */,
 				D1B97A1B112643A756935FA5 /* Embed Frameworks */,
 			);
@@ -671,6 +1566,55 @@
 			productName = App_Clip;
 			productReference = C22BEDE0B2217312642FADA2 /* App_Clip.app */;
 			productType = "com.apple.product-type.application.on-demand-install-capable";
+		};
+		5BE879342590E136B31C840B /* Framework2_watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B19E185DEA8C29F4234D14B9 /* Build configuration list for PBXNativeTarget "Framework2_watchOS" */;
+			buildPhases = (
+				55057164007640AC701A07CE /* Headers */,
+				C0EBE6EF18E598977615610E /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Framework2_watchOS;
+			productName = Framework2_watchOS;
+			productReference = EADBB714A4B3D4F89D79419E /* Framework2.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		5C6E1548456BE821C90E23F0 /* Framework2_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C7C54B832F1638EA1C8C506D /* Build configuration list for PBXNativeTarget "Framework2_iOS" */;
+			buildPhases = (
+				35F48F6942C6603620B5272D /* Headers */,
+				8F62F8852A468CE268D0D9F7 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Framework2_iOS;
+			productName = Framework2_iOS;
+			productReference = 0C6EA871817E3A864FDE5DA1 /* Framework2.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		6122E4E48939B4937E588B23 /* App_iOS_UITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA0D28F9C2ACF4146025F574 /* Build configuration list for PBXNativeTarget "App_iOS_UITests" */;
+			buildPhases = (
+				9D3F0641DC33C8222ACC3D00 /* Sources */,
+				779219E7849466ABE0506B3A /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				118733A7DC1EE1870914EA4D /* PBXTargetDependency */,
+			);
+			name = App_iOS_UITests;
+			productName = App_iOS_UITests;
+			productReference = C782AA5939417FFD3CF8EB52 /* App_iOS_UITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		63EAAEAE0535C975295781D4 /* TestFramework */ = {
 			isa = PBXNativeTarget;
@@ -712,6 +1656,7 @@
 			buildConfigurationList = 154811E763287E0982E4010C /* Build configuration list for PBXNativeTarget "App_Clip_UITests" */;
 			buildPhases = (
 				C7C8DBC92C9E0658B7D9EE40 /* Sources */,
+				3FE33BF71F952904B55B2C67 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -729,6 +1674,8 @@
 			buildPhases = (
 				42B63956FC51459D9C131348 /* Headers */,
 				2C73503B473B56249F74023D /* Sources */,
+				F3D411695D4C043FEF3265B7 /* Frameworks */,
+				3C88C9760FFCFF5C729DD22C /* MyScript */,
 			);
 			buildRules = (
 			);
@@ -756,12 +1703,29 @@
 			productReference = F55FFC5DC497CF889F859496 /* libStaticLibrary_ObjC.a */;
 			productType = "com.apple.product-type.library.static";
 		};
+		87194DCB93BF1A83EE181FBF /* iMessageStickersExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD8DBB7F2CADB523598B1D3A /* Build configuration list for PBXNativeTarget "iMessageStickersExtension" */;
+			buildPhases = (
+				44D2699A7F63415B1C76D682 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iMessageStickersExtension;
+			productName = iMessageStickersExtension;
+			productReference = 7CBC1BDF40FEDAC0DB9ACFFD /* iMessageStickersExtension.appex */;
+			productType = "com.apple.product-type.app-extension.messages-sticker-pack";
+		};
 		974B3EC2FF4FBAA1513A2950 /* Framework_macOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FECC727EC6A1CBB859258849 /* Build configuration list for PBXNativeTarget "Framework_macOS" */;
 			buildPhases = (
 				5A1839273A285D74BB199B27 /* Headers */,
 				220AD6BBDDF25CEF7C6FB356 /* Sources */,
+				286A764EB49712A6BE938CD9 /* Frameworks */,
+				A2C7EEAF062CD944C219DD8F /* MyScript */,
 			);
 			buildRules = (
 			);
@@ -779,21 +1743,64 @@
 			buildPhases = (
 				F6445A97D8E8467AFCE9F0B6 /* Sources */,
 				21BCDA8027E0DED5FD1F46B2 /* Resources */,
+				A603A9260F95BC8B6B945B34 /* CopyFiles */,
+				4620AC2C57607DEDA627907C /* Carthage */,
 				817E815A267F7A93B27C28C1 /* Frameworks */,
-				D76EC4273D7E9C453072365B /* Embed App Clips */,
+				E0B58B04AD09D3B4B1486315 /* Copy Bundle Resources */,
 				5FF5F332311FF39E3B020BD9 /* Embed Frameworks */,
+				EC033AB632FAAA03F670D215 /* Embed Watch Content */,
+				70145FE98044319FDDC0BB29 /* Strip Unused Architectures from Frameworks */,
+				6300B083DBBB177437172F25 /* MyScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				1BB7E24BD9F5BA34E14CC594 /* PBXTargetDependency */,
+				B17852290DB066C640ABDC2F /* PBXTargetDependency */,
+				BE366BE8CC8B292A296FDAAD /* PBXTargetDependency */,
+				578F376EB1922ADCB9482DE3 /* PBXTargetDependency */,
 				F637B36CED5B903A9B1EEAE4 /* PBXTargetDependency */,
 				C1F2B62314C8601132D452FE /* PBXTargetDependency */,
+				E14514F1BEE89DF60E569CC5 /* PBXTargetDependency */,
 			);
 			name = App_iOS;
 			productName = App_iOS;
 			productReference = 115047E35C1A4697DEC6D83F /* App_iOS.app */;
 			productType = "com.apple.product-type.application";
+		};
+		9E7BCAAA9E855251D33C5730 /* App_iOS_Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8B6F763B758ED180046D3908 /* Build configuration list for PBXNativeTarget "App_iOS_Tests" */;
+			buildPhases = (
+				A4664FD3828FBEF2CD8380C4 /* Sources */,
+				93C6B66FB2295D9FE2D068F0 /* Frameworks */,
+				807E1CB99AAD2470DC373BC0 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				222B62D87784D9E40353D4F9 /* PBXTargetDependency */,
+				DBBCD483619808FD913E8199 /* PBXTargetDependency */,
+			);
+			name = App_iOS_Tests;
+			productName = App_iOS_Tests;
+			productReference = 7ACB8439596DD7A77FD11AFD /* App_iOS_Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		C0A9408F6C298624A7E2A024 /* Framework2_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD2C419331E24B123E0CBC9E /* Build configuration list for PBXNativeTarget "Framework2_macOS" */;
+			buildPhases = (
+				5E8065203C5738ACE91D4D4C /* Headers */,
+				308A0B0D609D0E21A320A468 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Framework2_macOS;
+			productName = Framework2_macOS;
+			productReference = 81EEE090725ECD1354287E74 /* Framework2.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 		D691B96B3888D27A6050EF10 /* Framework_tvOS */ = {
 			isa = PBXNativeTarget;
@@ -801,6 +1808,8 @@
 			buildPhases = (
 				D8324BF10D443128242BFBF1 /* Headers */,
 				BEE11A37E1AD9A0DFE7376FA /* Sources */,
+				6DE5ACEB01740726A5F7FE20 /* Frameworks */,
+				1B8F5C5B489BAFF4289F6CE5 /* MyScript */,
 			);
 			buildRules = (
 			);
@@ -812,6 +1821,124 @@
 			productReference = 20B4D4D4A77434FA5593E35D /* Framework.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		D816F64720D160B9FE1F5AB1 /* StaticLibrary_Swift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 51ECBDC8632467DA3ADA886F /* Build configuration list for PBXNativeTarget "StaticLibrary_Swift" */;
+			buildPhases = (
+				7B234BC963946F3563B71335 /* Sources */,
+				694D2893BD4C5D54ABAA71C3 /* Copy Swift Objective-C Interface Header */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = StaticLibrary_Swift;
+			productName = StaticLibrary_Swift;
+			productReference = A74AC60A5F465A6542431675 /* libStaticLibrary_Swift.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		D8592DE6C0BC77BE0D4A2FAB /* XPC Service */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F5B278C2B6590DD1F0CBDE04 /* Build configuration list for PBXNativeTarget "XPC Service" */;
+			buildPhases = (
+				C3B2824FCF15AA1C94661F47 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "XPC Service";
+			productName = "XPC Service";
+			productReference = 51E2D479CB960CB44EB545C6 /* XPC Service.xpc */;
+			productType = "com.apple.product-type.xpc-service";
+		};
+		DAF9935ECEC17AA561D28998 /* App_watchOS Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E7F77B0DBCCD253D8A6B2645 /* Build configuration list for PBXNativeTarget "App_watchOS Extension" */;
+			buildPhases = (
+				DA3B1A921C17686292F054E9 /* Sources */,
+				B14B691D85C703DE27160E6C /* Resources */,
+				6A403DD09160A25A14C4D7E3 /* Carthage */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "App_watchOS Extension";
+			productName = "App_watchOS Extension";
+			productReference = 02C5C670B0624A007BCB341D /* App_watchOS Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
+		E8BDC848AB4F8D5927ADB55B /* App_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7FCE6665950846F21D6BA7F1 /* Build configuration list for PBXNativeTarget "App_macOS" */;
+			buildPhases = (
+				8C41B2F647E4DFC95A653712 /* Sources */,
+				A904A902001656E96B24C7A9 /* Resources */,
+				9830A88A58F9591CFE7662C9 /* CopyFiles */,
+				5A2BDC62A00DF008470998CA /* Frameworks */,
+				B4F76A1390264F5E325C3C1E /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				579118B5FDFABB980065C769 /* PBXTargetDependency */,
+				EAF163F407A28ED197A7BC3E /* PBXTargetDependency */,
+				0ACA28EFA6CBFE1E8FA8FBDA /* PBXTargetDependency */,
+			);
+			name = App_macOS;
+			productName = App_macOS;
+			productReference = DF3C1E903F8399E193F3B4BA /* App_macOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		EDE7907E34D077B346FC4CF1 /* iMessageExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 04F7DFEC84B28DEF04F71F0A /* Build configuration list for PBXNativeTarget "iMessageExtension" */;
+			buildPhases = (
+				DF1ADFADCFCF58DB93E22F75 /* Sources */,
+				0F3DD10DE4BA9F1995F576A8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iMessageExtension;
+			productName = iMessageExtension;
+			productReference = 6C14AF20FB1E07BF9D32937E /* iMessageExtension.appex */;
+			productType = "com.apple.product-type.app-extension.messages";
+		};
+		FF3DC3DF2AA3AE02377647C9 /* iMessageApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 65393391FA3D521A2D096C75 /* Build configuration list for PBXNativeTarget "iMessageApp" */;
+			buildPhases = (
+				6D95B3C6406DCAD3794FBFCD /* Resources */,
+				93EF9E66AA5ED7DE1C6A6FAD /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				39A6FEDAF7A2B3D517ED1E80 /* PBXTargetDependency */,
+			);
+			name = iMessageApp;
+			productName = iMessageApp;
+			productReference = 239041E1C2665F9EB8AEB019 /* iMessageApp.app */;
+			productType = "com.apple.product-type.application.messages";
+		};
+		FF646CE49D21E77229B5316B /* Tool */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB9AF55D22482CDEE8E9AC49 /* Build configuration list for PBXNativeTarget "Tool" */;
+			buildPhases = (
+				AC7B03CED863AF9296A0A7DF /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Tool;
+			productName = Tool;
+			productReference = 3BAAEBEC8B795DCF1C9C5ADE /* Tool */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -820,13 +1947,29 @@
 			attributes = {
 				LastUpgradeCheck = 1020;
 				TargetAttributes = {
+					21D7F6A04EF6BA1329685C17 = {
+						ProvisioningStyle = Automatic;
+					};
+					6122E4E48939B4937E588B23 = {
+						TestTargetID = 991BCE8E861305DE596EACFE;
+					};
 					6BBA6FB48BEE245ED177B75E = {
 						TestTargetID = 559F6E334A370096461729A9;
 					};
 					991BCE8E861305DE596EACFE = {
 						ProvisioningStyle = Automatic;
 					};
+					9C27C8C394ADD16FDCF6E624 = {
+						CUSTOM = value;
+					};
+					E8BDC848AB4F8D5927ADB55B = {
+						ProvisioningStyle = Automatic;
+					};
 				};
+				knownAssetTags = (
+					tag1,
+					tag2,
+				);
 			};
 			buildConfigurationList = 2961C7042EE5F08A22AAF183 /* Build configuration list for PBXProject "ProjectXcode12" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -838,27 +1981,71 @@
 			);
 			mainGroup = 54E9E53007DE91CA40153A40;
 			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = 63CA1B81E0D9E4D5F1683D64 /* Products */;
+					ProjectRef = 43EA7AFC9AC8E9116A228613 /* AnotherProject */;
+				},
+			);
 			projectRoot = "";
 			targets = (
 				559F6E334A370096461729A9 /* App_Clip */,
 				672091195E5FD01EDDFB6714 /* App_Clip_Tests */,
 				6BBA6FB48BEE245ED177B75E /* App_Clip_UITests */,
 				991BCE8E861305DE596EACFE /* App_iOS */,
+				9E7BCAAA9E855251D33C5730 /* App_iOS_Tests */,
+				6122E4E48939B4937E588B23 /* App_iOS_UITests */,
+				21D7F6A04EF6BA1329685C17 /* App_iOS_With_Clip */,
+				E8BDC848AB4F8D5927ADB55B /* App_macOS */,
+				34EF687C75C46BA8E8701BAB /* App_macOS_Tests */,
+				15A12B9A8B7A477CF2D4ABEF /* App_watchOS */,
+				DAF9935ECEC17AA561D28998 /* App_watchOS Extension */,
+				4D1BB58561A59EB6850A2D6D /* EntitledApp */,
+				5C6E1548456BE821C90E23F0 /* Framework2_iOS */,
+				C0A9408F6C298624A7E2A024 /* Framework2_macOS */,
+				1DD1EB52ED39F468AF836C80 /* Framework2_tvOS */,
+				5BE879342590E136B31C840B /* Framework2_watchOS */,
 				242476187403208F30D3219F /* Framework_iOS */,
 				974B3EC2FF4FBAA1513A2950 /* Framework_macOS */,
 				D691B96B3888D27A6050EF10 /* Framework_tvOS */,
 				786AB2F08EC86516E5EA092F /* Framework_watchOS */,
+				1765579FCB7609C001BB1488 /* Legacy */,
 				3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */,
 				3FCF5A083151C7E22B24E807 /* StaticLibrary_ObjC_macOS */,
 				8507B864DA27764F1EA6962C /* StaticLibrary_ObjC_tvOS */,
 				5239298BB84B4FDDFD84469E /* StaticLibrary_ObjC_watchOS */,
+				D816F64720D160B9FE1F5AB1 /* StaticLibrary_Swift */,
 				9C27C8C394ADD16FDCF6E624 /* SuperTarget */,
 				63EAAEAE0535C975295781D4 /* TestFramework */,
+				FF646CE49D21E77229B5316B /* Tool */,
+				D8592DE6C0BC77BE0D4A2FAB /* XPC Service */,
+				FF3DC3DF2AA3AE02377647C9 /* iMessageApp */,
+				EDE7907E34D077B346FC4CF1 /* iMessageExtension */,
+				87194DCB93BF1A83EE181FBF /* iMessageStickersExtension */,
 			);
 		};
 /* End PBXProject section */
 
+/* Begin PBXReferenceProxy section */
+		FF10A8919F65E6609784780A /* ExternalTarget.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = ExternalTarget.framework;
+			remoteRef = D65DFD803579AB5662714F99 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
 /* Begin PBXResourcesBuildPhase section */
+		0F3DD10DE4BA9F1995F576A8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				85332C85D63B652CAB836FB9 /* Assets.xcassets in Resources */,
+				16BD7E732A3294D973E79337 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		21BCDA8027E0DED5FD1F46B2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -869,7 +2056,30 @@
 				9A8AB7DE8957C82A8807559F /* Localizable.stringsdict in Resources */,
 				966364F9A5B152ED9292B335 /* LocalizedStoryboard.storyboard in Resources */,
 				89D00F3D1A87503F10AE7432 /* Main.storyboard in Resources */,
+				0060461B613150BA7D9CAF95 /* MyBundle.bundle in Resources */,
+				E4D57896F90E7AEC6FED0634 /* ResourceFolder in Resources */,
+				A5850DA4EB6491F7B3588832 /* SceneKitCatalog.scnassets in Resources */,
 				81724CEEA748160B950C85B5 /* Settings.bundle in Resources */,
+				11B2B5EF7172B6B837D951AA /* StandaloneAssets.xcassets in Resources */,
+				C57A966770059A0014B3326D /* example.mp4 in Resources */,
+				CC3D560B3E97CAAAC8B6076E /* iMessageApp.app in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		44D2699A7F63415B1C76D682 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6CA40F7223581AF6628DB4DE /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		541E93B3FAC6738328D848A9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1870224DAA5300F2EEB5C728 /* Assets.xcassets in Resources */,
+				064BCA54DD18E6F5EAFE5C1C /* Interface.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -883,7 +2093,257 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6D95B3C6406DCAD3794FBFCD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ED7050A16D1A986B9F47AC43 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A904A902001656E96B24C7A9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				793BD03EDB3A072945B82C27 /* Assets.xcassets in Resources */,
+				F94B7016C76FC0A6B74111B3 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B14B691D85C703DE27160E6C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9BE414C2C4CE2BA52F20E38D /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BBAF3F5A94735C7DE2A6A827 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DCFAD099E6E129BDE43E1B79 /* Assets.xcassets in Resources */,
+				C875EA6DE9F7090BDB27D6B9 /* LaunchScreen.storyboard in Resources */,
+				30E0C7F5317477917CFFCE52 /* Localizable.strings in Resources */,
+				40906CFD3662304ACD172B5C /* Localizable.stringsdict in Resources */,
+				3A0A1B20E2149C6B53848EAC /* LocalizedStoryboard.storyboard in Resources */,
+				329F958FE3152A51D6DBDC4F /* Main.storyboard in Resources */,
+				50E29FF7B2936111F9189780 /* Settings.bundle in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		1B8F5C5B489BAFF4289F6CE5 /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script\"\n";
+		};
+		1C42D5F7BAE0F2979CC08ED8 /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Result.framework",
+			);
+			name = Carthage;
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "carthage copy-frameworks\n";
+		};
+		3C88C9760FFCFF5C729DD22C /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script\"\n";
+		};
+		4620AC2C57607DEDA627907C /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Result.framework",
+			);
+			name = Carthage;
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "carthage copy-frameworks\n";
+		};
+		5EC541AC97EEFAF38B3C1C17 /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script\"\n";
+		};
+		6300B083DBBB177437172F25 /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				App_iOS/inputList.xcfilelist,
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputFileListPaths = (
+				App_iOS/outputList.xcfilelist,
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script!\"\n";
+		};
+		694D2893BD4C5D54ABAA71C3 /* Copy Swift Objective-C Interface Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DERIVED_SOURCES_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			name = "Copy Swift Objective-C Interface Header";
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/include/$(PRODUCT_MODULE_NAME)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "ditto \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+		};
+		6A403DD09160A25A14C4D7E3 /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/watchOS/Result.framework",
+			);
+			name = Carthage;
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "carthage copy-frameworks\n";
+		};
+		70145FE98044319FDDC0BB29 /* Strip Unused Architectures from Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Strip Unused Architectures from Frameworks";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "################################################################################\n#\n# Copyright 2015 Realm Inc.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n# http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n################################################################################\n\n# This script strips all non-valid architectures from dynamic libraries in\n# the application's `Frameworks` directory.\n#\n# The following environment variables are required:\n#\n# BUILT_PRODUCTS_DIR\n# FRAMEWORKS_FOLDER_PATH\n# VALID_ARCHS\n# EXPANDED_CODE_SIGN_IDENTITY\n\n\n# Signs a framework with the provided identity\ncode_sign() {\n  # Use the current code_sign_identitiy\n  echo \"Code Signing $1 with Identity ${EXPANDED_CODE_SIGN_IDENTITY_NAME}\"\n  echo \"/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements $1\"\n  /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements \"$1\"\n}\n\n# Set working directory to product’s embedded frameworks\ncd \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}\"\n\nif [ \"$ACTION\" = \"install\" ]; then\n  echo \"Copy .bcsymbolmap files to .xcarchive\"\n  find . -name '*.bcsymbolmap' -type f -exec mv {} \"${CONFIGURATION_BUILD_DIR}\" \\;\nelse\n  # Delete *.bcsymbolmap files from framework bundle unless archiving\n  find . -name '*.bcsymbolmap' -type f -exec rm -rf \"{}\" +\\;\nfi\n\necho \"Stripping frameworks\"\n\nfor file in $(find . -type f -perm +111); do\n  # Skip non-dynamic libraries\n  if ! [[ \"$(file \"$file\")\" == *\"dynamically linked shared library\"* ]]; then\n    continue\n  fi\n  # Get architectures for current file\n  archs=\"$(lipo -info \"${file}\" | rev | cut -d ':' -f1 | rev)\"\n  stripped=\"\"\n  for arch in $archs; do\n    if ! [[ \"${VALID_ARCHS}\" == *\"$arch\"* ]]; then\n      # Strip non-valid architectures in-place\n      lipo -remove \"$arch\" -output \"$file\" \"$file\" || exit 1\n      stripped=\"$stripped $arch\"\n    fi\n  done\n  if [[ \"$stripped\" != \"\" ]]; then\n    echo \"Stripped $file of architectures:$stripped\"\n    if [ \"${CODE_SIGNING_REQUIRED}\" == \"YES\" ]; then\n      code_sign \"${file}\"\n    fi\n  fi\ndone\n";
+		};
+		A2C7EEAF062CD944C219DD8F /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"You ran a script\"\n";
+		};
+		AC27EC6D44E51A1CB441A72E /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/Result.framework",
+			);
+			name = Carthage;
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/$(FRAMEWORKS_FOLDER_PATH)/Result.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "carthage copy-frameworks\n";
+		};
+		D4BA2D61D3DC727DA6E90F7E /* MyScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = MyScript;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "echo \"do the thing\"";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		07D5C6D7C8F6A3942C2254AB /* Sources */ = {
@@ -926,11 +2386,96 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		308A0B0D609D0E21A320A468 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0EDE93FD1B8EEA5E757A3EE1 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3153BE680CE6A42770AA895C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3863DD3BC5038A7987B495F /* AppDelegate.swift in Sources */,
+				5F3CD9C98D6FCF78A371850F /* Model.xcdatamodeld in Sources */,
+				16B6081EBDCE7DDBC89DDFEE /* Standalone.swift in Sources */,
+				37556609B05600FC511F540B /* SwiftFileInDotPath.swift in Sources */,
+				FB753FD180515AE293B2485C /* ViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		50E46638726052318507CD67 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		5AC22827901924EE4C7D2EE4 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				2778626BA6AC7257203DFA47 /* StaticLibrary_ObjC.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		65BD1A9FF4490B11C263E501 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2A39623B596284EC9DCDAE1D /* TestProjectTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7B234BC963946F3563B71335 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				00412000C589181F73BB9C88 /* StaticLibrary.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8C41B2F647E4DFC95A653712 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2514149FFB3E6498D579DBBB /* AppDelegate.swift in Sources */,
+				BF7D701BA63380CE76046BDB /* Standalone.swift in Sources */,
+				0035E2ED473E71B573FA73CF /* ViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8F62F8852A468CE268D0D9F7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				078DC5844DEA2DB6F020D455 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9D3F0641DC33C8222ACC3D00 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B6902E1019616CCCC8C84D7 /* TestProjectUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A4664FD3828FBEF2CD8380C4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B09EE60448F8EBD4546D3C41 /* TestProjectTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		AC7B03CED863AF9296A0A7DF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				092201CC0E7C18615C0B212A /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -951,6 +2496,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B771A52C53992E86CC375F81 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		BEE11A37E1AD9A0DFE7376FA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -959,11 +2511,53 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C0EBE6EF18E598977615610E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4BC91284F91B188CBBEBA38C /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C3B2824FCF15AA1C94661F47 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6E1725E31FE9D8D8B0075AD /* XPC_Service.m in Sources */,
+				922FA3335972E2600AD9C68D /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7C8DBC92C9E0658B7D9EE40 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				F316B77453C5A4A9692166AF /* TestProjectUITests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CDD0499E6DAD48E8BC32C503 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA3B1A921C17686292F054E9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A61DB3A89D0636D62F6134C /* ExtensionDelegate.swift in Sources */,
+				B5B0D4EAB3B78D5CE452E100 /* InterfaceController.swift in Sources */,
+				BF1837BBD7E8DA1998C80F7A /* NotificationController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DF1ADFADCFCF58DB93E22F75 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				820158D082BDA00E14BD61E2 /* MessagesViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -983,12 +2577,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F35CD0E35C79019C8412A011 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C42838B5395A013CF38EA48E /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F6445A97D8E8467AFCE9F0B6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				6F988879F73866310CE43F37 /* AppDelegate.swift in Sources */,
+				751D7A8B90209DDAAB9EB73E /* File1.swift in Sources */,
+				48B822DF3314CCF76EE74D6D /* File2.swift in Sources */,
 				3D8580B33361272D45C61A85 /* Model.xcdatamodeld in Sources */,
+				8F2C2446CC90D71637CA98DE /* Model.xcmappingmodel in Sources */,
+				B5BD65590F7EE7C3963B5122 /* MoreUnder.swift in Sources */,
 				37EDF33D6B4105F07070FB56 /* Standalone.swift in Sources */,
 				E9AB59E760C7776384AC7E32 /* SwiftFileInDotPath.swift in Sources */,
 				36FEB01A03A566B43A2C2434 /* ViewController.swift in Sources */,
@@ -998,20 +2604,35 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0ACA28EFA6CBFE1E8FA8FBDA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = D8592DE6C0BC77BE0D4A2FAB /* XPC Service */;
+			targetProxy = 1BC468AB18D1F023019F1FBA /* PBXContainerItemProxy */;
+		};
+		118733A7DC1EE1870914EA4D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 991BCE8E861305DE596EACFE /* App_iOS */;
+			targetProxy = 9D69D471B06AE37AEA2D84E3 /* PBXContainerItemProxy */;
+		};
 		1A8C378E7A510A6E0772386F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 63EAAEAE0535C975295781D4 /* TestFramework */;
 			targetProxy = 98E077CD4918FF68662C4337 /* PBXContainerItemProxy */;
 		};
-		1BB7E24BD9F5BA34E14CC594 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 559F6E334A370096461729A9 /* App_Clip */;
-			targetProxy = 0335EDE25056C73A036FE356 /* PBXContainerItemProxy */;
-		};
 		219E518662CD7D0BA64246D9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 3FCF5A083151C7E22B24E807 /* StaticLibrary_ObjC_macOS */;
 			targetProxy = C0408FA85DFD7E9F59541D2E /* PBXContainerItemProxy */;
+		};
+		222B62D87784D9E40353D4F9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 991BCE8E861305DE596EACFE /* App_iOS */;
+			targetProxy = 913CC94BAD23FF3E3636E8E5 /* PBXContainerItemProxy */;
+		};
+		39A6FEDAF7A2B3D517ED1E80 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = EDE7907E34D077B346FC4CF1 /* iMessageExtension */;
+			targetProxy = F2FCFF0F2338D8316F9D8D47 /* PBXContainerItemProxy */;
 		};
 		418D7F4A4C25F618DBC96B1A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1023,10 +2644,30 @@
 			target = 3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */;
 			targetProxy = F8D2CC44BE471C9C41F5B1E6 /* PBXContainerItemProxy */;
 		};
-		5D8D142415461F41AAF64E5B /* PBXTargetDependency */ = {
+		53E5D1FE14ECF98F9F9729CF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 559F6E334A370096461729A9 /* App_Clip */;
-			targetProxy = 4D8A3B8387E29C006CC9AD78 /* PBXContainerItemProxy */;
+			target = 242476187403208F30D3219F /* Framework_iOS */;
+			targetProxy = 4CA2280DE705720E8B851B8E /* PBXContainerItemProxy */;
+		};
+		578F376EB1922ADCB9482DE3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5C6E1548456BE821C90E23F0 /* Framework2_iOS */;
+			targetProxy = 2F6AB4DC84D6D8156D9743ED /* PBXContainerItemProxy */;
+		};
+		579118B5FDFABB980065C769 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 974B3EC2FF4FBAA1513A2950 /* Framework_macOS */;
+			targetProxy = 4DB3B584A41D1D19DE1B39E1 /* PBXContainerItemProxy */;
+		};
+		63AA55FB95FBE6655AF2BC44 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */;
+			targetProxy = 5A3133C260AB0B2EE767880A /* PBXContainerItemProxy */;
+		};
+		6F2B0CFA463F069B3F4857EF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DAF9935ECEC17AA561D28998 /* App_watchOS Extension */;
+			targetProxy = C68FFE66E063CA163CE1D68B /* PBXContainerItemProxy */;
 		};
 		789CE321F7B8ECC624741135 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1043,20 +2684,60 @@
 			target = 991BCE8E861305DE596EACFE /* App_iOS */;
 			targetProxy = 0FA2870744F254DD5E3D8374 /* PBXContainerItemProxy */;
 		};
+		A9BCB911887308296B1CA4F7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 242476187403208F30D3219F /* Framework_iOS */;
+			targetProxy = 193DD9683611F943D58ADCC6 /* PBXContainerItemProxy */;
+		};
 		B0BF35FE3796D451CA095789 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 559F6E334A370096461729A9 /* App_Clip */;
 			targetProxy = 6D2993924DD47F80ACB3567E /* PBXContainerItemProxy */;
+		};
+		B17852290DB066C640ABDC2F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = ExternalTarget;
+			targetProxy = 8C53BD3BF1B5227C831355F9 /* PBXContainerItemProxy */;
 		};
 		B2F2BF8FB4CBBFE658694D3E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 5239298BB84B4FDDFD84469E /* StaticLibrary_ObjC_watchOS */;
 			targetProxy = 5CFE6D622751CA41654F4B00 /* PBXContainerItemProxy */;
 		};
+		BE366BE8CC8B292A296FDAAD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 15A12B9A8B7A477CF2D4ABEF /* App_watchOS */;
+			targetProxy = FF4780B89575C7C171A9B401 /* PBXContainerItemProxy */;
+		};
 		C1F2B62314C8601132D452FE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 3DBB411AF8D365588E21D8CA /* StaticLibrary_ObjC_iOS */;
 			targetProxy = F7BDEB5E84BA34C6E32E8C1F /* PBXContainerItemProxy */;
+		};
+		CFA15A6B9BBC6ABEA148E61B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E8BDC848AB4F8D5927ADB55B /* App_macOS */;
+			targetProxy = 3BFFB177BC0E51F54F902AE2 /* PBXContainerItemProxy */;
+		};
+		D8B398F93CADCBB7ACF6CD9B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 559F6E334A370096461729A9 /* App_Clip */;
+			targetProxy = F52878EB4A2F3E2E1F89036F /* PBXContainerItemProxy */;
+		};
+		DBBCD483619808FD913E8199 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 63EAAEAE0535C975295781D4 /* TestFramework */;
+			targetProxy = BB3B4DE7EE8CEE505BBC6DF4 /* PBXContainerItemProxy */;
+		};
+		E14514F1BEE89DF60E569CC5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FF3DC3DF2AA3AE02377647C9 /* iMessageApp */;
+			targetProxy = D7FD49F1E9A4B29D528D18A5 /* PBXContainerItemProxy */;
+		};
+		EAF163F407A28ED197A7BC3E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 3FCF5A083151C7E22B24E807 /* StaticLibrary_ObjC_macOS */;
+			targetProxy = 9F4AAED22329F820EA5DB2F7 /* PBXContainerItemProxy */;
 		};
 		F637B36CED5B903A9B1EEAE4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1071,6 +2752,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		214F642E7193A3E608845F4B /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				DF5EEB3171D1A7722CD9413A /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
 		21AA0A827D6C74A605DEE03E /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
@@ -1113,12 +2802,28 @@
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
+		7E1427FBA94B073C3FD2830A /* Interface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				DEC53DADDC767F9AE310B83E /* Base */,
+			);
+			name = Interface.storyboard;
+			sourceTree = "<group>";
+		};
 		917AA3E4306C1A12FCC17994 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
 				5DB17246AF97AF5311C1CB7B /* Base */,
 			);
 			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		95933688FAC17B9E7752CB4F /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				6F98C5891F0CE8C0DEF57B40 /* Base */,
+			);
+			name = MainInterface.storyboard;
 			sourceTree = "<group>";
 		};
 		EE817D9DBEBA01EC4FFCED25 /* LocalizedStoryboard.storyboard */ = {
@@ -1133,6 +2838,19 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		02EA7A15EF79E850F9399B41 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Tool;
+				SDKROOT = macosx;
+			};
+			name = "Staging Debug";
+		};
 		0359995ADD0BFA44E9905752 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1147,6 +2865,20 @@
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = "Production Release";
+		};
+		03A06B8262F1B39589A3B310 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
 		};
 		04A44577D412ADA4AF40B0CF /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1186,12 +2918,37 @@
 			};
 			name = "Production Debug";
 		};
+		09AF4A26FD4A80AFB95F39CD /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
 		0C7B61BCB19F18E1CAFA9B02 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
 				);
 				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
@@ -1207,10 +2964,130 @@
 			};
 			name = "Staging Debug";
 		};
+		0D47838E4B33810EB0F412F9 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		0E9BABB47957C3D52D4A7E4F /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		114E824F1D0EAA35886DEF0D /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+			};
+			name = "Staging Release";
+		};
+		115D9C7C569E8D6887075F9D /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Test Release";
+		};
+		15A1BFD9417590DDD02F6216 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = iMessageExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
+		15BF441D2B0ED86F6B90EF49 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		15DA3659204C3AFA53F64ED5 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Tool;
+				SDKROOT = macosx;
+			};
+			name = "Test Release";
+		};
 		167CE7ABBB81B98E243004BF /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1233,6 +3110,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
@@ -1248,6 +3129,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1257,7 +3142,7 @@
 					"$(inherited)",
 					"-ObjC",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip.clip;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1272,6 +3157,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1286,6 +3175,20 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Production Release";
+		};
+		1978017BCE4AD3F7E426F0F5 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
 		};
 		198A1841A62FDD2285BE1DEC /* Production Release */ = {
 			isa = XCBuildConfiguration;
@@ -1334,8 +3237,31 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = "Production Release";
+		};
+		1B0C38D8839436D77EA16EF1 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+			};
+			name = "Production Debug";
 		};
 		1B2F2C5941E877806806E44C /* Test Release */ = {
 			isa = XCBuildConfiguration;
@@ -1348,6 +3274,28 @@
 			};
 			name = "Test Release";
 		};
+		1D26D189CE20775E78D4CCD8 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Staging Release";
+		};
 		1D9C86CF49283D1F266E73A9 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1357,6 +3305,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1372,6 +3324,70 @@
 			};
 			name = "Staging Release";
 		};
+		1ECD0F546386B34DBFE6C17F /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		212617C380F45FC243973AA9 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Production Debug";
+		};
+		2155EF66022A1C8A143AFA7D /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageStickers/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		21F40CDB7C206A6F9BFD7E33 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
+			};
+			name = "Staging Debug";
+		};
 		23235B1E6CC12E9F18293EC7 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1384,6 +3400,28 @@
 				PRODUCT_NAME = StaticLibrary_ObjC;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+			};
+			name = "Test Debug";
+		};
+		23B260C8D36C1C7B2EBAE948 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
 			};
 			name = "Test Debug";
 		};
@@ -1401,6 +3439,28 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Staging Debug";
+		};
+		2D4302BB2BDA1637648EE400 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+			};
+			name = "Test Release";
 		};
 		31C024516D94D042748F457B /* Production Release */ = {
 			isa = XCBuildConfiguration;
@@ -1428,8 +3488,63 @@
 		32AC37B65B0AD18D0BF30034 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MY_SETTING = hello;
 			};
 			name = "Staging Release";
+		};
+		352CFDDF22878B21B74F23E7 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = iMessageExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		35AC2E0FB7F982F87319A38C /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+			};
+			name = "Test Debug";
+		};
+		35EF59B0A6F4215250FC8B6D /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.EntitledApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
 		};
 		3AAD22CDEC8A1FDDB8A2708D /* Staging Release */ = {
 			isa = XCBuildConfiguration;
@@ -1441,6 +3556,44 @@
 				TARGETED_DEVICE_FAMILY = 4;
 			};
 			name = "Staging Release";
+		};
+		3AECB926A8AE276B2019557F /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		3AFAF82F6BD13C63D55A8308 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Staging Debug";
 		};
 		3CD4C8467FE69F1D2092CE66 /* Production Release */ = {
 			isa = XCBuildConfiguration;
@@ -1466,6 +3619,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1481,6 +3638,27 @@
 			};
 			name = "Test Release";
 		};
+		423A0373D51B89C5AF9344BF /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
+			};
+			name = "Staging Release";
+		};
 		485C71D2CEF34712CE8813C8 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1490,6 +3668,34 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-ObjC-iOS";
 				PRODUCT_NAME = StaticLibrary_ObjC;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		487F219E0C5B4852D4240AE3 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
+		48EFEA0B3CA6F5271B373A92 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1551,6 +3757,30 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = "Production Debug";
+		};
+		49E2ACC01AEF00C167607E25 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
 			};
 			name = "Production Debug";
 		};
@@ -1564,6 +3794,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1577,6 +3811,50 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Production Debug";
+		};
+		4C04971715A77E238CBE8A94 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Production Release";
+		};
+		4D7EF24F4501941FCCD063BD /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Test Release";
 		};
 		4FA21CDBD95C8B64FED4FD1F /* Production Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1593,6 +3871,47 @@
 			};
 			name = "Production Debug";
 		};
+		501FA5E165A41A6BD1F9045A /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Tool;
+				SDKROOT = macosx;
+			};
+			name = "Test Debug";
+		};
+		50D70A3741393712CD35C80C /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Staging Release";
+		};
+		53F9B1C928C6DFEEDA0AF698 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageStickers/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
 		541AF6B4C6B5311D339FF3ED /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1607,6 +3926,29 @@
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = "Test Release";
+		};
+		55ED3060EF856102ED57B470 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
+			};
+			name = "Test Debug";
 		};
 		5728D851D92C8BA0550695BA /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1664,6 +4006,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = "Staging Debug";
 		};
@@ -1673,6 +4016,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
 				);
 				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
@@ -1688,6 +4032,30 @@
 			};
 			name = "Test Debug";
 		};
+		589C74C57B978EEE60A84A5D /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
 		5924F68913C8A193D4081E97 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1697,6 +4065,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
@@ -1713,6 +4085,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
 				INFOPLIST_FILE = App_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1728,6 +4105,26 @@
 			};
 			name = "Staging Release";
 		};
+		5D1AA3424F6EE7831AC065C9 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
 		5D37F8F1E8C7B174E2BCDBAF /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1742,6 +4139,50 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Test Debug";
+		};
+		5D7368280048BFE21CA52364 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		5FDFD00BB647A99AA957DC2D /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
 		};
 		61401F625B86180823D74815 /* Test Release */ = {
 			isa = XCBuildConfiguration;
@@ -1775,6 +4216,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
@@ -1785,6 +4230,29 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Staging Debug";
+		};
+		6286DF5CB32608C929F71F73 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
+			};
+			name = "Test Release";
 		};
 		63B8C37C32DB75550B534E3F /* Test Debug */ = {
 			isa = XCBuildConfiguration;
@@ -1809,10 +4277,71 @@
 			};
 			name = "Test Debug";
 		};
+		6745735B601E00712C6449B5 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
+		};
+		674DF9FC12EEAD2B65EDABF3 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
+			};
+			name = "Staging Release";
+		};
+		67878061E7FE44186F01A87F /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Test Debug";
+		};
 		67DEEE053A621B66857F9803 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1826,10 +4355,78 @@
 			};
 			name = "Test Debug";
 		};
+		68C41F11EC3A5F2AD63A9561 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Production Debug";
+		};
+		6A0FBBF697209EA1BF1B8341 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageStickers/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		6A0FCE5AE89BD83A6554BB0D /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = "XPC Service/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.XPCService;
+				SDKROOT = macosx;
+			};
+			name = "Production Release";
+		};
+		6E5F7AD78B7D395020B2206E /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
 		6F20523C3582CFAD67FF337B /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1839,7 +4436,7 @@
 					"$(inherited)",
 					"-ObjC",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip.clip;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1855,6 +4452,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1868,6 +4469,19 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Staging Debug";
+		};
+		70AC839150951CD4A4A30F96 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
 		};
 		71A3AC6722DE3CBD99092E8C /* Staging Release */ = {
 			isa = XCBuildConfiguration;
@@ -1888,6 +4502,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1897,9 +4515,22 @@
 					"$(inherited)",
 					"-ObjC",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip.clip;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		73A4D390B3E40C79BD6411FF /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Tool;
+				SDKROOT = macosx;
 			};
 			name = "Staging Release";
 		};
@@ -1951,6 +4582,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = "Staging Release";
 		};
@@ -1974,6 +4606,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1989,6 +4625,22 @@
 			};
 			name = "Test Release";
 		};
+		7715B294A5F1C088685F4C82 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = "Staging Release";
+		};
 		77FF85B1482FA6B1F5C7464D /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1998,6 +4650,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2018,6 +4674,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
 				INFOPLIST_FILE = App_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2032,6 +4693,52 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Staging Debug";
+		};
+		798CA37D8B725F91A13557B6 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+			};
+			name = "Staging Debug";
+		};
+		7A0E151513EC4860871B3533 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
 		};
 		7CBE3B17DB26AE387A5182D9 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
@@ -2071,6 +4778,19 @@
 			};
 			name = "Production Debug";
 		};
+		821EB3E3E2FE9AA073D17D12 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
 		83369794BD5F599701ECCCAB /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2081,6 +4801,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2098,6 +4822,7 @@
 		838050FA296DBA072BFBDAC6 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MY_SETTING = hello;
 			};
 			name = "Test Release";
 		};
@@ -2110,6 +4835,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2129,6 +4858,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2142,6 +4875,66 @@
 			};
 			name = "Staging Release";
 		};
+		85832F389D795BA2E92FCB58 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		86A9639B679041971A10A4A5 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS";
+				SDKROOT = macosx;
+			};
+			name = "Production Release";
+		};
+		894820264A634C140A7FB375 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Tool;
+				SDKROOT = macosx;
+			};
+			name = "Production Release";
+		};
 		89AF7A6AD1A97A3595BE385D /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2151,6 +4944,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2166,6 +4963,36 @@
 			};
 			name = "Production Debug";
 		};
+		8ADCC8ACD4DB8DE8A806C3AF /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = iMessageExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
+		8DF455FCCB15089A12904A09 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageStickers/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
 		8E57FECDCAC83BC80F2950B1 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2176,6 +5003,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2195,6 +5026,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
 				INFOPLIST_FILE = App_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2219,6 +5055,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
@@ -2230,10 +5070,50 @@
 			};
 			name = "Staging Release";
 		};
+		8F50C33D75184956D99FA6FB /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.EntitledApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		904C4C86D542B6372931CF17 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
 		90B900384791067500B135B7 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2243,11 +5123,80 @@
 					"$(inherited)",
 					"-ObjC",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip.clip;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Staging Debug";
+		};
+		90C4F3586ECA83132F0DE7B9 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		942D2844B060AD5CF5605E6D /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
+		9432DC33411B23B8E85E4497 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Test Release";
 		};
 		96EBFB5B0E95829CA24B888F /* Test Release */ = {
 			isa = XCBuildConfiguration;
@@ -2297,6 +5246,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = "Test Release";
 		};
@@ -2315,9 +5265,45 @@
 			};
 			name = "Staging Debug";
 		};
+		97943DF689772FAAD2763252 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
+			};
+			name = "Test Debug";
+		};
+		97F35E644613C31A0F6057A9 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageStickers/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
 		983179BB00CE13590396D418 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MY_SETTING = hello;
 			};
 			name = "Staging Debug";
 		};
@@ -2336,6 +5322,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2354,6 +5344,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
 				INFOPLIST_FILE = App_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2369,10 +5364,135 @@
 			};
 			name = "Test Release";
 		};
+		998C0C1803A225B371B1D1B6 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		9ACC54B12ACACAC806B2713A /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
+		9B7E01C60F1BED584E59C229 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = iMessageExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		9DFC9F38D927AEADC5D39497 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		9E61D0D048FBFE4862531A9D /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
+		A12C7C6B28D447A2883E64B1 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
 		A3FA0FDB6F5345F5DC6FAF6A /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2382,7 +5502,7 @@
 					"$(inherited)",
 					"-ObjC",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip.clip;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -2445,8 +5565,25 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
 			};
 			name = "Test Debug";
+		};
+		AA43CD2CE072AC067D41C7B9 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = iMessageExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
 		};
 		AB794EA9075BC2B2E1D742DB /* Production Release */ = {
 			isa = XCBuildConfiguration;
@@ -2458,6 +5595,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2472,6 +5613,20 @@
 			};
 			name = "Production Release";
 		};
+		AB891D5B82CC0DE77E5B3592 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
 		AE10B9A8DD8696989527226F /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2483,6 +5638,66 @@
 			};
 			name = "Production Release";
 		};
+		AEBAEEB0BF317DB830098ECE /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_UITests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-UITests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = App_iOS;
+			};
+			name = "Staging Debug";
+		};
+		B131DD67F7FAA5B3E8F96D43 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
+		B325DC45C94C7C885627F1F7 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
 		B34E6EA38DD860CEECFB2DAB /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2492,6 +5707,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2507,12 +5726,29 @@
 			};
 			name = "Production Release";
 		};
+		B427DC9B644A03F75D5EE3B3 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.EntitledApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Debug";
+		};
 		B63AEDBE2CAF03E47A42EFBB /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
 				);
 				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
@@ -2528,11 +5764,54 @@
 			};
 			name = "Production Release";
 		};
+		BB3A650A1BBB9DB6128BE748 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
+				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-iOS-Tests";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_iOS.app/App_iOS";
+			};
+			name = "Production Release";
+		};
+		BC7790D72F07EA795C1E173E /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
+				INFOPLIST_FILE = iMessageExtension/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp.extension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
 		BCD6DAE84F6D39A359582F34 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
 				INFOPLIST_FILE = App_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2557,6 +5836,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2572,12 +5855,47 @@
 			};
 			name = "Test Debug";
 		};
+		C17A2093AEB51B28A3486357 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Production Debug";
+		};
+		C2170A503C4035851621CFA5 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Legacy;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
+		};
 		C348EEA27988050B1A7E44CF /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
 				);
 				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
@@ -2593,7 +5911,35 @@
 			};
 			name = "Test Release";
 		};
-		C914FA6353BCB691D4770A79 /* Staging Release */ = {
+		C349399AC28634700389BFA0 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		C3683443B5207E92AE54AC3E /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageStickers/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageStickersExtension;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
+		C5CA0964CE9711DD3663414F /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
@@ -2608,6 +5954,123 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		C7A2E4059491C4D3F913820C /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		C8385848D7EC802322A4C9E3 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-watchOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		C841B18259CE051FD4B3E172 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-iOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		C8CB6354514BACC27ACFD497 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
+			};
+			name = "Staging Debug";
+		};
+		C914FA6353BCB691D4770A79 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-iOS";
 				PRODUCT_NAME = Framework;
 				SDKROOT = iphoneos;
@@ -2616,6 +6079,20 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Staging Release";
+		};
+		CAEC3E96990ECDF1F0232D86 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.StaticLibrary-Swift";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
 		};
 		CB42404875DC01211537EBC0 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2632,6 +6109,38 @@
 			};
 			name = "Test Debug";
 		};
+		CB7E81E3E358741E4AF626EE /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = "Staging Debug";
+		};
+		CD636013A0F9EE18BC558EE7 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.EntitledApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
 		CED7E259E7C0F45F2011E81C /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2641,6 +6150,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
@@ -2656,6 +6169,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2669,11 +6186,103 @@
 			};
 			name = "Test Release";
 		};
+		CF1651D9B7BDA2E47376B8B4 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = "Test Release";
+		};
 		CF210234FD3BAEE7A36DD67A /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MY_SETTING = hello;
 			};
 			name = "Production Debug";
+		};
+		D0AFC812B233C6FED331FFEA /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
+			};
+			name = "Production Debug";
+		};
+		D1080DDE709BA2BCAC27E94D /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = "Production Debug";
+		};
+		D2D301B65251BF1D19527185 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
+		D3CFCC35812F6922F93421BA /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
 		};
 		D4EA5ACE61DD1FF1759A15F9 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2698,6 +6307,46 @@
 			};
 			name = "Production Debug";
 		};
+		D5E3DB3EA2AFB7B01449A25A /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.EntitledApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Release";
+		};
+		D66CCEDDDB6EEDDFDB01A429 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
 		D7EF4B53953AC7DBC16BF5CC /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2713,6 +6362,30 @@
 			};
 			name = "Test Release";
 		};
+		DAB2F470DFA47016103F2844 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
 		DE81F17DA26F80B807A0ECB4 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2723,6 +6396,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2743,6 +6420,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
 				);
 				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
@@ -2758,9 +6436,31 @@
 			};
 			name = "Production Debug";
 		};
+		DF17269AA7642511FE3478FA /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Staging Release";
+		};
 		E0C7BB51B137528004C6D05B /* Test Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MY_SETTING = hello;
 			};
 			name = "Test Debug";
 		};
@@ -2773,6 +6473,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2814,12 +6518,58 @@
 			};
 			name = "Staging Debug";
 		};
+		ED80084E3BA60F92AB7E8272 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Production Release";
+		};
+		EDA22633538092F196CADFA5 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
 		EDA66845ACB2EC1E2D02DBCE /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
 				);
 				INFOPLIST_FILE = App_iOS_Tests/Info.plist;
@@ -2835,11 +6585,40 @@
 			};
 			name = "Staging Release";
 		};
+		EDC7F56FE70242B7197B6DBA /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Staging Release";
+		};
 		EF12A546F36561AD22ABE953 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Carthage/Build/iOS/Static",
+				);
 				INFOPLIST_FILE = App_iOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2855,6 +6634,114 @@
 			};
 			name = "Production Release";
 		};
+		EF761FB40B58F9986BB1EACE /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = "Test Debug";
+		};
+		F049A3E0F7C36718151231E3 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.Tool;
+				SDKROOT = macosx;
+			};
+			name = "Production Debug";
+		};
+		F07B8E737BE84E5ACDBC65A1 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = App_watchOS/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 4.0;
+			};
+			name = "Production Release";
+		};
+		F0AEA3C92D045D0911EE0ECD /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Staging Debug";
+		};
+		F0E85A781F359CDBA52C713C /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
+			};
+			name = "Production Release";
+		};
+		F149A50FEDE1D473D0C057F9 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
+				INFOPLIST_FILE = "App_watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.watch.extension;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+			};
+			name = "Test Debug";
+		};
 		F3605B5D6C4420A1213360A8 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2864,6 +6751,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2878,6 +6769,70 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Staging Debug";
+		};
+		F4603F248DE18834462CB0E5 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-tvOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
+		};
+		F4757FF1CECDB8A2B713F51F /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INFOPLIST_FILE = App_iOS/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Production Debug";
+		};
+		F5347351BC19A7749E673E47 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App_iOS/App.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.EntitledApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Release";
 		};
 		F60F56A09B66D2E156A6BE9B /* Production Release */ = {
 			isa = XCBuildConfiguration;
@@ -2897,6 +6852,7 @@
 		F6979D0393CC0D4FB9CA9877 /* Production Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				MY_SETTING = hello;
 			};
 			name = "Production Release";
 		};
@@ -2919,6 +6875,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip_UITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2932,6 +6892,20 @@
 			};
 			name = "Production Release";
 		};
+		F7814E81F508C5AAFD0FF25E /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = iMessageApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.iMessageApp;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Test Debug";
+		};
 		F94FDBEFBDAC270102F161C3 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2941,6 +6915,10 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/watchOS",
+				);
 				INFOPLIST_FILE = Framework/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework-watchOS";
@@ -2971,6 +6949,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = App_Clip/Clip.entitlements;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = App_Clip/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2980,15 +6962,99 @@
 					"$(inherited)",
 					"-ObjC",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.project.app.clip;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.appwithclip.clip;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Production Debug";
 		};
+		FBCB8E4B1BFF276E0CC4A6BC /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.Framework2-macOS";
+				PRODUCT_NAME = Framework2;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
+		FD44525A79C922C647A546C9 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				COMBINE_HIDPI_IMAGES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INFOPLIST_FILE = App_macOS_Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.project.App-macOS-Tests";
+				SDKROOT = macosx;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/App_macOS.app/Contents/MacOS/App_macOS";
+			};
+			name = "Test Release";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		04F7DFEC84B28DEF04F71F0A /* Build configuration list for PBXNativeTarget "iMessageExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC7790D72F07EA795C1E173E /* Production Debug */,
+				9B7E01C60F1BED584E59C229 /* Production Release */,
+				8ADCC8ACD4DB8DE8A806C3AF /* Staging Debug */,
+				AA43CD2CE072AC067D41C7B9 /* Staging Release */,
+				352CFDDF22878B21B74F23E7 /* Test Debug */,
+				15A1BFD9417590DDD02F6216 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		12219412F67F790403913F07 /* Build configuration list for PBXLegacyTarget "Legacy" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				821EB3E3E2FE9AA073D17D12 /* Production Debug */,
+				0D47838E4B33810EB0F412F9 /* Production Release */,
+				1ECD0F546386B34DBFE6C17F /* Staging Debug */,
+				70AC839150951CD4A4A30F96 /* Staging Release */,
+				998C0C1803A225B371B1D1B6 /* Test Debug */,
+				C2170A503C4035851621CFA5 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		1245739E28D036CED2FF55C1 /* Build configuration list for PBXNativeTarget "App_iOS_With_Clip" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4757FF1CECDB8A2B713F51F /* Production Debug */,
+				3AECB926A8AE276B2019557F /* Production Release */,
+				B325DC45C94C7C885627F1F7 /* Staging Debug */,
+				EDC7F56FE70242B7197B6DBA /* Staging Release */,
+				D66CCEDDDB6EEDDFDB01A429 /* Test Debug */,
+				942D2844B060AD5CF5605E6D /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
 		154811E763287E0982E4010C /* Build configuration list for PBXNativeTarget "App_Clip_UITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -3054,6 +7120,19 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
 		};
+		51ECBDC8632467DA3ADA886F /* Build configuration list for PBXNativeTarget "StaticLibrary_Swift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0E9BABB47957C3D52D4A7E4F /* Production Debug */,
+				CAEC3E96990ECDF1F0232D86 /* Production Release */,
+				03A06B8262F1B39589A3B310 /* Staging Debug */,
+				48EFEA0B3CA6F5271B373A92 /* Staging Release */,
+				C349399AC28634700389BFA0 /* Test Debug */,
+				487F219E0C5B4852D4240AE3 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
 		6107B10D2E2D953A15120917 /* Build configuration list for PBXNativeTarget "Framework_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -3063,6 +7142,32 @@
 				C914FA6353BCB691D4770A79 /* Staging Release */,
 				C0E6F72AC67FDABEC3DA0F56 /* Test Debug */,
 				751BB7D52B5275C48FA8561B /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		65393391FA3D521A2D096C75 /* Build configuration list for PBXNativeTarget "iMessageApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1978017BCE4AD3F7E426F0F5 /* Production Debug */,
+				D3CFCC35812F6922F93421BA /* Production Release */,
+				6E5F7AD78B7D395020B2206E /* Staging Debug */,
+				B131DD67F7FAA5B3E8F96D43 /* Staging Release */,
+				F7814E81F508C5AAFD0FF25E /* Test Debug */,
+				AB891D5B82CC0DE77E5B3592 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		6BB95AFCC887A7C884112DCD /* Build configuration list for PBXNativeTarget "Framework2_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				09AF4A26FD4A80AFB95F39CD /* Production Debug */,
+				DAB2F470DFA47016103F2844 /* Production Release */,
+				F4603F248DE18834462CB0E5 /* Staging Debug */,
+				15BF441D2B0ED86F6B90EF49 /* Staging Release */,
+				C7A2E4059491C4D3F913820C /* Test Debug */,
+				EDA22633538092F196CADFA5 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
@@ -3080,6 +7185,19 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
 		};
+		7FCE6665950846F21D6BA7F1 /* Build configuration list for PBXNativeTarget "App_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				49E2ACC01AEF00C167607E25 /* Production Debug */,
+				86A9639B679041971A10A4A5 /* Production Release */,
+				21F40CDB7C206A6F9BFD7E33 /* Staging Debug */,
+				674DF9FC12EEAD2B65EDABF3 /* Staging Release */,
+				55ED3060EF856102ED57B470 /* Test Debug */,
+				6286DF5CB32608C929F71F73 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
 		8ABE44BA99ABFD6518573B75 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_macOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -3089,6 +7207,19 @@
 				71A3AC6722DE3CBD99092E8C /* Staging Release */,
 				23235B1E6CC12E9F18293EC7 /* Test Debug */,
 				F990CC508784D61CF58463E6 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		8B6F763B758ED180046D3908 /* Build configuration list for PBXNativeTarget "App_iOS_Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1B0C38D8839436D77EA16EF1 /* Production Debug */,
+				BB3A650A1BBB9DB6128BE748 /* Production Release */,
+				798CA37D8B725F91A13557B6 /* Staging Debug */,
+				114E824F1D0EAA35886DEF0D /* Staging Release */,
+				35AC2E0FB7F982F87319A38C /* Test Debug */,
+				2D4302BB2BDA1637648EE400 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
@@ -3119,6 +7250,19 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
 		};
+		B19E185DEA8C29F4234D14B9 /* Build configuration list for PBXNativeTarget "Framework2_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6745735B601E00712C6449B5 /* Production Debug */,
+				5FDFD00BB647A99AA957DC2D /* Production Release */,
+				C8385848D7EC802322A4C9E3 /* Staging Debug */,
+				A12C7C6B28D447A2883E64B1 /* Staging Release */,
+				5D1AA3424F6EE7831AC065C9 /* Test Debug */,
+				904C4C86D542B6372931CF17 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
 		BCC8658A349BEF8B35DCEE45 /* Build configuration list for PBXNativeTarget "StaticLibrary_ObjC_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -3145,6 +7289,32 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
 		};
+		C7C54B832F1638EA1C8C506D /* Build configuration list for PBXNativeTarget "Framework2_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7A0E151513EC4860871B3533 /* Production Debug */,
+				9DFC9F38D927AEADC5D39497 /* Production Release */,
+				C841B18259CE051FD4B3E172 /* Staging Debug */,
+				9ACC54B12ACACAC806B2713A /* Staging Release */,
+				90C4F3586ECA83132F0DE7B9 /* Test Debug */,
+				C5CA0964CE9711DD3663414F /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		C7E8A05AB55B088CE727B579 /* Build configuration list for PBXNativeTarget "App_macOS_Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D0AFC812B233C6FED331FFEA /* Production Debug */,
+				F0E85A781F359CDBA52C713C /* Production Release */,
+				C8CB6354514BACC27ACFD497 /* Staging Debug */,
+				423A0373D51B89C5AF9344BF /* Staging Release */,
+				97943DF689772FAAD2763252 /* Test Debug */,
+				FD44525A79C922C647A546C9 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
 		D5A2344247FF33D62704E2C2 /* Build configuration list for PBXNativeTarget "Framework_tvOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -3158,6 +7328,19 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
 		};
+		D8F179BDF8E4EF8A9DF9D8B7 /* Build configuration list for PBXNativeTarget "App_watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D1080DDE709BA2BCAC27E94D /* Production Debug */,
+				F07B8E737BE84E5ACDBC65A1 /* Production Release */,
+				CB7E81E3E358741E4AF626EE /* Staging Debug */,
+				7715B294A5F1C088685F4C82 /* Staging Release */,
+				EF761FB40B58F9986BB1EACE /* Test Debug */,
+				CF1651D9B7BDA2E47376B8B4 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
 		DA4742F9D7A73F3DB2B4AC87 /* Build configuration list for PBXNativeTarget "Framework_watchOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -3167,6 +7350,97 @@
 				8E96D4EBF49E14AF234B6211 /* Staging Release */,
 				CED7E259E7C0F45F2011E81C /* Test Debug */,
 				16C3E5AA32E607CF8AE94952 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		DD2C419331E24B123E0CBC9E /* Build configuration list for PBXNativeTarget "Framework2_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5D7368280048BFE21CA52364 /* Production Debug */,
+				9E61D0D048FBFE4862531A9D /* Production Release */,
+				85832F389D795BA2E92FCB58 /* Staging Debug */,
+				589C74C57B978EEE60A84A5D /* Staging Release */,
+				D2D301B65251BF1D19527185 /* Test Debug */,
+				FBCB8E4B1BFF276E0CC4A6BC /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		DD8DBB7F2CADB523598B1D3A /* Build configuration list for PBXNativeTarget "iMessageStickersExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2155EF66022A1C8A143AFA7D /* Production Debug */,
+				8DF455FCCB15089A12904A09 /* Production Release */,
+				6A0FBBF697209EA1BF1B8341 /* Staging Debug */,
+				53F9B1C928C6DFEEDA0AF698 /* Staging Release */,
+				C3683443B5207E92AE54AC3E /* Test Debug */,
+				97F35E644613C31A0F6057A9 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		E7F77B0DBCCD253D8A6B2645 /* Build configuration list for PBXNativeTarget "App_watchOS Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C17A2093AEB51B28A3486357 /* Production Debug */,
+				ED80084E3BA60F92AB7E8272 /* Production Release */,
+				F0AEA3C92D045D0911EE0ECD /* Staging Debug */,
+				DF17269AA7642511FE3478FA /* Staging Release */,
+				F149A50FEDE1D473D0C057F9 /* Test Debug */,
+				9432DC33411B23B8E85E4497 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		EA0D28F9C2ACF4146025F574 /* Build configuration list for PBXNativeTarget "App_iOS_UITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				68C41F11EC3A5F2AD63A9561 /* Production Debug */,
+				4C04971715A77E238CBE8A94 /* Production Release */,
+				AEBAEEB0BF317DB830098ECE /* Staging Debug */,
+				1D26D189CE20775E78D4CCD8 /* Staging Release */,
+				23B260C8D36C1C7B2EBAE948 /* Test Debug */,
+				4D7EF24F4501941FCCD063BD /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		F5B278C2B6590DD1F0CBDE04 /* Build configuration list for PBXNativeTarget "XPC Service" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				212617C380F45FC243973AA9 /* Production Debug */,
+				6A0FCE5AE89BD83A6554BB0D /* Production Release */,
+				3AFAF82F6BD13C63D55A8308 /* Staging Debug */,
+				50D70A3741393712CD35C80C /* Staging Release */,
+				67878061E7FE44186F01A87F /* Test Debug */,
+				115D9C7C569E8D6887075F9D /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		FB9AF55D22482CDEE8E9AC49 /* Build configuration list for PBXNativeTarget "Tool" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F049A3E0F7C36718151231E3 /* Production Debug */,
+				894820264A634C140A7FB375 /* Production Release */,
+				02EA7A15EF79E850F9399B41 /* Staging Debug */,
+				73A4D390B3E40C79BD6411FF /* Staging Release */,
+				501FA5E165A41A6BD1F9045A /* Test Debug */,
+				15DA3659204C3AFA53F64ED5 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		FBA5F15A7524F82764D43342 /* Build configuration list for PBXNativeTarget "EntitledApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8F50C33D75184956D99FA6FB /* Production Debug */,
+				D5E3DB3EA2AFB7B01449A25A /* Production Release */,
+				B427DC9B644A03F75D5EE3B3 /* Staging Debug */,
+				CD636013A0F9EE18BC558EE7 /* Staging Release */,
+				35EF59B0A6F4215250FC8B6D /* Test Debug */,
+				F5347351BC19A7749E673E47 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:ProjectXcode12.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_Clip.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_Clip.xcscheme
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "D137C04B64B7052419A2DF4E"
+               BlueprintIdentifier = "559F6E334A370096461729A9"
                BuildableName = "App_Clip.app"
                BlueprintName = "App_Clip"
-               ReferencedContainer = "container:Project.xcodeproj">
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -33,30 +33,30 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "63BFF75AA22335E3DDD5E26A"
+               BlueprintIdentifier = "672091195E5FD01EDDFB6714"
                BuildableName = "App_Clip_Tests.xctest"
                BlueprintName = "App_Clip_Tests"
-               ReferencedContainer = "container:Project.xcodeproj">
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "91C3E922A8482E07649971B9"
+               BlueprintIdentifier = "6BBA6FB48BEE245ED177B75E"
                BuildableName = "App_Clip_UITests.xctest"
                BlueprintName = "App_Clip_UITests"
-               ReferencedContainer = "container:Project.xcodeproj">
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D137C04B64B7052419A2DF4E"
+            BlueprintIdentifier = "559F6E334A370096461729A9"
             BuildableName = "App_Clip.app"
             BlueprintName = "App_Clip"
-            ReferencedContainer = "container:Project.xcodeproj">
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
@@ -76,10 +76,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D137C04B64B7052419A2DF4E"
+            BlueprintIdentifier = "559F6E334A370096461729A9"
             BuildableName = "App_Clip.app"
             BlueprintName = "App_Clip"
-            ReferencedContainer = "container:Project.xcodeproj">
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
@@ -95,10 +95,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D137C04B64B7052419A2DF4E"
+            BlueprintIdentifier = "559F6E334A370096461729A9"
             BuildableName = "App_Clip.app"
             BlueprintName = "App_Clip"
-            ReferencedContainer = "container:Project.xcodeproj">
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+               BuildableName = "App_iOS.app"
+               BlueprintName = "App_iOS"
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Production Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Production Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Production Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Production Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Production Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+               BuildableName = "App_iOS.app"
+               BlueprintName = "App_iOS"
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Production Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Production Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Production Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Production Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Production Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
@@ -26,9 +26,31 @@
       buildConfiguration = "Staging Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      disableMainThreadChecker = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
+               BuildableName = "App_iOS_Tests.xctest"
+               BlueprintName = "App_iOS_Tests"
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6122E4E48939B4937E588B23"
+               BuildableName = "App_iOS_UITests.xctest"
+               BlueprintName = "App_iOS_UITests"
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -40,6 +62,14 @@
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
+         <CommandLineArgument
+            argument = "MyDisabledArgument"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "MyEnabledArgument"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
@@ -51,7 +81,9 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      disableMainThreadChecker = "YES"
+      stopOnEveryMainThreadCheckerIssue = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
@@ -63,11 +95,19 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
+         <CommandLineArgument
+            argument = "MyDisabledArgument"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "MyEnabledArgument"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Staging Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
@@ -82,6 +122,14 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
+         <CommandLineArgument
+            argument = "MyDisabledArgument"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "MyEnabledArgument"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+               BuildableName = "App_iOS.app"
+               BlueprintName = "App_iOS"
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Staging Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Staging Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Staging Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Staging Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Staging Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
@@ -26,9 +26,31 @@
       buildConfiguration = "Test Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "NO"
+      disableMainThreadChecker = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
+               BuildableName = "App_iOS_Tests.xctest"
+               BlueprintName = "App_iOS_Tests"
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6122E4E48939B4937E588B23"
+               BuildableName = "App_iOS_UITests.xctest"
+               BlueprintName = "App_iOS_UITests"
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -40,6 +62,14 @@
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
+         <CommandLineArgument
+            argument = "MyDisabledArgument"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "MyEnabledArgument"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
@@ -51,7 +81,9 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
+      allowLocationSimulation = "YES"
+      disableMainThreadChecker = "YES"
+      stopOnEveryMainThreadCheckerIssue = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
@@ -63,11 +95,19 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
+         <CommandLineArgument
+            argument = "MyDisabledArgument"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "MyEnabledArgument"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Test Release"
-      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
@@ -82,6 +122,14 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
+         <CommandLineArgument
+            argument = "MyDisabledArgument"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "MyEnabledArgument"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1020"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+               BuildableName = "App_iOS.app"
+               BlueprintName = "App_iOS"
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Test Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      onlyGenerateCoverageForSpecifiedTargets = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Test Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Test Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
+            BuildableName = "App_iOS.app"
+            BlueprintName = "App_iOS"
+            ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Test Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Test Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS_With_Clip Production.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS_With_Clip Production.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-               BuildableName = "App_iOS.app"
-               BlueprintName = "App_iOS"
+               BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+               BuildableName = "App_iOS_With_Clip.app"
+               BlueprintName = "App_iOS_With_Clip"
                ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,50 +26,20 @@
       buildConfiguration = "Production Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      disableMainThreadChecker = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
-               BuildableName = "App_iOS_Tests.xctest"
-               BlueprintName = "App_iOS_Tests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6122E4E48939B4937E588B23"
-               BuildableName = "App_iOS_UITests.xctest"
-               BlueprintName = "App_iOS_UITests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+            BuildableName = "App_iOS_With_Clip.app"
+            BlueprintName = "App_iOS_With_Clip"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
@@ -81,33 +51,23 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      disableMainThreadChecker = "YES"
-      stopOnEveryMainThreadCheckerIssue = "YES">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+            BuildableName = "App_iOS_With_Clip.app"
+            BlueprintName = "App_iOS_With_Clip"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Production Release"
-      shouldUseLaunchSchemeArgsEnv = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
@@ -115,21 +75,13 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+            BuildableName = "App_iOS_With_Clip.app"
+            BlueprintName = "App_iOS_With_Clip"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS_With_Clip Staging.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS_With_Clip Staging.xcscheme
@@ -14,51 +14,28 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-               BuildableName = "App_iOS.app"
-               BlueprintName = "App_iOS"
+               BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+               BuildableName = "App_iOS_With_Clip.app"
+               BlueprintName = "App_iOS_With_Clip"
                ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Production Debug"
+      buildConfiguration = "Staging Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6122E4E48939B4937E588B23"
-               BuildableName = "App_iOS_UITests.xctest"
-               BlueprintName = "App_iOS_UITests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
-               BuildableName = "App_iOS_Tests.xctest"
-               BlueprintName = "App_iOS_Tests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+            BuildableName = "App_iOS_With_Clip.app"
+            BlueprintName = "App_iOS_With_Clip"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -66,7 +43,7 @@
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Production Debug"
+      buildConfiguration = "Staging Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -79,21 +56,17 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+            BuildableName = "App_iOS_With_Clip.app"
+            BlueprintName = "App_iOS_With_Clip"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <LocationScenarioReference
-         identifier = "Honolulu, HI, USA"
-         referenceType = "1">
-      </LocationScenarioReference>
       <CommandLineArguments>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Production Release"
+      buildConfiguration = "Staging Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -102,18 +75,20 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+            BuildableName = "App_iOS_With_Clip.app"
+            BlueprintName = "App_iOS_With_Clip"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Production Debug">
+      buildConfiguration = "Staging Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Production Release"
+      buildConfiguration = "Staging Release"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS_With_Clip Test.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_iOS_With_Clip Test.xcscheme
@@ -14,51 +14,28 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-               BuildableName = "App_iOS.app"
-               BlueprintName = "App_iOS"
+               BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+               BuildableName = "App_iOS_With_Clip.app"
+               BlueprintName = "App_iOS_With_Clip"
                ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Production Debug"
+      buildConfiguration = "Test Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6122E4E48939B4937E588B23"
-               BuildableName = "App_iOS_UITests.xctest"
-               BlueprintName = "App_iOS_UITests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO"
-            parallelizable = "YES"
-            testExecutionOrdering = "random">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
-               BuildableName = "App_iOS_Tests.xctest"
-               BlueprintName = "App_iOS_Tests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+            BuildableName = "App_iOS_With_Clip.app"
+            BlueprintName = "App_iOS_With_Clip"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -66,7 +43,7 @@
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Production Debug"
+      buildConfiguration = "Test Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -79,21 +56,17 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+            BuildableName = "App_iOS_With_Clip.app"
+            BlueprintName = "App_iOS_With_Clip"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <LocationScenarioReference
-         identifier = "Honolulu, HI, USA"
-         referenceType = "1">
-      </LocationScenarioReference>
       <CommandLineArguments>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Production Release"
+      buildConfiguration = "Test Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -102,18 +75,20 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "21D7F6A04EF6BA1329685C17"
+            BuildableName = "App_iOS_With_Clip.app"
+            BlueprintName = "App_iOS_With_Clip"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
-      buildConfiguration = "Production Debug">
+      buildConfiguration = "Test Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Production Release"
+      buildConfiguration = "Test Release"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_macOS.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_macOS.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-               BuildableName = "App_iOS.app"
-               BlueprintName = "App_iOS"
+               BlueprintIdentifier = "E8BDC848AB4F8D5927ADB55B"
+               BuildableName = "App_macOS.app"
+               BlueprintName = "App_macOS"
                ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,50 +26,20 @@
       buildConfiguration = "Production Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      disableMainThreadChecker = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
-               BuildableName = "App_iOS_Tests.xctest"
-               BlueprintName = "App_iOS_Tests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6122E4E48939B4937E588B23"
-               BuildableName = "App_iOS_UITests.xctest"
-               BlueprintName = "App_iOS_UITests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "E8BDC848AB4F8D5927ADB55B"
+            BuildableName = "App_macOS.app"
+            BlueprintName = "App_macOS"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
@@ -81,33 +51,23 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      disableMainThreadChecker = "YES"
-      stopOnEveryMainThreadCheckerIssue = "YES">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "E8BDC848AB4F8D5927ADB55B"
+            BuildableName = "App_macOS.app"
+            BlueprintName = "App_macOS"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Production Release"
-      shouldUseLaunchSchemeArgsEnv = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
@@ -115,21 +75,13 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "E8BDC848AB4F8D5927ADB55B"
+            BuildableName = "App_macOS.app"
+            BlueprintName = "App_macOS"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_watchOS.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/App_watchOS.xcscheme
@@ -14,6 +14,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "15A12B9A8B7A477CF2D4ABEF"
+               BuildableName = "App_watchOS.app"
+               BlueprintName = "App_watchOS"
+               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "991BCE8E861305DE596EACFE"
                BuildableName = "App_iOS.app"
                BlueprintName = "App_iOS"
@@ -26,50 +40,20 @@
       buildConfiguration = "Production Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      disableMainThreadChecker = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
-               BuildableName = "App_iOS_Tests.xctest"
-               BlueprintName = "App_iOS_Tests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6122E4E48939B4937E588B23"
-               BuildableName = "App_iOS_UITests.xctest"
-               BlueprintName = "App_iOS_UITests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "15A12B9A8B7A477CF2D4ABEF"
+            BuildableName = "App_watchOS.app"
+            BlueprintName = "App_watchOS"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
@@ -81,33 +65,24 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      disableMainThreadChecker = "YES"
-      stopOnEveryMainThreadCheckerIssue = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      allowLocationSimulation = "YES">
+      <RemoteRunnable
+         BundleIdentifier = "com.apple.Carousel"
+         runnableDebuggingMode = "2">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "15A12B9A8B7A477CF2D4ABEF"
+            BuildableName = "App_watchOS.app"
+            BlueprintName = "App_watchOS"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Production Release"
-      shouldUseLaunchSchemeArgsEnv = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
@@ -115,21 +90,13 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "15A12B9A8B7A477CF2D4ABEF"
+            BuildableName = "App_watchOS.app"
+            BlueprintName = "App_watchOS"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
@@ -3,8 +3,26 @@
    LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
-      parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "NO">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo Starting Framework Build">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "242476187403208F30D3219F"
+                     BuildableName = "Framework.framework"
+                     BlueprintName = "Framework_iOS"
+                     ReferencedContainer = "container:ProjectXcode12.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -14,9 +32,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-               BuildableName = "App_iOS.app"
-               BlueprintName = "App_iOS"
+               BlueprintIdentifier = "242476187403208F30D3219F"
+               BuildableName = "Framework.framework"
+               BlueprintName = "Framework_iOS"
                ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,50 +44,23 @@
       buildConfiguration = "Production Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "ja"
+      region = "en"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      disableMainThreadChecker = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
-               BuildableName = "App_iOS_Tests.xctest"
-               BlueprintName = "App_iOS_Tests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6122E4E48939B4937E588B23"
-               BuildableName = "App_iOS_UITests.xctest"
-               BlueprintName = "App_iOS_UITests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "242476187403208F30D3219F"
+            BuildableName = "Framework.framework"
+            BlueprintName = "Framework_iOS"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
@@ -81,33 +72,30 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      disableMainThreadChecker = "YES"
-      stopOnEveryMainThreadCheckerIssue = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "242476187403208F30D3219F"
+            BuildableName = "Framework.framework"
+            BlueprintName = "Framework_iOS"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
+            argument = "argument"
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "MyEnabledArgument"
+            argument = "argument.with.dot"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Production Release"
-      shouldUseLaunchSchemeArgsEnv = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
@@ -115,22 +103,12 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "242476187403208F30D3219F"
+            BuildableName = "Framework.framework"
+            BlueprintName = "Framework_iOS"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
-      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Production Debug">

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/Tool.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-               BuildableName = "App_iOS.app"
-               BlueprintName = "App_iOS"
+               BlueprintIdentifier = "FF646CE49D21E77229B5316B"
+               BuildableName = "Tool"
+               BlueprintName = "Tool"
                ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,50 +26,20 @@
       buildConfiguration = "Production Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      disableMainThreadChecker = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
-               BuildableName = "App_iOS_Tests.xctest"
-               BlueprintName = "App_iOS_Tests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6122E4E48939B4937E588B23"
-               BuildableName = "App_iOS_UITests.xctest"
-               BlueprintName = "App_iOS_UITests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "FF646CE49D21E77229B5316B"
+            BuildableName = "Tool"
+            BlueprintName = "Tool"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
@@ -81,33 +51,23 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      disableMainThreadChecker = "YES"
-      stopOnEveryMainThreadCheckerIssue = "YES">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "FF646CE49D21E77229B5316B"
+            BuildableName = "Tool"
+            BlueprintName = "Tool"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Production Release"
-      shouldUseLaunchSchemeArgsEnv = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
@@ -115,21 +75,13 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "FF646CE49D21E77229B5316B"
+            BuildableName = "Tool"
+            BlueprintName = "Tool"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction

--- a/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/iMessageApp.xcscheme
+++ b/Tests/Fixtures/TestProject/ProjectXcode12.xcodeproj/xcshareddata/xcschemes/iMessageApp.xcscheme
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-               BuildableName = "App_iOS.app"
-               BlueprintName = "App_iOS"
+               BlueprintIdentifier = "FF3DC3DF2AA3AE02377647C9"
+               BuildableName = "iMessageApp.app"
+               BlueprintName = "iMessageApp"
                ReferencedContainer = "container:ProjectXcode12.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,50 +26,20 @@
       buildConfiguration = "Production Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO"
-      shouldUseLaunchSchemeArgsEnv = "NO"
-      disableMainThreadChecker = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9E7BCAAA9E855251D33C5730"
-               BuildableName = "App_iOS_Tests.xctest"
-               BlueprintName = "App_iOS_Tests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "6122E4E48939B4937E588B23"
-               BuildableName = "App_iOS_UITests.xctest"
-               BlueprintName = "App_iOS_UITests"
-               ReferencedContainer = "container:ProjectXcode12.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "FF3DC3DF2AA3AE02377647C9"
+            BuildableName = "iMessageApp.app"
+            BlueprintName = "iMessageApp"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </TestAction>
    <LaunchAction
@@ -81,33 +51,23 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES"
-      disableMainThreadChecker = "YES"
-      stopOnEveryMainThreadCheckerIssue = "YES">
+      allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "FF3DC3DF2AA3AE02377647C9"
+            BuildableName = "iMessageApp.app"
+            BlueprintName = "iMessageApp"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Production Release"
-      shouldUseLaunchSchemeArgsEnv = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
@@ -115,21 +75,13 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "991BCE8E861305DE596EACFE"
-            BuildableName = "App_iOS.app"
-            BlueprintName = "App_iOS"
+            BlueprintIdentifier = "FF3DC3DF2AA3AE02377647C9"
+            BuildableName = "iMessageApp.app"
+            BlueprintName = "iMessageApp"
             ReferencedContainer = "container:ProjectXcode12.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-         <CommandLineArgument
-            argument = "MyDisabledArgument"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "MyEnabledArgument"
-            isEnabled = "YES">
-         </CommandLineArgument>
       </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction

--- a/Tests/Fixtures/TestProject/build.sh
+++ b/Tests/Fixtures/TestProject/build.sh
@@ -23,7 +23,7 @@ echo "✅ Successfully built iOS app"
 if [[ "$XCODE_VERSION" == 12* ]]; then
     echo "
     ⚙️ Building iOS app (Xcode 12+)"
-    xcodebuild -quiet -project ProjectXcode12.xcodeproj -scheme "App_iOS Test" -configuration "Test Debug" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+    xcodebuild -quiet -project ProjectXcode12.xcodeproj -scheme "App_iOS_With_Clip Test" -configuration "Test Debug" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
     echo "✅ Successfully built iOS app (Xcode 12+)"
 fi
 

--- a/Tests/Fixtures/TestProject/build.sh
+++ b/Tests/Fixtures/TestProject/build.sh
@@ -13,10 +13,19 @@ echo "MACH_O_TYPE = staticlib" > $STATIC_CONFIG
 XCODE_XCCONFIG_FILE=$STATIC_CONFIG \
     carthage bootstrap $CARTHAGE_STATIC_FRAMEWORKS --cache-builds
 
+XCODE_VERSION=$(/usr/libexec/PlistBuddy -c "Print :DTXcode" "$(xcode-select -p)/../Info.plist")
+
 echo "
 ⚙️ Building iOS app"
 xcodebuild -quiet -workspace Workspace.xcworkspace -scheme "App_iOS Test" -configuration "Test Debug" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
 echo "✅ Successfully built iOS app"
+
+if [[ "$XCODE_VERSION" == 12* ]]; then
+    echo "
+    ⚙️ Building iOS app (Xcode 12+)"
+    xcodebuild -quiet -project ProjectXcode12.xcodeproj -scheme "App_iOS Test" -configuration "Test Debug" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGNING_ALLOWED="NO"
+    echo "✅ Successfully built iOS app (Xcode 12+)"
+fi
 
 echo "
 ⚙️ Building macOS app"

--- a/Tests/Fixtures/TestProject/project-xcode-12.yml
+++ b/Tests/Fixtures/TestProject/project-xcode-12.yml
@@ -2,18 +2,9 @@
 # this file can be merged into project.yml. As-is, it generates
 # targets that Xcode 11 doesn't understand or know how to build.
 name: ProjectXcode12
-include: [environments.yml]
-options:
-  bundleIdPrefix: com.project
-  usesTabs: false
-  indentWidth: 2
-  tabWidth: 2
-  transitivelyLinkDependencies: true
-  groupSortPosition: top
-configFiles:
-  Test Debug: Configs/config.xcconfig
+include: [project.yml]
 targets:
-  App_iOS:
+  App_iOS_With_Clip:
     type: application
     platform: iOS
     attributes:
@@ -30,7 +21,7 @@ targets:
           - "Model.xcmappingmodel"
     settings:
       INFOPLIST_FILE: App_iOS/Info.plist
-      PRODUCT_BUNDLE_IDENTIFIER: com.project.app
+      PRODUCT_BUNDLE_IDENTIFIER: com.project.appwithclip
     dependencies:
       - target: Framework_iOS
       - target: StaticLibrary_ObjC_iOS
@@ -48,13 +39,13 @@ targets:
     entitlements:
       path: App_Clip/Clip.entitlements
       properties:
-        com.apple.developer.parent-application-identifiers: [$(AppIdentifierPrefix)com.project.app]
+        com.apple.developer.parent-application-identifiers: [$(AppIdentifierPrefix)com.project.appwithclip]
         com.apple.security.application-groups: group.com.app
     sources:
       App_Clip
     settings:
       INFOPLIST_FILE: App_Clip/Info.plist
-      PRODUCT_BUNDLE_IDENTIFIER: com.project.app.clip
+      PRODUCT_BUNDLE_IDENTIFIER: com.project.appwithclip.clip
     dependencies:
       - target: Framework_iOS
       - target: StaticLibrary_ObjC_iOS
@@ -62,36 +53,6 @@ targets:
       testTargets:
         - App_Clip_Tests
         - App_Clip_UITests
-
-  StaticLibrary_ObjC:
-    type: library.static
-    platform: [iOS, tvOS, watchOS, macOS]
-    sources: StaticLibrary_ObjC
-
-  Framework:
-    type: framework
-    platform: [iOS, tvOS, watchOS, macOS]
-    sources:
-      - path: Framework
-        excludes:
-          - "*.xcodeproj"
-      - path: Headers
-        buildPhase: headers
-        type: folder
-        headerVisibility: public
-    dependencies:
-      - target: StaticLibrary_ObjC_${platform}
-
-  TestFramework:
-    type: framework
-    platform: iOS
-    sources:
-      - path: Framework
-        excludes:
-          - "*.xcodeproj"
-    depencencies:
-      - sdk: Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework
-        root: DEVELOPER_DIR
 
   App_Clip_Tests:
     type: bundle.unit-test
@@ -109,17 +70,3 @@ targets:
     sources: App_Clip_UITests
     dependencies:
       - target: App_Clip
-
-schemes:
-  App_Scheme:
-    build:
-      targets:
-        App_iOS: all
-targetTemplates:
-  MyTemplate:
-    scheme: {}
-aggregateTargets:
-  SuperTarget:
-    targets:
-      - App_iOS
-      - App_Clip

--- a/Tests/Fixtures/TestProject/project-xcode-12.yml
+++ b/Tests/Fixtures/TestProject/project-xcode-12.yml
@@ -19,6 +19,7 @@ targets:
     attributes:
       ProvisioningStyle: Automatic
     sources:
+      - path: StandaloneFiles/Standalone.swift
       - path: App_iOS
         name: App
         compilerFlags:

--- a/Tests/Fixtures/TestProject/project-xcode-12.yml
+++ b/Tests/Fixtures/TestProject/project-xcode-12.yml
@@ -1,0 +1,124 @@
+# NOTE: when Xcode 12 goes GM and the Xcode 11 CI can be dropped,
+# this file can be merged into project.yml. As-is, it generates
+# targets that Xcode 11 doesn't understand or know how to build.
+name: ProjectXcode12
+include: [environments.yml]
+options:
+  bundleIdPrefix: com.project
+  usesTabs: false
+  indentWidth: 2
+  tabWidth: 2
+  transitivelyLinkDependencies: true
+  groupSortPosition: top
+configFiles:
+  Test Debug: Configs/config.xcconfig
+targets:
+  App_iOS:
+    type: application
+    platform: iOS
+    attributes:
+      ProvisioningStyle: Automatic
+    sources:
+      - path: App_iOS
+        name: App
+        compilerFlags:
+          - "-Werror"
+        excludes:
+          - "**/excluded-file"
+          - "excluded-file"
+          - "Model.xcmappingmodel"
+    settings:
+      INFOPLIST_FILE: App_iOS/Info.plist
+      PRODUCT_BUNDLE_IDENTIFIER: com.project.app
+    dependencies:
+      - target: Framework_iOS
+      - target: StaticLibrary_ObjC_iOS
+      - target: App_Clip
+      - sdk: Contacts.framework
+    scheme:
+      configVariants:
+        - Test
+        - Staging
+        - Production
+
+  App_Clip:
+    type: application.on-demand-install-capable
+    platform: iOS
+    entitlements:
+      path: App_Clip/Clip.entitlements
+      properties:
+        com.apple.developer.parent-application-identifiers: [$(AppIdentifierPrefix)com.project.app]
+        com.apple.security.application-groups: group.com.app
+    sources:
+      App_Clip
+    settings:
+      INFOPLIST_FILE: App_Clip/Info.plist
+      PRODUCT_BUNDLE_IDENTIFIER: com.project.app.clip
+    dependencies:
+      - target: Framework_iOS
+      - target: StaticLibrary_ObjC_iOS
+    scheme:
+      testTargets:
+        - App_Clip_Tests
+        - App_Clip_UITests
+
+  StaticLibrary_ObjC:
+    type: library.static
+    platform: [iOS, tvOS, watchOS, macOS]
+    sources: StaticLibrary_ObjC
+
+  Framework:
+    type: framework
+    platform: [iOS, tvOS, watchOS, macOS]
+    sources:
+      - path: Framework
+        excludes:
+          - "*.xcodeproj"
+      - path: Headers
+        buildPhase: headers
+        type: folder
+        headerVisibility: public
+    dependencies:
+      - target: StaticLibrary_ObjC_${platform}
+
+  TestFramework:
+    type: framework
+    platform: iOS
+    sources:
+      - path: Framework
+        excludes:
+          - "*.xcodeproj"
+    depencencies:
+      - sdk: Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework
+        root: DEVELOPER_DIR
+
+  App_Clip_Tests:
+    type: bundle.unit-test
+    platform: iOS
+    sources: App_iOS_Tests
+    dependencies:
+      - target: App_Clip
+      - target: TestFramework
+      - carthage: swift-tagged
+        linkType: static
+
+  App_Clip_UITests:
+    type: bundle.ui-testing
+    platform: iOS
+    sources: App_Clip_UITests
+    dependencies:
+      - target: App_Clip
+
+schemes:
+  App_Scheme:
+    build:
+      targets:
+        App_iOS: all
+targetTemplates:
+  MyTemplate:
+    scheme: {}
+aggregateTargets:
+  SuperTarget:
+    targets:
+      - App_iOS
+      - App_Clip

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -115,7 +115,6 @@ targets:
       - target: Framework2_iOS
         weak: true
       - target: App_watchOS
-      - target: App_Clip
       - target: iMessageApp
       - sdk: Contacts.framework
       - bundle: BundleX.bundle
@@ -145,27 +144,6 @@ targets:
           - App_iOS/inputList.xcfilelist
         outputFileLists:
           - App_iOS/outputList.xcfilelist
-
-  App_Clip:
-    type: application.on-demand-install-capable
-    platform: iOS
-    entitlements:
-      path: App_Clip/Clip.entitlements
-      properties:
-        com.apple.developer.parent-application-identifiers: [$(AppIdentifierPrefix)com.project.app]
-        com.apple.security.application-groups: group.com.app
-    sources:
-      App_Clip
-    settings:
-      INFOPLIST_FILE: App_Clip/Info.plist
-      PRODUCT_BUNDLE_IDENTIFIER: com.project.app.clip
-    dependencies:
-      - target: Framework_iOS
-      - target: StaticLibrary_ObjC_iOS
-    scheme:
-      testTargets:
-        - App_Clip_Tests
-        - App_Clip_UITests
 
   EntitledApp:
     type: application
@@ -281,22 +259,6 @@ targets:
     dependencies:
       - target: App_iOS
 
-  App_Clip_Tests:
-    type: bundle.unit-test
-    platform: iOS
-    sources: App_iOS_Tests
-    dependencies:
-      - target: App_Clip
-      - target: TestFramework
-      - carthage: swift-tagged
-        linkType: static
-  App_Clip_UITests:
-    type: bundle.ui-testing
-    platform: iOS
-    sources: App_Clip_UITests
-    dependencies:
-      - target: App_Clip
-
   App_macOS_Tests:
     type: bundle.unit-test
     platform: macOS
@@ -358,7 +320,6 @@ aggregateTargets:
       CUSTOM: value
     targets:
       - App_iOS
-      - App_Clip
       - Framework_iOS
     settings:
       MY_SETTING: hello

--- a/scripts/gen-fixtures.sh
+++ b/scripts/gen-fixtures.sh
@@ -3,5 +3,6 @@ set -e
 
 swift run xcodegen --spec Tests/Fixtures/TestProject/AnotherProject/project.yml
 swift run xcodegen --spec Tests/Fixtures/TestProject/project.yml
+swift run xcodegen --spec Tests/Fixtures/TestProject/project-xcode-12.yml
 swift run xcodegen --spec Tests/Fixtures/CarthageProject/project.yml
 swift run xcodegen --spec Tests/Fixtures/SPM/project.yml


### PR DESCRIPTION
* Pull app clips out of `TestProject/project.yml`
* Move to `TestProject/project-xcode-12.yml`
* Generate new fixtures
* Update build script to selectively build Xcode 12 project based on selected xcode version

Xcodegen itself can't build with Xcode 12 yet due to the Spectre dependency not building:

```
[44/69] Compiling JSONUtilities URL+JSONPrimitiveConvertible.swift
/Users/runner/work/XcodeGen/XcodeGen/.build/checkouts/Spectre/Sources/Spectre/XCTest.swift:35:14: error: 'recordFailure(withDescription:inFile:atLine:expected:)' is only available in macOS 10.13 or newer
    testCase.recordFailure(withDescription: "\(name): \(failure.reason)", inFile: failure.file, atLine: failure.line, expected: false)
```