### PR TITLE
Fixed adding Info.plists with custom names to Copy Bundle Resources build phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 #### Added
 - Add `useBaseInternationalization` to Project Spec Options to opt out of Base Internationalization. [#961](https://github.com/yonaskolb/XcodeGen/pull/961) @liamnichols
 
-#### Fixed
-- Adding Info.plists with custom names to Copy Bundle Resources build phase [#945](https://github.com/yonaskolb/XcodeGen/pull/945) @anivaros
+#### Changed
+- Info.plists with custom prefixes are no longer added to the Copy Bundle Resources build phase [#945](https://github.com/yonaskolb/XcodeGen/pull/945) @anivaros
 
 ## 2.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Added
 - Add `useBaseInternationalization` to Project Spec Options to opt out of Base Internationalization. [#961](https://github.com/yonaskolb/XcodeGen/pull/961) @liamnichols
 
+#### Fixed
+- Adding Info.plists with custom names to Copy Bundle Resources build phase [#945](https://github.com/yonaskolb/XcodeGen/pull/945) @anivaros
+
 ## 2.18.0
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add `useBaseInternationalization` to Project Spec Options to opt out of Base Internationalization. [#961](https://github.com/yonaskolb/XcodeGen/pull/961) @liamnichols
 
 #### Changed
-- Info.plists with custom prefixes are no longer added to the Copy Bundle Resources build phase [#945](https://github.com/yonaskolb/XcodeGen/pull/945) @anivaros
+- **Breaking**: Info.plists with custom prefixes are no longer added to the Copy Bundle Resources build phase [#945](https://github.com/yonaskolb/XcodeGen/pull/945) @anivaros
 
 ## 2.18.0
 

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -250,7 +250,7 @@ class SourceGenerator {
 
     /// returns a default build phase for a given path. This is based off the filename
     private func getDefaultBuildPhase(for path: Path, targetType: PBXProductType) -> BuildPhaseSpec? {
-        if path.lastComponent == "Info.plist" {
+        if path.lastComponent.hasSuffix("Info.plist") {
             return nil
         }
         if let buildPhase = getFileType(path: path)?.buildPhase {


### PR DESCRIPTION
Fixes warnings for custom named plists:

> warning: The Copy Bundle Resources build phase contains this target's Info.plist file 'HardwareSupport-Info.plist'. (in target 'HardwareSupport' from project 'LegacySupport')

- Extended check for Info.plist, because they usually named not just "Info.plist", but "<TargetName>-Info.plist"