### PR TITLE
Glob isDirectory cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 #### Fixed
 - Remove force-unwrapping causing crash for `LegacyTarget`s [#982](https://github.com/yonaskolb/XcodeGen/pull/982) @jcolicchio
+- Improve performance of directory traversing by replacing cache type. [#918](https://github.com/yonaskolb/XcodeGen/issues/918) @tcamin
 
 ## 2.18.0
 

--- a/Sources/Core/Glob.swift
+++ b/Sources/Core/Glob.swift
@@ -104,8 +104,6 @@ public class Glob: Collection {
         paths = Array(Set(paths)).sorted { lhs, rhs in
             lhs.compare(rhs) != ComparisonResult.orderedDescending
         }
-
-        clearCaches()
     }
 
     // MARK: Subscript Support
@@ -202,13 +200,9 @@ public class Glob: Collection {
 
         var isDirectoryBool = ObjCBool(false)
         let isDirectory = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectoryBool) && isDirectoryBool.boolValue
-        isDirectoryCache.setObject(isDirectoryBool.boolValue as NSNumber, forKey: path as NSString)
+        Self.isDirectoryCache.setObject(isDirectoryBool.boolValue as NSNumber, forKey: path as NSString)
 
         return isDirectory
-    }
-
-    private func clearCaches() {
-        isDirectoryCache.removeAllObjects()
     }
 
     private func populateFiles(gt: glob_t, includeFiles: Bool) {


### PR DESCRIPTION
By running time profiler using Xcode 11.5 it turns out that a significant amount of time is spent getting/setting data to the cache, as shown below:

<img width="1094" alt="Screenshot 2020-07-30 at 15 31 05" src="https://user-images.githubusercontent.com/875025/88974406-dd7d1900-d2b8-11ea-8a8d-0c5408600814.png">

<img width="956" alt="Screenshot 2020-07-30 at 23 11 56" src="https://user-images.githubusercontent.com/875025/88975185-11a50980-d2ba-11ea-853a-4f3aaceeb9ac.png">

<img width="946" alt="Screenshot 2020-07-30 at 23 12 59" src="https://user-images.githubusercontent.com/875025/88975289-37321300-d2ba-11ea-966d-e10c4873a02d.png">

<img width="945" alt="Screenshot 2020-07-30 at 23 14 11" src="https://user-images.githubusercontent.com/875025/88975394-647ec100-d2ba-11ea-8f19-164451b7f53d.png">

It is likely that this might be due to the fact that we have several include/exclude globs in our configuration yaml however a pretty simple fix is to replace the Dictionary with an NSCache or NSDictionary. Gotta be honest that I don't really understand what's going on here, but it seems that a significant amount of type is spent on checking equality (of keys?) as if there were lots of hash collisions going on internally. I tried increasing the capacity of the Dictionary and while things improved a bit they were very far from results obtained with NSCache or NSDictionary.

With NSDictionary generation went down from 16s to 4s. I'm profiling with release build configuration so optimizations are enabled.

Moreover, with our project I never got a cache hit unless I made the cache static so that previous evaluations are reused over multiple instances of Glob.

