### PR TITLE
Fix race condition in json decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### Fixed
 - Fixed error message output for `minimumXcodeGenVersion`. [#967](https://github.com/yonaskolb/XcodeGen/pull/967) @joshwalker
+- Fixed a race condition in an internal JSON decoder, which would occasionally fail with an error like `Parsing project spec failed: Error Domain=Unspecified error Code=0`. [#995](https://github.com/yonaskolb/XcodeGen/pull/995) @elliottwilliams
 
 #### Internal
 - Updated to Yams 4.0.0 [#984](https://github.com/yonaskolb/XcodeGen/pull/984) @swiftty


### PR DESCRIPTION
I have a [project spec](https://gist.github.com/elliottwilliams/a5dcd597a501a2cd3d1bb8696879467a) that will occasionally fail to generate with an error like:
```
Parsing project spec failed: Error Domain=Unspecified error Code=0 "(null)
```

When I'd run xcodegen 100 times in sequence, it would typically fail 1-3 times, so I began suspecting a race condition 🕵️‍♂️. I traced it down to a block in `json(atKeyPath:invalidItemBehavior:parallel:)`.

[Concurrently populating an array is not thread-safe](https://stackoverflow.com/questions/55195857/filling-an-array-concurrently) because the underlying buffer may change. I think what's happening is that each `BlockOperation` has a mutable reference to the array, making its storage non-uniquely referenced. So each time an operation executes, the array COWs and switches to a new buffer. If another operation is in the middle of writing to the previous buffer, that mutation is lost.

Confirmed by breaking at the BlockOperation's assignment statement and checking the uniqueness of the array's buffer:

```
(lldb) p itemResults._buffer._storage.isUniquelyReferencedNative()
(Bool) $R12 = false
```

TSan also catches the error:

<details><summary>TSan report</summary>

```
==================
WARNING: ThreadSanitizer: Swift access race (pid=60834)
  Modifying access of Swift variable at 0x7b0800005ab0 by thread T4:
    #0 closure #1 in Dictionary<>.json<A>(atKeyPath:invalidItemBehaviour:parallel:) <null>:2 (xcodegen:x86_64+0x1004210db)
    #1 partial apply for closure #1 in Dictionary<>.json<A>(atKeyPath:invalidItemBehaviour:parallel:) <null>:2 (xcodegen:x86_64+0x100421c3e)
    #2 thunk for @escaping @callee_guaranteed () -> () <null>:2 (xcodegen:x86_64+0x1004215c3)
    #3 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ <null>:2 (Foundation:x86_64+0x41ac4)
    #4 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x2657)

  Previous modifying access of Swift variable at 0x7b0800005ab0 by thread T1:
    #0 closure #1 in Dictionary<>.json<A>(atKeyPath:invalidItemBehaviour:parallel:) <null>:2 (xcodegen:x86_64+0x1004210db)
    #1 partial apply for closure #1 in Dictionary<>.json<A>(atKeyPath:invalidItemBehaviour:parallel:) <null>:2 (xcodegen:x86_64+0x100421c3e)
    #2 thunk for @escaping @callee_guaranteed () -> () <null>:2 (xcodegen:x86_64+0x1004215c3)
    #3 __NSBLOCKOPERATION_IS_CALLING_OUT_TO_A_BLOCK__ <null>:2 (Foundation:x86_64+0x41ac4)
    #4 _dispatch_client_callout <null>:2 (libdispatch.dylib:x86_64+0x2657)

  Location is heap block of size 24 at 0x7b0800005aa0 allocated by main thread:
    #0 malloc <null>:3 (libclang_rt.tsan_osx_dynamic.dylib:x86_64h+0x523ea)
    #1 swift_slowAlloc <null>:2 (libswiftCore.dylib:x86_64+0x2f2ca8)
    #2 Project.init(basePath:jsonDictionary:) <null>:2 (xcodegen:x86_64+0x10045c489)
    #3 SpecLoader.loadProject(path:projectRoot:variables:) <null>:2 (xcodegen:x86_64+0x1004c4f02)
    #4 ProjectCommand.execute() <null>:2 (xcodegen:x86_64+0x10080e77a)
    #5 protocol witness for Command.execute() in conformance ProjectCommand <null>:2 (xcodegen:x86_64+0x10080ed95)
    #6 CLI.go(with:) <null>:2 (xcodegen:x86_64+0x10076442d)
    #7 CLI.go() <null>:2 (xcodegen:x86_64+0x100763a45)
    #8 XcodeGenCLI.execute(arguments:) <null>:2 (xcodegen:x86_64+0x100811205)
    #9 main main.swift:8 (xcodegen:x86_64+0x100004cb2)

  Thread T4 (tid=2113925, running) is a GCD worker thread

  Thread T1 (tid=2113922, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: Swift access race (xcodegen:x86_64+0x1004210db) in closure #1 in Dictionary<>.json<A>(atKeyPath:invalidItemBehaviour:parallel:)+0x8bb
==================
```

</details>

Fixed by using `withUnsafeMutableBuffer` to force a c-style buffer while this code writes to it, and using `DispatchQueue.concurrentPerform` to make the closure non-escaping. Now, TSan doesn't complain and I cannot reproduce the error!