### PR TITLE
Fixed issue of optionally excluding swift package from target dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 #### Fixed
 - Treat all directories with known UTI as file wrapper. [#896](https://github.com/yonaskolb/XcodeGen/pull/896) @KhaosT
-- Generated chemes for application extensions now contain `wasCreatedForAppExtension = YES`. [#898](https://github.com/yonaskolb/XcodeGen/issues/898) @muizidn
+- Generated schemes for application extensions now contain `wasCreatedForAppExtension = YES`. [#898](https://github.com/yonaskolb/XcodeGen/issues/898) @muizidn
+- Issue of excluding swift package from target dependencies. [#920](https://github.com/yonaskolb/XcodeGen/pull/920) @k-thorat   
 
 #### Internal
 - Updated to XcodeProj 7.13.0 [#908](https://github.com/yonaskolb/XcodeGen/pull/908) @brentleyjones

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -865,7 +865,11 @@ public class PBXProjGenerator {
                 let packageDependency = addObject(
                     XCSwiftPackageProductDependency(productName: productName, package: packageReference)
                 )
-                packageDependencies.append(packageDependency)
+
+                // Add package dependency if linking is true.
+                if dependency.link ?? true {
+                    packageDependencies.append(packageDependency)
+                }
 
                 let link = dependency.link ?? (target.type != .staticLibrary)
                 if link {


### PR DESCRIPTION
When you specify Dependency->linking options->link to false, then do not link package product to target. 

https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#dependency

Fixes:
https://github.com/yonaskolb/XcodeGen/issues/868
https://github.com/yonaskolb/XcodeGen/issues/911