### PR TITLE
Add github helper for swift package url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Added
+- Allow specifying a `github` name like `JohnSundell/Ink` instead of a full `url` for Swift Packages [#1029](https://github.com/yonaskolb/XcodeGen/pull/1029) @yonaskolb
+
 #### Fixed
 - Fixed regression on **.storekit** configuration files' default build phase. [#1026](https://github.com/yonaskolb/XcodeGen/pull/1026) @jcolicchio
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -936,6 +936,7 @@ Swift packages are defined at a project level, and then linked to individual tar
   - `minVersion: 1.0.0, maxVersion: 1.2.9`
   - `branch: master`
   - `revision: xxxxxx`
+- [ ] **github** : **String**- this is an optional helper you can use for github repos. Instead of specifying the full url in `url` you can just specify the github org and repo
   
 ### Local Package
 
@@ -946,13 +947,11 @@ packages:
   Yams:
     url: https://github.com/jpsim/Yams
     from: 2.0.0
+  Yams:
+    github: JohnSundell/Ink
+    from: 0.5.0
   RxClient:
     path: ../RxClient
-targets:
-  App:
-    dependencies:
-      - package: Yams
-      - package: RxClient
 ```
 
 ## Project Reference

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -1175,6 +1175,7 @@ class SpecLoadingTests: XCTestCase {
                     "package7": .remote(url: "package.git", versionRequirement: .exact("1.2.2")),
                     "package8": .remote(url: "package.git", versionRequirement: .upToNextMajorVersion("4.0.0-beta.5")),
                     "package9": .local(path: "package/package"),
+                    "package10": .remote(url: "https://github.com/yonaskolb/XcodeGen", versionRequirement: .exact("1.2.2")),
                     "XcodeGen": .local(path: "../XcodeGen"),
                 ], options: .init(localPackagesGroup: "MyPackages"))
 
@@ -1193,6 +1194,7 @@ class SpecLoadingTests: XCTestCase {
                         "package7": ["url": "package.git", "version": "1.2.2"],
                         "package8": ["url": "package.git", "majorVersion": "4.0.0-beta.5"],
                         "package9": ["path": "package/package"],
+                        "package10": ["github": "yonaskolb/XcodeGen", "exactVersion": "1.2.2"],
                     ],
                     "localPackages": ["../XcodeGen"],
                 ]


### PR DESCRIPTION
This allows you to specify a simple github name instead of a full url for Swift Packages
```diff
packages:
  Ink:
-  url: https://github.com/JohnSundell/Ink
+  github: JohnSundell/Ink
   from: 0.5.0
```