### PR TITLE
More detailed error message with method arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Added
 - Support for building and running on Linux platforms. Tested for compatibility with Swift 5.3+ and Ubuntu 18.04. [#988](https://github.com/yonaskolb/XcodeGen/pull/988) @elliottwilliams
 - Add `useBaseInternationalization` to Project Spec Options to opt out of Base Internationalization. [#961](https://github.com/yonaskolb/XcodeGen/pull/961) @liamnichols
+- More detailed error message with method arguments. [#990](https://github.com/yonaskolb/XcodeGen/pull/990) @bannzai
 
 #### Fixed
 - Fixed error message output for `minimumXcodeGenVersion`. [#967](https://github.com/yonaskolb/XcodeGen/pull/967) @joshwalker

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -370,13 +370,13 @@ public class PBXProjGenerator {
 
     func generateExternalTargetDependency(from: String, to target: String, in project: String, platform: Platform) throws -> (PBXTargetDependency, Target, PBXReferenceProxy) {
         guard let projectReference = self.project.getProjectReference(project) else {
-            fatalError("project not found")
+            fatalError("project '\(project)' not found")
         }
 
         let pbxProj = try getPBXProj(from: projectReference)
 
         guard let targetObject = pbxProj.targets(named: target).first else {
-            fatalError("target not found")
+            fatalError("target '\(target)' not found in project '\(project)'")
         }
 
         let projectFileReferenceIndex = self.pbxProj.rootObject!


### PR DESCRIPTION
## Abstract
This PR shows more detailed `fatalError` message with target and project names when cause `fatalError` in `PBXProjGenerator.generateExternalTargetDependency(from:,target:, project:, platform:)`

## Motivation
Team member got below error messages. But we can not understand which target in project.
So, Think I improved error message for development with xcodegen.

```
Fatal error: target not found: file XcodeGenKit/PBXProjGenerator.swift, line 374
```