### PR TITLE
Fix multiple targets named 'Core' in: GraphViz, XcodeGen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Fixed
+- Fix multiple targets named 'Core' in: GraphViz, XcodeGen [#1049](https://github.com/yonaskolb/XcodeGen/pull/1029) @d-date
+
 ## 2.20.0
 
 #### Added

--- a/Package.swift
+++ b/Package.swift
@@ -39,14 +39,14 @@ let package = Package(
             "JSONUtilities",
             "XcodeProj",
             "PathKit",
-            "Core",
+            .target(name: "Core"),
             "GraphViz",
         ]),
         .target(name: "ProjectSpec", dependencies: [
             "JSONUtilities",
             "XcodeProj",
             "Yams",
-            "Core",
+            .target(name: "Core"),
             "Version",
         ]),
         .target(name: "Core", dependencies: [
@@ -71,7 +71,7 @@ let package = Package(
             "TestSupport",
         ]),
         .testTarget(name: "CoreTests", dependencies: [
-            "Core",
+            .target(name: "Core"),
             "Spectre",
             "PathKit",
             "TestSupport",

--- a/Package.swift
+++ b/Package.swift
@@ -39,20 +39,20 @@ let package = Package(
             "JSONUtilities",
             "XcodeProj",
             "PathKit",
-            .target(name: "Core"),
+            .target(name: "XcodeGenCore"),
             "GraphViz",
         ]),
         .target(name: "ProjectSpec", dependencies: [
             "JSONUtilities",
             "XcodeProj",
             "Yams",
-            .target(name: "Core"),
+            .target(name: "XcodeGenCore"),
             "Version",
         ]),
-        .target(name: "Core", dependencies: [
+        .target(name: "XcodeGenCore", dependencies: [
             "PathKit",
             "Yams",
-        ]),
+        ], path: "Sources/Core"),
         .target(name: "TestSupport", dependencies: [
             "XcodeProj",
             "Spectre",
@@ -71,7 +71,7 @@ let package = Package(
             "TestSupport",
         ]),
         .testTarget(name: "CoreTests", dependencies: [
-            .target(name: "Core"),
+            .target(name: "XcodeGenCore"),
             "Spectre",
             "PathKit",
             "TestSupport",

--- a/Package.swift
+++ b/Package.swift
@@ -39,14 +39,14 @@ let package = Package(
             "JSONUtilities",
             "XcodeProj",
             "PathKit",
-            .target(name: "XcodeGenCore"),
+            "XcodeGenCore",
             "GraphViz",
         ]),
         .target(name: "ProjectSpec", dependencies: [
             "JSONUtilities",
             "XcodeProj",
             "Yams",
-            .target(name: "XcodeGenCore"),
+            "XcodeGenCore",
             "Version",
         ]),
         .target(name: "XcodeGenCore", dependencies: [
@@ -71,7 +71,7 @@ let package = Package(
             "TestSupport",
         ]),
         .testTarget(name: "CoreTests", dependencies: [
-            .target(name: "XcodeGenCore"),
+            "XcodeGenCore",
             "Spectre",
             "PathKit",
             "TestSupport",

--- a/Sources/ProjectSpec/CacheFile.swift
+++ b/Sources/ProjectSpec/CacheFile.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Core
+import XcodeGenCore
 import Version
 
 public class CacheFile {

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -3,7 +3,7 @@ import SwiftCLI
 import ProjectSpec
 import XcodeGenKit
 import PathKit
-import Core
+import XcodeGenCore
 import Version
 
 class ProjectCommand: Command {

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -2,7 +2,7 @@ import Foundation
 import PathKit
 import ProjectSpec
 import XcodeProj
-import Core
+import XcodeGenCore
 
 struct SourceFile {
     let path: Path

--- a/Tests/CoreTests/GlobTests.swift
+++ b/Tests/CoreTests/GlobTests.swift
@@ -7,7 +7,7 @@
 //  Adapted from https://gist.github.com/efirestone/ce01ae109e08772647eb061b3bb387c3
 
 import XCTest
-@testable import Core
+@testable import XcodeGenCore
 
 class GlobTests: XCTestCase {
 

--- a/Tests/CoreTests/PathExtensionsTests.swift
+++ b/Tests/CoreTests/PathExtensionsTests.swift
@@ -1,7 +1,7 @@
 import Spectre
 import PathKit
 import XCTest
-import Core
+import XcodeGenCore
 import TestSupport
 
 class PathExtensionsTests: XCTestCase {


### PR DESCRIPTION
Fix #1048 