### PR TITLE
Add useBaseInternationalization to SpecOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Added
+- Add `useBaseInternationalization` to Project Spec Options to opt out of Base Internationalization. [#961](https://github.com/yonaskolb/XcodeGen/pull/961) @liamnichols
+
 ## 2.18.0
 
 #### Added

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -127,6 +127,7 @@ Note that target names can also be changed by adding a `name` property to a targ
 - [ ] **fileTypes**: **[String: [FileType](#filetype)]** - A list of default file options for specific file extensions across the project. Values in [Sources](#sources) will overwrite these settings.
 - [ ] **preGenCommand**: **String** - A bash command to run before the project has been generated. If the project isn't generated due to no changes when using the cache then this won't run. This is useful for running things like generating resources files before the project is regenerated.
 - [ ] **postGenCommand**: **String** - A bash command to run after the project has been generated. If the project isn't generated due to no changes when using the cache then this won't run. This is useful for running things like `pod install` only if the project is actually regenerated.
+- [ ] **useBaseInternationalization**: **Bool** If this is `false` and your project does not include resources located in a **Base.lproj** directory then `Base` will not be included in the projects 'known regions'. The default value is `true`. 
 
 ```yaml
 options:

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -9,6 +9,7 @@ public struct SpecOptions: Equatable {
     public static let groupSortPositionDefault = GroupSortPosition.bottom
     public static let generateEmptyDirectoriesDefault = false
     public static let findCarthageFrameworksDefault = false
+    public static let useBaseInternationalizationDefault = true
 
     public var minimumXcodeGenVersion: Version?
     public var carthageBuildPath: String?
@@ -33,6 +34,7 @@ public struct SpecOptions: Equatable {
     public var localPackagesGroup: String?
     public var preGenCommand: String?
     public var postGenCommand: String?
+    public var useBaseInternationalization: Bool
 
     public enum ValidationType: String {
         case missingConfigs
@@ -93,7 +95,8 @@ public struct SpecOptions: Equatable {
         findCarthageFrameworks: Bool = findCarthageFrameworksDefault,
         localPackagesGroup: String? = nil,
         preGenCommand: String? = nil,
-        postGenCommand: String? = nil
+        postGenCommand: String? = nil,
+        useBaseInternationalization: Bool = useBaseInternationalizationDefault
     ) {
         self.minimumXcodeGenVersion = minimumXcodeGenVersion
         self.carthageBuildPath = carthageBuildPath
@@ -118,6 +121,7 @@ public struct SpecOptions: Equatable {
         self.localPackagesGroup = localPackagesGroup
         self.preGenCommand = preGenCommand
         self.postGenCommand = postGenCommand
+        self.useBaseInternationalization = useBaseInternationalization
     }
 }
 
@@ -149,6 +153,7 @@ extension SpecOptions: JSONObjectConvertible {
         localPackagesGroup = jsonDictionary.json(atKeyPath: "localPackagesGroup")
         preGenCommand = jsonDictionary.json(atKeyPath: "preGenCommand")
         postGenCommand = jsonDictionary.json(atKeyPath: "postGenCommand")
+        useBaseInternationalization = jsonDictionary.json(atKeyPath: "useBaseInternationalization") ?? SpecOptions.useBaseInternationalizationDefault
         if jsonDictionary["fileTypes"] != nil {
             fileTypes = try jsonDictionary.json(atKeyPath: "fileTypes")
         } else {
@@ -191,6 +196,9 @@ extension SpecOptions: JSONEncodable {
         }
         if findCarthageFrameworks != SpecOptions.findCarthageFrameworksDefault {
             dict["findCarthageFrameworks"] = findCarthageFrameworks
+        }
+        if useBaseInternationalization != SpecOptions.useBaseInternationalizationDefault {
+            dict["useBaseInternationalization"] = useBaseInternationalization
         }
 
         return dict

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -292,7 +292,12 @@ public class PBXProjGenerator {
             projectAttributes["knownAssetTags"] = assetTags
         }
 
-        pbxProject.knownRegions = sourceGenerator.knownRegions.union(["Base", developmentRegion]).sorted()
+        var knownRegions = Set(sourceGenerator.knownRegions)
+        knownRegions.insert(developmentRegion)
+        if project.options.useBaseInternationalization {
+            knownRegions.insert("Base")
+        }
+        pbxProject.knownRegions = knownRegions.sorted()
 
         pbxProject.packages = packageReferences.sorted { $0.key < $1.key }.map { $1 }
 

--- a/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
@@ -86,7 +86,6 @@
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				Base,
 				en,
 			);
 			mainGroup = 4E8CFA4275C972686621210C;

--- a/Tests/Fixtures/TestProject/AnotherProject/project.yml
+++ b/Tests/Fixtures/TestProject/AnotherProject/project.yml
@@ -1,5 +1,7 @@
 name: AnotherProject
 include: [../environments.yml]
+options:
+  useBaseInternationalization: false
 configFiles:
   Test Debug: ../Configs/config.xcconfig
 targets:


### PR DESCRIPTION
Closes #954 

So following a discussion in the linked issue, it was mentioned that it'll probably be easier just to provide a mechanism for opting back out of _"Use Base Internationalization"_ but to make it opt-in by default (how it was after #955). 

Do you think this does the job @yonaskolb?