### PR TITLE
Support runPostActionsOnFailure on build scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 2.21.1
 
+#### Added
+- Support `runPostActionsOnFailure` for running build post scripts on failing build [#----](https://github.com/yonaskolb/XcodeGen/pull/----) @freddi-kit
+
 #### Fixed
 - Fixed no such module `DOT` error when package is used as a dependency [#1067](https://github.com/yonaskolb/XcodeGen/pull/1067) @yanamura
 - Fixed scheme config variant lookups for some configs like `ProdDebug` and `Prod-Debug` that broke in 2.21.0 [#1070](https://github.com/yonaskolb/XcodeGen/pull/1070) @yonaskolb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 2.21.1
 
 #### Added
-- Support `runPostActionsOnFailure` for running build post scripts on failing build [#----](https://github.com/yonaskolb/XcodeGen/pull/----) @freddi-kit
+- Support `runPostActionsOnFailure` for running build post scripts on failing build [#1073](https://github.com/yonaskolb/XcodeGen/pull/1073) @freddi-kit
 
 #### Fixed
 - Fixed no such module `DOT` error when package is used as a dependency [#1067](https://github.com/yonaskolb/XcodeGen/pull/1067) @yanamura

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -752,6 +752,11 @@ Schemes allows for more control than the convenience [Target Scheme](#target-sch
   - `true`: Discover implicit dependencies of this scheme
   - `false`: Only build explicit dependencies of this scheme
 
+- [ ] **runPostActionsOnFailure**: **Bool** - Flag to determine if Xcode should run post scripts despite failure build. By default this is `false` if not set.
+- `true`: Run post scripts even if build is failed
+- `false`: Only run post scripts if build success
+
+
 ```yaml
 targets:
   MyTarget: all

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -73,25 +73,29 @@ public struct Scheme: Equatable {
     public struct Build: Equatable {
         public static let parallelizeBuildDefault = true
         public static let buildImplicitDependenciesDefault = true
+        public static let runPostActionsOnFailureDefault = false
 
         public var targets: [BuildTarget]
         public var parallelizeBuild: Bool
         public var buildImplicitDependencies: Bool
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
+        public var runPostActionsOnFailure: Bool
 
         public init(
             targets: [BuildTarget],
             parallelizeBuild: Bool = parallelizeBuildDefault,
             buildImplicitDependencies: Bool = buildImplicitDependenciesDefault,
             preActions: [ExecutionAction] = [],
-            postActions: [ExecutionAction] = []
+            postActions: [ExecutionAction] = [],
+            runPostActionsOnFailure: Bool = false
         ) {
             self.targets = targets
             self.parallelizeBuild = parallelizeBuild
             self.buildImplicitDependencies = buildImplicitDependencies
             self.preActions = preActions
             self.postActions = postActions
+            self.runPostActionsOnFailure = runPostActionsOnFailure
         }
     }
 
@@ -671,6 +675,7 @@ extension Scheme.Build: JSONObjectConvertible {
         postActions = try jsonDictionary.json(atKeyPath: "postActions")?.map(Scheme.ExecutionAction.init) ?? []
         parallelizeBuild = jsonDictionary.json(atKeyPath: "parallelizeBuild") ?? Scheme.Build.parallelizeBuildDefault
         buildImplicitDependencies = jsonDictionary.json(atKeyPath: "buildImplicitDependencies") ?? Scheme.Build.buildImplicitDependenciesDefault
+        runPostActionsOnFailure = jsonDictionary.json(atKeyPath: "runPostActionsOnFailure") ?? Scheme.Build.runPostActionsOnFailureDefault
     }
 }
 
@@ -689,6 +694,9 @@ extension Scheme.Build: JSONEncodable {
         }
         if buildImplicitDependencies != Scheme.Build.buildImplicitDependenciesDefault {
             dict["buildImplicitDependencies"] = buildImplicitDependencies
+        }
+        if runPostActionsOnFailure != Scheme.Build.runPostActionsOnFailureDefault {
+            dict["runPostActionsOnFailure"] = runPostActionsOnFailure
         }
 
         return dict

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -183,7 +183,8 @@ public class SchemeGenerator {
             preActions: scheme.build.preActions.map(getExecutionAction),
             postActions: scheme.build.postActions.map(getExecutionAction),
             parallelizeBuild: scheme.build.parallelizeBuild,
-            buildImplicitDependencies: scheme.build.buildImplicitDependencies
+            buildImplicitDependencies: scheme.build.buildImplicitDependencies,
+            runPostActionsOnFailure: scheme.build.runPostActionsOnFailure
         )
 
         let testables = zip(testTargets, testBuildTargetEntries).map { testTarget, testBuilEntries in

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
@@ -5,7 +5,7 @@
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "NO"
-      runPostActionsOnFailure = "NO">
+      runPostActionsOnFailure = "YES">
       <PreActions>
          <ExecutionAction
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -341,6 +341,7 @@ schemes:
       preActions:
         - script: echo Starting Framework Build
           settingsTarget: Framework_iOS
+      runPostActionsOnFailure: true
     run:
       commandLineArguments:
         argument: YES

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -756,6 +756,7 @@ class SpecLoadingTests: XCTestCase {
                     "build": [
                         "parallelizeBuild": false,
                         "buildImplicitDependencies": false,
+                        "runPostActionsOnFailure": true,
                         "targets": [
                             "Target1": "all",
                             "Target2": "testing",
@@ -813,6 +814,7 @@ class SpecLoadingTests: XCTestCase {
 
                 try expect(scheme.build.parallelizeBuild) == false
                 try expect(scheme.build.buildImplicitDependencies) == false
+                try expect(scheme.build.runPostActionsOnFailure) == true
 
                 let expectedRun = Scheme.Run(
                     config: "debug",
@@ -981,6 +983,7 @@ class SpecLoadingTests: XCTestCase {
                             "build": [
                                 "parallelizeBuild": false,
                                 "buildImplicitDependencies": false,
+                                "runPostActionsOnFailure": true,
                                 "targets": [
                                     "Target${name_1}": "all",
                                     "Target2": "testing",
@@ -1046,6 +1049,7 @@ class SpecLoadingTests: XCTestCase {
 
                 try expect(scheme.build.parallelizeBuild) == false
                 try expect(scheme.build.buildImplicitDependencies) == false
+                try expect(scheme.build.runPostActionsOnFailure) == true
 
                 try expect(scheme.run?.storeKitConfiguration) == "Configuration.storekit"
 

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -69,6 +69,7 @@ class SchemeGeneratorTests: XCTestCase {
                 try expect(scheme.name) == "MyScheme"
                 try expect(xcscheme.buildAction?.buildImplicitDependencies) == true
                 try expect(xcscheme.buildAction?.parallelizeBuild) == true
+                try expect(xcscheme.buildAction?.runPostActionsOnFailure) == false
                 try expect(xcscheme.buildAction?.preActions.first?.title) == "Script"
                 try expect(xcscheme.buildAction?.preActions.first?.scriptText) == "echo Starting"
                 try expect(xcscheme.buildAction?.preActions.first?.environmentBuildable?.buildableName) == "MyApp.app"


### PR DESCRIPTION
# What is it for?
Now, tuist/XcodeProj supports `runPostActionsOnFailure`. XcodeGen can also use it. https://github.com/tuist/XcodeProj/pull/603