### PR TITLE
Add support for specifying Info.plist paths in an xcconfig using `SRCROOT` and `PRODUCT_NAME` variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Next Version
 
+#### Added
+- Add support for specifying Info.plist paths in an xcconfig using `SRCROOT` and `PRODUCT_NAME` variables [#1058](https://github.com/yonaskolb/XcodeGen/pull/1058) @dalemyers
+
+#### Fixed
+
+#### Internal
+
+
 ## 2.20.0
 
 #### Added


### PR DESCRIPTION
If the info plist is set in an xcconfig then it has access to the same variables that Xcode uses. The most common of these for paths are `SRCROOT` and `PRODUCT_NAME`. This adds support for replacing those variables during evaluation.

Example: If you specify your Info.plist as `$(SRCROOT)/SomePath/$(PRODUCT_NAME)/Info.plist` then, while it will be found and used, it won't be recognised as the canonical one, and therefore will be added to the copy resources phase. With this change, `/some/path/on/disk/project/SomePath/MyTarget/Info.plist` and `$(SRCROOT)/SomePath/$(PRODUCT_NAME)/Info.plist` are treated as the same (assuming `SRCROOT` = `/some/path/on/disk/project` and `PRODUCT_NAME` = `MyTarget`)