### PR TITLE
throw SpecValidationError for minimumXcodeGenVers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Added
 - Add `useBaseInternationalization` to Project Spec Options to opt out of Base Internationalization. [#961](https://github.com/yonaskolb/XcodeGen/pull/961) @liamnichols
 
+#### Fixed
+- Fixed error message output for `minimumXcodeGenVersion`. [#967](https://github.com/yonaskolb/XcodeGen/pull/967) @joshwalker
+
 ## 2.18.0
 
 #### Added

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -228,7 +228,7 @@ extension Project {
 
     public func validateMinimumXcodeGenVersion(_ xcodeGenVersion: Version) throws {
         if let minimumXcodeGenVersion = options.minimumXcodeGenVersion, xcodeGenVersion < minimumXcodeGenVersion {
-            throw SpecValidationError.ValidationError.invalidXcodeGenVersion(minimumVersion: minimumXcodeGenVersion, version: xcodeGenVersion)
+            throw SpecValidationError(errors: [SpecValidationError.ValidationError.invalidXcodeGenVersion(minimumVersion: minimumXcodeGenVersion, version: xcodeGenVersion)])
         }
     }
 

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -111,7 +111,7 @@ class ProjectSpecTests: XCTestCase {
                 project.options = SpecOptions(minimumXcodeGenVersion: minimumVersion)
 
                 func expectMinimumXcodeGenVersionError(_ project: Project, minimumVersion: Version, xcodeGenVersion: Version, file: String = #file, line: Int = #line) throws {
-                    try expectError(SpecValidationError.ValidationError.invalidXcodeGenVersion(minimumVersion: minimumVersion, version: xcodeGenVersion), file: file, line: line) {
+                    try expectError(SpecValidationError(errors: [SpecValidationError.ValidationError.invalidXcodeGenVersion(minimumVersion: minimumVersion, version: xcodeGenVersion)]), file: file, line: line) {
                         try project.validateMinimumXcodeGenVersion(xcodeGenVersion)
                     }
                 }


### PR DESCRIPTION
Using minimumXcodeGenVersion gives a non-useful error
`Error: The operation couldn’t be completed. (ProjectSpec.SpecValidationError.ValidationError error 0.)`

The issue is validate is expecting a SpecValidationError, but validateMinimumXcodeGenVersion throws a SpecValidationError.ValidationError

Now you get the intended message
`Spec validation error: XcodeGen version is 2.18.0, but minimum required version specified as 2.20.0`