### PR TITLE
Update graphviz to 0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         xcodebuild -version
         swift --version
         swift package --version
+    - name: Install System Dependencies
+      run: |
+        brew install graphviz
     - name: Resolve
       run: swift package resolve
     - name: Build
@@ -37,5 +40,9 @@ jobs:
     name: Linux
     steps:
       - uses: actions/checkout@master
+      - name: Install System Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-dev graphviz-dev
       - name: Build and run tests
         run: swift test --enable-test-discovery

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/GraphViz.git",
         "state": {
           "branch": null,
-          "revision": "70bebcf4597b9ce33e19816d6bbd4ba9b7bdf038",
-          "version": "0.2.0"
+          "revision": "e9a73a30755c3c5b26ba7c73312b1f2ccb9a1a30",
+          "version": "0.4.0"
         }
       },
       {

--- a/Sources/XcodeGenKit/GraphVizGenerator.swift
+++ b/Sources/XcodeGenKit/GraphVizGenerator.swift
@@ -1,4 +1,3 @@
-import DOT
 import Foundation
 import GraphViz
 import ProjectSpec


### PR DESCRIPTION
When I use XcodeGen as dependency, SwiftPM fetches latest GraphViz package.
So it causes compilation error.

related? #1057 #1049