### PR TITLE
Project Reference LegacyTarget Crash Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 #### Added
 - Add `useBaseInternationalization` to Project Spec Options to opt out of Base Internationalization. [#961](https://github.com/yonaskolb/XcodeGen/pull/961) @liamnichols
 
+#### Fixed
+- Remove force-unwrapping causing crash for `LegacyTarget`s [#982](https://github.com/yonaskolb/XcodeGen/pull/982) @jcolicchio
+
 ## 2.18.0
 
 #### Added

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -402,7 +402,7 @@ public class PBXProjGenerator {
         let productProxy = addObject(
             PBXContainerItemProxy(
                 containerPortal: .fileReference(projectFileReference),
-                remoteGlobalID: .object(targetObject.product!),
+                remoteGlobalID: targetObject.product.flatMap(PBXContainerItemProxy.RemoteGlobalID.object),
                 proxyType: .reference,
                 remoteInfo: target
             )
@@ -417,7 +417,7 @@ public class PBXProjGenerator {
 
         let productReferenceProxy = addObject(
             PBXReferenceProxy(
-                fileType: Xcode.fileType(path: Path(targetObject.productNameWithExtension()!)),
+                fileType: targetObject.productNameWithExtension().flatMap { Xcode.fileType(path: Path($0)) },
                 path: path,
                 remote: productProxy,
                 sourceTree: .buildProductsDir
@@ -433,14 +433,14 @@ public class PBXProjGenerator {
             )
         )
 
-        guard let productType = targetObject.productType,
-            let buildConfigurations = targetObject.buildConfigurationList?.buildConfigurations,
+        guard let buildConfigurations = targetObject.buildConfigurationList?.buildConfigurations,
             let defaultConfigurationName = targetObject.buildConfigurationList?.defaultConfigurationName,
             let defaultConfiguration = buildConfigurations.first(where: { $0.name == defaultConfigurationName }) ?? buildConfigurations.first else {
 
             fatalError("Missing target info")
         }
 
+        let productType: PBXProductType = targetObject.productType ?? .none
         let buildSettings = defaultConfiguration.buildSettings
         let settings = Settings(buildSettings: buildSettings, configSettings: [:], groups: [])
         let deploymentTargetString = buildSettings[platform.deploymentTargetSetting] as? String


### PR DESCRIPTION
Fixes #980 

This PR removes force-unwrapping and allows to continue with a product whose type is `.none` (the unfortunately named enum case, not `nil`)