### PR TITLE
Fix no such module 'DOT'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Fixed
+- Fixed no such mocule `DOT` error [#1065](https://github.com/yonaskolb/XcodeGen/pull/1065) @yanamura
+
 ## 2.21.0
 
 #### Added

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/GraphViz.git",
         "state": {
           "branch": null,
-          "revision": "70bebcf4597b9ce33e19816d6bbd4ba9b7bdf038",
-          "version": "0.2.0"
+          "revision": "e9a73a30755c3c5b26ba7c73312b1f2ccb9a1a30",
+          "version": "0.4.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/XcodeProj.git", from: "7.18.0"),
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.0"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
-        .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", from: "0.1.0"),
+        .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", from: "0.4.0"),
     ],
     targets: [
         .target(name: "XcodeGen", dependencies: [

--- a/Sources/XcodeGenKit/GraphVizGenerator.swift
+++ b/Sources/XcodeGenKit/GraphVizGenerator.swift
@@ -1,4 +1,3 @@
-import DOT
 import Foundation
 import GraphViz
 import ProjectSpec


### PR DESCRIPTION
## Problem
create `cli` folder and put this Package.swift
```
// swift-tools-version:5.1
import PackageDescription

let package = Package(
    name: "Tools",
    dependencies: [
        .package(url: "https://github.com/yonaskolb/XcodeGen", .branch("master"))
    ]
)
```

and run
`swift run --package-path cli xcodegen`

cause this error
```
XcodeGen/Sources/XcodeGenKit/GraphVizGenerator.swift:1:8: error: no such module 'DOT'
import DOT`
```

## Solution
Update GraphViz 0.2.0 to 0.4.0
[diff](https://github.com/SwiftDocOrg/GraphViz/compare/0.2.0...0.4.0)

With this update, we no longer to import Dot.
```
Changed package to produce a single library named `GraphViz` so that
  `Dot`, `Tools`, and `GraphVizBuilder` need not be imported separately anymore.
```