### PR TITLE
Run CI against Xcode 12 beta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:
-        xcode: ["11"]
+        xcode: ["11", "12_beta"]
     steps:
     - uses: actions/checkout@master
     - name: Set Xcode


### PR DESCRIPTION
Originally tried this in #909 / #917 but reverted because `Spectre` wouldn't build with Xcode 12b3. It _does_ build with b4, but GitHub Actions doesn't support it yet (incoming with https://github.com/actions/virtual-environments/pull/1409)

This PR will probably fail but once 12b4 is deployed on GH, it should pass on re-run 🤞 

@yonaskolb (cc @brentleyjones)