### PR TITLE
Update Crashlytics FAQ

### DIFF
--- a/Docs/FAQ.md
+++ b/Docs/FAQ.md
@@ -24,13 +24,12 @@ Yes, but you need to use a little trick when using CocoaPods. Add this script in
 
 ```ruby:Podfile
 // Your dependencies
-pod 'Fabric'
-pod 'Crashlytics'
+pod 'Firebase/Crashlytics'
 
-script_phase :name => 'Run Fabric',
-             :script => '"${PODS_ROOT}/Fabric/run"',
-             :input_files => ['$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)']
-
+script_phase name: 'Run Firebase Crashlytics',
+             shell_path: '/bin/sh',
+             script: '"${PODS_ROOT}/FirebaseCrashlytics/run"',
+             input_files: ['$(SRCROOT)/$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)']
 ```
 
 This script will be added after `[CP] Embed Pods Frameworks.`


### PR DESCRIPTION
We have to update `Crashlytics` FAQ because `Fabric` was integrated into `Firebase` and the run script was changed.

## Ref

* [Get started with Firebase Crashlytics - Initialize Crashlytics](https://firebase.google.com/docs/crashlytics/get-started#initialize-crashlytics)