### PR TITLE
Revert "Change FRAMEWORK_SEARCH_PATH for xcframeworks (#1015)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+#### Fixed
+- Reverted "Change FRAMEWORK_SEARCH_PATH for xcframeworks (#1015)", introduced in 2.20.0. XCFrameworks need to be
+  referenced directly in the project for Xcode's build system to extract the appropriate frameworks.
+
 ## 2.22.0
 
 #### Added
@@ -41,6 +45,7 @@
 
 #### Fixed
 - Fixed regression on `.storekit` configuration files' default build phase. [#1026](https://github.com/yonaskolb/XcodeGen/pull/1026) @jcolicchio
+- Fixed framework search paths when using `.xcframework`s. [#1015](https://github.com/yonaskolb/XcodeGen/pull/1015) @FranzBusch
 - Fixed bug where schemes without a build target would crash instead of displaying an error [#1040](https://github.com/yonaskolb/XcodeGen/pull/1040) @dalemyers
 - Fixed files with names ending in **Info.plist** (such as **GoogleServices-Info.plist**) from being omitted from the Copy Resources build phase. Now, only the resolved info plist file for each specific target is omitted. [#1027](https://github.com/yonaskolb/XcodeGen/pull/1027) @liamnichols
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@
 
 #### Fixed
 - Fixed regression on `.storekit` configuration files' default build phase. [#1026](https://github.com/yonaskolb/XcodeGen/pull/1026) @jcolicchio
-- Fixed framework search paths when using `.xcframework`s. [#1015](https://github.com/yonaskolb/XcodeGen/pull/1015) @FranzBusch
 - Fixed bug where schemes without a build target would crash instead of displaying an error [#1040](https://github.com/yonaskolb/XcodeGen/pull/1040) @dalemyers
 - Fixed files with names ending in **Info.plist** (such as **GoogleServices-Info.plist**) from being omitted from the Copy Resources build phase. Now, only the resolved info plist file for each specific target is omitted. [#1027](https://github.com/yonaskolb/XcodeGen/pull/1027) @liamnichols
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 #### Fixed
 - Reverted "Change FRAMEWORK_SEARCH_PATH for xcframeworks (#1015)", introduced in 2.20.0. XCFrameworks need to be
-  referenced directly in the project for Xcode's build system to extract the appropriate frameworks.
+  referenced directly in the project for Xcode's build system to extract the appropriate frameworks [#1081](https://github.com/yonaskolb/XcodeGen/pull/1081) @elliottwilliams
 
 ## 2.22.0
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -122,7 +122,7 @@ Note that target names can also be changed by adding a `name` property to a targ
 - [ ] **groupOrdering**: **[[GroupOrdering]](#groupOrdering)** - An order of groups.
 - [ ] **transitivelyLinkDependencies**: **Bool** - If this is `true` then targets will link to the dependencies of their target dependencies. If a target should embed its dependencies, such as application and test bundles, it will embed these transitive dependencies as well. Some complex setups might want to set this to `false` and explicitly specify dependencies at every level. Targets can override this with [Target](#target).transitivelyLinkDependencies. Defaults to `false`.
 - [ ] **generateEmptyDirectories**: **Bool** - If this is `true` then empty directories will be added to project too else will be missed. Defaults to `false`.
-- [ ] **findCarthageFrameworks**: **Bool** - When this is set to `true`, all the invididual frameworks for Carthage dependencies will automatically be found. This property can be overriden individually for each carthage dependency - for more details see See **findFrameworks** in the [Dependency](#dependency) section. Defaults to `false`.
+- [ ] **findCarthageFrameworks**: **Bool** - When this is set to `true`, all the invididual frameworks for Carthage framework dependencies will automatically be found. This property can be overriden individually for each carthage dependency - for more details see See **findFrameworks** in the [Dependency](#dependency) section. Defaults to `false`.
 - [ ] **localPackagesGroup**: **String** - The group name that local packages are put into. This defaults to `Packages`
 - [ ] **fileTypes**: **[String: [FileType](#filetype)]** - A list of default file options for specific file extensions across the project. Values in [Sources](#sources) will overwrite these settings.
 - [ ] **preGenCommand**: **String** - A bash command to run before the project has been generated. If the project isn't generated due to no changes when using the cache then this won't run. This is useful for running things like generating resources files before the project is regenerated.
@@ -232,7 +232,7 @@ Settings are merged in the following order: groups, base, configs.
 - [ ] **configFiles**: **[Config Files](#config-files)** - `.xcconfig` files per config
 - [ ] **settings**: **[Settings](#settings)** - Target specific build settings. Default platform and product type settings will be applied first before any custom settings defined here. Other context dependant settings will be set automatically as well:
 	- `INFOPLIST_FILE`: If it doesn't exist your sources will be searched for `Info.plist` files and the first one found will be used for this setting
-	- `FRAMEWORK_SEARCH_PATHS`: If carthage dependencies are used, the platform build path will be added to this setting
+	- `FRAMEWORK_SEARCH_PATHS`: If carthage framework dependencies are used, the platform build path will be added to this setting
 	- `OTHER_LDFLAGS`:  See `requiresObjCLinking` below
   - `TEST_TARGET_NAME`: for ui tests that target an application
   - `TEST_HOST`: for unit tests that target an application
@@ -250,7 +250,7 @@ Settings are merged in the following order: groups, base, configs.
 - [ ] **templates**: **[String]** - A list of [Target Templates](#target-template) referenced by name that will be merged with the target in order. Any instances of `${target_name}` within these templates will be replaced with the target name.
 - [ ] **templateAttributes**: **[String: String]** - A list of attributes where each instance of `${attributeName}` within the templates listed in `templates` will be replaced with the value specified.
 - [ ] **transitivelyLinkDependencies**: **Bool** - If this is not specified the value from the project set in [Options](#options)`.transitivelyLinkDependencies` will be used.
-- [ ] **directlyEmbedCarthageDependencies**: **Bool** - If this is `true` Carthage dependencies will be embedded using an `Embed Frameworks` build phase instead of the `copy-frameworks` script. Defaults to `true` for all targets except iOS/tvOS/watchOS Applications.
+- [ ] **directlyEmbedCarthageDependencies**: **Bool** - If this is `true` Carthage framework dependencies will be embedded using an `Embed Frameworks` build phase instead of the `copy-frameworks` script. Defaults to `true` for all targets except iOS/tvOS/watchOS Applications.
 - [ ] **requiresObjCLinking**: **Bool** - If this is `true` any targets that link to this target will have `-ObjC` added to their `OTHER_LDFLAGS`. This is required if a static library has any catagories or extensions on Objective-C code. See [this guide](https://pewpewthespells.com/blog/objc_linker_flags.html#objc) for more details. Defaults to `true` if `type` is `library.static`. If you are 100% sure you don't have catagories or extensions on Objective-C code (pure Swift with no use of Foundation/UIKit) you can set this to `false`, otherwise it's best to leave it alone.
 - [ ] **onlyCopyFilesOnInstall**: **Bool** – If this is `true`, the `Embed Frameworks` and `Embed App Extensions` (if available) build phases will have the "Copy only when installing" chekbox checked. Defaults to `false`.
 - [ ] **preBuildScripts**: **[[Build Script](#build-script)]** - Build scripts that run *before* any other build phases
@@ -415,8 +415,8 @@ targets:
 A dependency can be one of a 6 types:
 
 - `target: name` - links to another target. If you are using project references you can specify a target within another project by using `ProjectName/TargetName` for the name
-- `framework: path` - links to a framework
-- `carthage: name` - helper for linking to a Carthage framework
+- `framework: path` - links to a framework or XCFramework
+- `carthage: name` - helper for linking to a Carthage framework (not XCFramework)
 - `sdk: name` - links to a dependency with the SDK. This can either be a relative path within the sdk root or a single filename that references a framework (.framework) or lib (.tbd)
 - `package: name` - links to a Swift Package. The name must match the name of a package defined in the top level `packages`
 - `bundle: name` - adds the pre-built bundle for the supplied name to the copy resources build phase. This is useful when a dependency exists on a static library target that has an associated bundle target, both existing in a separate project. Only usable in target types which can copy resources.
@@ -445,6 +445,9 @@ Carthage frameworks are expected to be in `CARTHAGE_BUILD_PATH/PLATFORM/FRAMEWOR
  - `CARTHAGE_BUILD_PATH` = `options.carthageBuildPath` or `Carthage/Build` by default
  - `PLATFORM` = the target's platform
  - `FRAMEWORK` = the specified name.
+
+ To link an XCFramework produced by Carthage (in `CARTHAGE_BUILD_PATH/FRAMEWORK.xcframework`), use a normal `framework:`
+ dependency. The helper logic provided by this dependency type is not necessary.
 
 All the individual frameworks of a Carthage dependency can be automatically found via `findFrameworks: true`. This overrides the value of [Options](#options).findCarthageFrameworks. Otherwise each one will have to be listed individually.
 Xcodegen uses `.version` files generated by Carthage in order for this framework lookup to work, so the Carthage dependencies will need to have already been built at the time XcodeGen is run.

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -767,19 +767,9 @@ public class PBXProjGenerator {
 
             case .framework:
                 if !dependency.implicit {
-                    let buildPath = Path(dependency.reference)
-                    let buildPathString: String
-                    
-                    if buildPath.extension == "xcframework" {
-                        buildPathString = """
-                        "\(Path(dependency.reference).string)/**"
-                        """
-                    } else {
-                        buildPathString = buildPath.parent().string.quoted
-                    }
-                    frameworkBuildPaths.insert(buildPathString)
+                    let buildPath = Path(dependency.reference).parent().string.quoted
+                    frameworkBuildPaths.insert(buildPath)
                 }
-                
 
                 let fileReference: PBXFileElement
                 if dependency.implicit {

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -1369,45 +1369,6 @@ class ProjectGeneratorTests: XCTestCase {
                 // generated plist should not be in buildsettings
                 try expect(targetConfig.buildSettings["INFOPLIST_FILE"] as? String) == predefinedPlistPath
             }
-            
-            describe("XCFramework dependencies") {
-                $0.context("with xcframework dependency") {
-                    $0.it("should add FRAMEWORK_SEARCH_PATHS") {
-                        let app = Target(
-                            name: "MyApp",
-                            type: .application,
-                            platform: .iOS,
-                            dependencies: [
-                                Dependency(type: .framework, reference: "some/folder/MyXCFramework.xcframework"),
-                            ]
-                        )
-                        let project = Project(name: "test", targets: [app])
-                        let pbxProject = try project.generatePbxProj()
-                        
-                        let target = pbxProject.nativeTargets.first!
-                        let configuration = target.buildConfigurationList!.buildConfigurations.first!
-                        try expect(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String]) == ["$(inherited)", "\"some/folder/MyXCFramework.xcframework/**\""]
-                    }
-                }
-                $0.context("with regular framework") {
-                    $0.it("should add FRAMEWORK_SEARCH_PATHS") {
-                        let app = Target(
-                            name: "MyApp",
-                            type: .application,
-                            platform: .iOS,
-                            dependencies: [
-                                Dependency(type: .framework, reference: "some/folder/MyXCFramework.framework"),
-                            ]
-                        )
-                        let project = Project(name: "test", targets: [app])
-                        let pbxProject = try project.generatePbxProj()
-                        
-                        let target = pbxProject.nativeTargets.first!
-                        let configuration = target.buildConfigurationList!.buildConfigurations.first!
-                        try expect(configuration.buildSettings["FRAMEWORK_SEARCH_PATHS"] as? [String]) == ["$(inherited)", "\"some/folder\""]
-                    }
-                }
-            }
 
             describe("Carthage dependencies") {
                 $0.context("with static dependency") {


### PR DESCRIPTION
Hey! Sorry if there's a better way to propose this, but I think there are some issues with #1015 that slipped into production:

As implemented, if you declare a dependency on an XCFramework, then XcodeGen will add _every framework bundle inside the XCFramework_ to the target's FRAMEWORK_SEARCH_PATHS. For example, if I declare

```yaml
- framework: Carthage/Build/Dwifft.xcframework
```

the resulting compile command looks like

    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift \
    … \
    -F /Users/emw/Library/Developer/Xcode/DerivedData/project-fwonskwjwimmihaeflmjkuwijxnn/Build/Products/Debug-iphonesimulator \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_armv7 \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_i386_x86_64-simulator \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_armv7/BCSymbolMaps \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_armv7/dSYMs \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_i386_x86_64-simulator/dSYMs \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_armv7/dSYMs/Dwifft.framework.dSYM \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_i386_x86_64-simulator/dSYMs/Dwifft.framework.dSYM \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_armv7/dSYMs/Dwifft.framework.dSYM/Contents \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_i386_x86_64-simulator/dSYMs/Dwifft.framework.dSYM/Contents \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_armv7/dSYMs/Dwifft.framework.dSYM/Contents/Resources \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_i386_x86_64-simulator/dSYMs/Dwifft.framework.dSYM/Contents/Resources \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_armv7/dSYMs/Dwifft.framework.dSYM/Contents/Resources/DWARF \
    -F /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_i386_x86_64-simulator/dSYMs/Dwifft.framework.dSYM/Contents/Resources/DWARF

This is suboptimal for a number of reasons:

1. **Xcode doesn't need any of these search paths, and if you add an xcframework to a project manually, these search paths are not present.** When Xcode builds a target that links an XCFramework, it extracts the appropriate framework from the .xcframework bundle into BUILT_PRODUCTS_DIR. This shows up in build logs as a "ProcessXCFramework" step. So the framework we actually want the compiler to use is not in any of these paths, it's in DerivedData.

2. If for some reason the extracted framework in DerivedData is missing, **these search paths do not provide a useful fallback**, because the compiler will attempt to link the first framework it finds, and the framework inside the .xcframework bundle are target-specific. So if I were building for a simulator (target: `arm64-apple-ios13.0-simulator`), in the above scenario the compiler would find the framework at `Dwifft.xcframework/ios-arm64_armv7/Dwifft.framework˙` (target: `arm64-apple-ios8.0`), and emit an error:

       error: module 'Dwifft' was created for incompatible target arm64-apple-ios8.0: /Users/emw/project/Carthage/Build/Dwifft.xcframework/ios-arm64_armv7/Dwifft.framework/Modules/Dwifft.swiftmodule/arm64.swiftmodule

3. The extra search paths amount to ~1.5KB of arguments per xcframework in many circumstances. This is a bit of a scalability issue, since the compile command is limited by ARG_MAX (1MB on most macs) and the length of the command scales with the number of xcframeworks.

This change reverts that PR and clarifies how to integrate XCFrameworks in the docs.

I think a preferable solution to the issue described in #1015 would have been to reconfigure the target to reference the xcframework directly (not indirectly via something like `OTHER_LDFLAGS`), and to make sure that target was building to the same BUILT_PRODUCTS_DIR as the rest of the project.