### PR TITLE
Bugfix/StoreKitConfiguration BuildPhase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Fixed
+- Fixed regression on **.storekit** configuration files' default build phase. [#1026](https://github.com/yonaskolb/XcodeGen/pull/1026) @jcolicchio
+
 ## 2.19.0
 
 #### Added

--- a/Sources/ProjectSpec/FileType.swift
+++ b/Sources/ProjectSpec/FileType.swift
@@ -71,6 +71,7 @@ extension FileType {
         // resources
         "bundle": FileType(buildPhase: .resources),
         "xcassets": FileType(buildPhase: .resources),
+        "storekit": FileType(buildPhase: .resources),
 
         // sources
         "swift": FileType(buildPhase: .sources),
@@ -110,6 +111,5 @@ extension FileType {
         "xcfilelist": FileType(buildPhase: BuildPhaseSpec.none),
         "apns": FileType(buildPhase: BuildPhaseSpec.none),
         "pch": FileType(buildPhase: BuildPhaseSpec.none),
-        "storekit": FileType(buildPhase: BuildPhaseSpec.none),
     ]
 }

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -21,6 +21,7 @@ fileGroups:
   - FileGroup
   - SomeFile
   - Utilities
+  - App_iOS/Configuration.storekit
 projectReferences:
   AnotherProject:
     path: ./AnotherProject/AnotherProject.xcodeproj
@@ -76,6 +77,7 @@ targets:
           - "**/excluded-file"
           - "excluded-file"
           - "Model.xcmappingmodel"
+          - "Configuration.storekit"
       - path: App_iOS
         name: App
         includes:

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -591,6 +591,7 @@ class SourceGeneratorTests: XCTestCase {
                     - file.mlmodel
                     - Info.plist
                     - Intent.intentdefinition
+                    - Configuration.storekit
                     - Settings.bundle:
                       - en.lproj:
                         - Root.strings
@@ -646,6 +647,7 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFile(paths: ["C", "file.metal"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["C", "file.mlmodel"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["C", "Intent.intentdefinition"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: ["C", "Configuration.storekit"], buildPhase: .resources)
                 try pbxProj.expectFile(paths: ["C", "Settings.bundle"], buildPhase: .resources)
                 try pbxProj.expectFileMissing(paths: ["C", "Settings.bundle", "en.lproj"])
                 try pbxProj.expectFileMissing(paths: ["C", "Settings.bundle", "en.lproj", "Root.strings"])


### PR DESCRIPTION
This PR changes the default build phase for **.storekit** files from **.none** to **.resources**, since this is required for tests which want to load an arbitrary storekit configuration at runtime.

For use in schemes only, we can add the **.storekit** file via **fileGroups:** so that it won't be associated with any target, and won't be included in any bundle resources

Fixes #1025 