### PR TITLE
Delete unnecessary processes. (#927)

### DIFF
--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -122,13 +122,12 @@ extension TargetSource: JSONEncodable {
             "buildPhase": buildPhase?.toJSONValue(),
             "createIntermediateGroups": createIntermediateGroups,
             "resourceTags": resourceTags,
+            "path": path,
         ]
 
         if optional != TargetSource.optionalDefault {
             dict["optional"] = optional
         }
-
-        dict["path"] = path
 
         return dict
     }

--- a/Sources/ProjectSpec/TargetSource.swift
+++ b/Sources/ProjectSpec/TargetSource.swift
@@ -128,10 +128,6 @@ extension TargetSource: JSONEncodable {
             dict["optional"] = optional
         }
 
-        if dict.count == 0 {
-            return path
-        }
-
         dict["path"] = path
 
         return dict


### PR DESCRIPTION
#927

# Abstract
In the variable dict, the property count never becomes 0 when the key is specified.

https://github.com/yonaskolb/XcodeGen/blob/2d30bb1db51aba4e1ecebafb3b1f7abeceb13db6/Sources/ProjectSpec/TargetSource.swift#L114_L125

# Target

https://github.com/yonaskolb/XcodeGen/blob/2d30bb1db51aba4e1ecebafb3b1f7abeceb13db6/Sources/ProjectSpec/TargetSource.swift#L131_L133

# Suggestion
Deleted `dict.count == 0`.

```swift
var dict: [String: Any?] = [
    "compilerFlags": nil,
    "excludes": nil,
    "includes": nil,
    "name": nil,
    "group": nil,
    "headerVisibility": nil,
    "type": nil,
    "buildPhase": nil,
    "createIntermediateGroups": nil,
    "resourceTags": nil
]

print(dict.count)  // 10
```

`dict.count == 0` returns the number of keys, even if the dict values are all nil.

Thank you so much XcodeGen :)