### PR TITLE
Fix config variant lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixed
 - Fixed no such module `DOT` error when package is used as a dependency [#1067](https://github.com/yonaskolb/XcodeGen/pull/1067) @yanamura
+- Fixed scheme config variant lookups for some configs like `ProdDebug` and `Prod-Debug` that broke in 2.21.0 [#1070](https://github.com/yonaskolb/XcodeGen/pull/1070) @yonaskolb
 
 [Commits](https://github.com/yonaskolb/XcodeGen/compare/2.21.0...2.21.1)
 

--- a/Sources/ProjectSpec/Config.swift
+++ b/Sources/ProjectSpec/Config.swift
@@ -22,22 +22,20 @@ public enum ConfigType: String {
     }
 }
 
-public extension Collection where Element == Config {
-    func first(including configVariant: String, for type: ConfigType) -> Config? {
-        first(where: { $0.type == type && $0.name.variantName(for: $0.type) == configVariant })
+extension Config {
+
+    public func matchesVariant(_ variant: String, for type: ConfigType) -> Bool {
+        guard self.type == type else { return false }
+        let nameWithoutType = self.name.lowercased()
+            .replacingOccurrences(of: type.name.lowercased(), with: "")
+            .trimmingCharacters(in: CharacterSet(charactersIn: " -_"))
+        return nameWithoutType == variant.lowercased()
     }
 }
 
-private extension String {
-    func variantName(for configType: ConfigType?) -> String {
-        self.components(separatedBy: " ")
-            .compactMap { component in
-                if component.lowercased() == (configType?.name.lowercased() ?? "") {
-                    return nil
-                }
-                return component
-            }
-            .joined(separator: " ")
-            .trimmingCharacters(in: CharacterSet.whitespaces)
+public extension Collection where Element == Config {
+    func first(including configVariant: String, for type: ConfigType) -> Config? {
+        first { $0.matchesVariant(configVariant, for: type) }
     }
 }
+

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -339,6 +339,27 @@ class ProjectSpecTests: XCTestCase {
                 project.schemes = [scheme]
                 try project.validate()
             }
+
+            $0.it("validates scheme variants") {
+
+                func expectVariant(_ variant: String, type: ConfigType = .debug, for config: Config, matches: Bool, file: String = #file, line: Int = #line) throws {
+                    let configs = [Config(name: "xxxxxxxxxxx", type: .debug), config]
+                    let foundConfig = configs.first(including: variant, for: type)
+                    let found = foundConfig != nil && foundConfig != configs[0]
+                    try expect(found, file: file, line: line) == matches
+                }
+
+                try expectVariant("Dev", for: Config(name: "DevDebug", type: .debug), matches: true)
+                try expectVariant("Dev", for: Config(name: "Dev debug", type: .debug), matches: true)
+                try expectVariant("Dev", for: Config(name: "DEV DEBUG", type: .debug), matches: true)
+                try expectVariant("Dev", for: Config(name: "Debug Dev", type: .debug), matches: true)
+                try expectVariant("Dev", for: Config(name: "dev Debug", type: .debug), matches: true)
+                try expectVariant("Dev", for: Config(name: "Dev debug", type: .release), matches: false)
+                try expectVariant("Dev", for: Config(name: "Dev-debug", type: .debug), matches: true)
+                try expectVariant("Dev", for: Config(name: "Dev_debug", type: .debug), matches: true)
+                try expectVariant("Prod", for: Config(name: "PreProd debug", type: .debug), matches: false)
+                try expectVariant("Develop", for: Config(name: "Dev debug", type: .debug), matches: false)
+            }
         }
     }
 

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -197,11 +197,11 @@ class SchemeGeneratorTests: XCTestCase {
                 var target = app
                 target.scheme = TargetScheme(configVariants: configVariants)
                 
-                // Including here a double test for custom upper/lowercase in config types
+                // Including here a double test for custom upper/lowercase, and dash delimited in config types
                 let configs: [Config] = [
-                    Config(name: "Test Debug", type: .debug),
+                    Config(name: "Test-Debug", type: .debug),
                     Config(name: "PreProd debug", type: .debug),
-                    Config(name: "Prod Debug", type: .debug),
+                    Config(name: "Prod-Debug", type: .debug),
                     Config(name: "Test Release", type: .release),
                     Config(name: "PreProd release", type: .release),
                     Config(name: "Prod Release", type: .release),
@@ -224,10 +224,10 @@ class SchemeGeneratorTests: XCTestCase {
                         try expect(xcscheme.analyzeAction?.buildConfiguration) == "\(variantName) debug"
                         try expect(xcscheme.archiveAction?.buildConfiguration) == "\(variantName) release"
                     } else {
-                        try expect(xcscheme.launchAction?.buildConfiguration) == "\(variantName) Debug"
-                        try expect(xcscheme.testAction?.buildConfiguration) == "\(variantName) Debug"
+                        try expect(xcscheme.launchAction?.buildConfiguration) == "\(variantName)-Debug"
+                        try expect(xcscheme.testAction?.buildConfiguration) == "\(variantName)-Debug"
                         try expect(xcscheme.profileAction?.buildConfiguration) == "\(variantName) Release"
-                        try expect(xcscheme.analyzeAction?.buildConfiguration) == "\(variantName) Debug"
+                        try expect(xcscheme.analyzeAction?.buildConfiguration) == "\(variantName)-Debug"
                         try expect(xcscheme.archiveAction?.buildConfiguration) == "\(variantName) Release"
                     }
                 }


### PR DESCRIPTION
This fixes some cases https://github.com/yonaskolb/XcodeGen/issues/975 broke when looking up config variants, with config names like `DevDebug` or `Dev-Debug`. 
This still keeps the original fix where `Prod` doesn't return `PreProd`