### PR TITLE
Select the first runnable target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Updates CI to run on Xcode 12 beta. [#936](https://github.com/yonaskolb/XcodeGen/pull/936) @dflems
 
 #### Fixed
+- Select the first runnable build target, if present. [#957](https://github.com/yonaskolb/XcodeGen/pull/957) @codeman9
 - Allow SDK dependencies to be embedded. [#922](https://github.com/yonaskolb/XcodeGen/pull/922) @k-thorat
 - Allow creating intermediary groups outside of the project directory. [#892](https://github.com/yonaskolb/XcodeGen/pull/892) @segiddins
 - Fix appex's Runpath Search Paths under macOS target. [#952](https://github.com/yonaskolb/XcodeGen/pull/952) @rinsuki

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -783,7 +783,7 @@ Scheme run scripts added via **preActions** or **postActions**. They run before 
 A multiline script can be written using the various YAML multiline methods, for example with `|`. See [Build Script](#build-script).
 
 ### Run Action
-- [ ] **executable**: **String** - the name of the target to launch as an executable. Defaults to the first build target in the scheme
+- [ ] **executable**: **String** - the name of the target to launch as an executable. Defaults to the first runnable build target in the scheme, or the first build target if a runnable build target is not found
 - [ ] **customLLDBInit**: **String** - the absolute path to the custom `.lldbinit` file
 
 ### Test Action

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -165,7 +165,8 @@ public class SchemeGenerator {
         if let targetName = scheme.run?.executable {
             schemeTarget = project.getTarget(targetName)
         } else {
-            schemeTarget = target ?? project.getTarget(scheme.build.targets.first!.target.name)
+            let name = scheme.build.targets.first { $0.buildTypes.contains(.running) }?.target.name ?? scheme.build.targets.first!.target.name
+            schemeTarget = target ?? project.getTarget(name)
         }
 
         let shouldExecuteOnLaunch = schemeTarget?.shouldExecuteOnLaunch == true

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -104,6 +104,24 @@ class SchemeGeneratorTests: XCTestCase {
                 try expect(xcscheme.testAction?.customLLDBInitFile) == "/test/.lldbinit"
             }
 
+            let frameworkTarget = Scheme.BuildTarget(target: .local(framework.name), buildTypes: [.archiving])
+            $0.it("generates a scheme with the first runnable selected") {
+                let scheme = Scheme(
+                    name: "MyScheme",
+                    build: Scheme.Build(targets: [frameworkTarget, buildTarget])
+                )
+                let project = Project(
+                    name: "test",
+                    targets: [framework, app],
+                    schemes: [scheme]
+                )
+                let xcodeProject = try project.generateXcodeProject()
+                let xcscheme = try unwrap(xcodeProject.sharedData?.schemes.first)
+
+                let buildableReference = xcscheme.launchAction?.runnable?.buildableReference
+                try expect(buildableReference?.buildableName) == "MyApp.app"
+            }
+
             $0.it("generates scheme with multiple configs") {
                 let configs: [Config] = [
                     Config(name: "Beta", type: .debug),


### PR DESCRIPTION
Instead of just selecting the first target as the scheme target, search for and select the first runnable target. If there are no runnables found, then fallback to the first target of the scheme.

Fixes: #675 