### PR TITLE
Support `askForAppToLaunch` on profile scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Added
 - Allow specifying a `github` name like `JohnSundell/Ink` instead of a full `url` for Swift Packages [#1029](https://github.com/yonaskolb/XcodeGen/pull/1029) @yonaskolb
+- Added  `askForAppToLaunch` for `profile` in `schemes`  [#1029](https://github.com/yonaskolb/XcodeGen/pull/1035) @freddi-kit
+
 
 #### Fixed
 - Fixed regression on **.storekit** configuration files' default build phase. [#1026](https://github.com/yonaskolb/XcodeGen/pull/1026) @jcolicchio

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -777,7 +777,7 @@ The different actions share some properties:
 - [ ] **region**: **String** - `run` and `test` actions can define a language that is used for Application Region
 - [ ] **debugEnabled**: **Bool** - `run` and `test` actions can define a whether debugger should be used. This defaults to true.
 - [ ] **simulateLocation**: **[Simulate Location](#simulate-location)** - `run` action can define a simulated location
-- [ ] **askForAppToLaunch**: **Bool** - `run`  and `profile` actions can define the executable set to ask to launch. This defaults to false.
+- [ ] **askForAppToLaunch**: **Bool** - `run` and `profile` actions can define the executable set to ask to launch. This defaults to false.
 - [ ] **launchAutomaticallySubstyle**: **String** - `run` action can define the launch automatically substyle ('2' for extensions).
 - [ ] **storeKitConfiguration**: **String** - `run` action can specify a storekit configuration. See [Options](#options).
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -777,7 +777,7 @@ The different actions share some properties:
 - [ ] **region**: **String** - `run` and `test` actions can define a language that is used for Application Region
 - [ ] **debugEnabled**: **Bool** - `run` and `test` actions can define a whether debugger should be used. This defaults to true.
 - [ ] **simulateLocation**: **[Simulate Location](#simulate-location)** - `run` action can define a simulated location
-- [ ] **askForAppToLaunch**: **Bool** - `run` action can define the executable set to ask to launch. This defaults to false.
+- [ ] **askForAppToLaunch**: **Bool** - `run`  and `profile` actions can define the executable set to ask to launch. This defaults to false.
 - [ ] **launchAutomaticallySubstyle**: **String** - `run` action can define the launch automatically substyle ('2' for extensions).
 - [ ] **storeKitConfiguration**: **String** - `run` action can specify a storekit configuration. See [Options](#options).
 

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -260,18 +260,22 @@ public struct Scheme: Equatable {
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
         public var environmentVariables: [XCScheme.EnvironmentVariable]
+        public var askForAppToLaunch: Bool?
+
         public init(
             config: String,
             commandLineArguments: [String: Bool] = [:],
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
-            environmentVariables: [XCScheme.EnvironmentVariable] = []
+            environmentVariables: [XCScheme.EnvironmentVariable] = [],
+            askForAppToLaunch: Bool? = nil
         ) {
             self.config = config
             self.commandLineArguments = commandLineArguments
             self.preActions = preActions
             self.postActions = postActions
             self.environmentVariables = environmentVariables
+            self.askForAppToLaunch = askForAppToLaunch
         }
 
         public var shouldUseLaunchSchemeArgsEnv: Bool {
@@ -539,6 +543,9 @@ extension Scheme.Profile: JSONObjectConvertible {
         preActions = jsonDictionary.json(atKeyPath: "preActions") ?? []
         postActions = jsonDictionary.json(atKeyPath: "postActions") ?? []
         environmentVariables = try XCScheme.EnvironmentVariable.parseAll(jsonDictionary: jsonDictionary)
+        if let askLaunch: Bool = jsonDictionary.json(atKeyPath: "askForAppToLaunch") {
+            askForAppToLaunch = askLaunch
+        }
     }
 }
 
@@ -550,6 +557,7 @@ extension Scheme.Profile: JSONEncodable {
             "postActions": postActions.map { $0.toJSONValue() },
             "environmentVariables": environmentVariables.map { $0.toJSONValue() },
             "config": config,
+            "askForAppToLaunch": askForAppToLaunch,
         ] as [String: Any?]
     }
 }

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -269,6 +269,7 @@ public class SchemeGenerator {
             preActions: scheme.profile?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.profile?.postActions.map(getExecutionAction) ?? [],
             shouldUseLaunchSchemeArgsEnv: scheme.profile?.shouldUseLaunchSchemeArgsEnv ?? true,
+            askForAppToLaunch: scheme.profile?.askForAppToLaunch,
             commandlineArguments: profileCommandLineArgs,
             environmentVariables: profileVariables
         )

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -53,7 +53,8 @@ class SchemeGeneratorTests: XCTestCase {
                     name: "MyScheme",
                     build: Scheme.Build(targets: [buildTarget], preActions: [preAction]),
                     run: Scheme.Run(config: "Debug", askForAppToLaunch: true, launchAutomaticallySubstyle: "2", simulateLocation: simulateLocation, storeKitConfiguration: storeKitConfiguration, customLLDBInit: "/sample/.lldbinit"),
-                    test: Scheme.Test(config: "Debug", customLLDBInit: "/test/.lldbinit")
+                    test: Scheme.Test(config: "Debug", customLLDBInit: "/test/.lldbinit"),
+                    profile: Scheme.Profile(config: "Release", askForAppToLaunch: true)
                 )
                 let project = Project(
                     name: "test",
@@ -98,6 +99,7 @@ class SchemeGeneratorTests: XCTestCase {
                 try expect(xcscheme.testAction?.selectedDebuggerIdentifier) == XCScheme.defaultDebugger
 
                 try expect(xcscheme.launchAction?.askForAppToLaunch) == true
+                try expect(xcscheme.profileAction?.askForAppToLaunch) == true
                 try expect(xcscheme.launchAction?.launchAutomaticallySubstyle) == "2"
                 try expect(xcscheme.launchAction?.allowLocationSimulation) == true
                 try expect(xcscheme.launchAction?.storeKitConfigurationFileReference?.identifier) == "../Configuration.storekit"


### PR DESCRIPTION
# Summary
Support `askForAppToLaunch` on profile scheme

# What Changed?
Support `askForAppToLaunch` on profile scheme, same as `run`

```yml
schemes:
  SchemeName:
    build:
       ...
    run:
       ...
      askForAppToLaunch: true # run already supports
    profile:
      askForAppToLaunch: true # currently `profile` does not support
```
