### PR TITLE
Fix appex's Runpath Search Paths under macOS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 #### Fixed
 - Allow SDK dependencies to be embedded. [#922](https://github.com/yonaskolb/XcodeGen/pull/922) @k-thorat
 - Allow creating intermediary groups outside of the project directory. [#892](https://github.com/yonaskolb/XcodeGen/pull/892) @segiddins
+- Fix appex's Runpath Search Paths under macOS target. [#952](https://github.com/yonaskolb/XcodeGen/pull/952) @rinsuki
 
 ## 2.17.0
 

--- a/SettingPresets/Product_Platform/app-extension_macOS.yml
+++ b/SettingPresets/Product_Platform/app-extension_macOS.yml
@@ -1,0 +1,1 @@
+LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/../Frameworks", "@executable_path/../../../../Frameworks"]


### PR DESCRIPTION
Unlike other operating systems, macOS app is not a flat bundle, so appex is in a deeper hierarchy than other OSes.

- macOS: `Host.app/Contents/PlugIns/Widget.appex/Contents/MacOS/Widget` (search path: `../../../../Frameworks`)
- Other OSes (e.g. iOS): `Host.app/PlugIns/Widget.appex/Widget` (search path: `../../Frameworks`)

so, we must be specify LD_RUNPATH_SEARCH_PATHS for macOS target, or dyld can't find Framework (and fail to launch).