### PR TITLE
Add ability to set executable to an external application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next Version
 
 #### Added
-- Added ability to set executable to an external application by providing a `filePath` in the Run Action
+- Added ability to set executable to an external application by providing a `filePath` in the Run Action [#1085](https://github.com/yonaskolb/XcodeGen/pull/1085) @platysma
 
 ## 2.23.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next Version
 
+#### Added
+- Added ability to set executable to an external application by providing a `filePath` in the Run Action
+
 ## 2.23.1
 
 ### Changed

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -803,7 +803,7 @@ A multiline script can be written using the various YAML multiline methods, for 
 
 ### Run Action
 - [ ] **executable**: **String** - the name of the target to launch as an executable. Defaults to the first runnable build target in the scheme, or the first build target if a runnable build target is not found
-- [ ] **filePath**: **String** - the absolute path to an external program to launch as an executable.
+- [ ] **filePath**: **String** - the absolute path to an external program to launch as an executable. This value is applied if `executable` is not set
 - [ ] **customLLDBInit**: **String** - the absolute path to the custom `.lldbinit` file
 
 ### Test Action

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -803,6 +803,7 @@ A multiline script can be written using the various YAML multiline methods, for 
 
 ### Run Action
 - [ ] **executable**: **String** - the name of the target to launch as an executable. Defaults to the first runnable build target in the scheme, or the first build target if a runnable build target is not found
+- [ ] **filePath**: **String** - the absolute path to an external program to launch as an executable.
 - [ ] **customLLDBInit**: **String** - the absolute path to the custom `.lldbinit` file
 
 ### Test Action

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -118,6 +118,7 @@ public struct Scheme: Equatable {
         public var debugEnabled: Bool
         public var simulateLocation: SimulateLocation?
         public var executable: String?
+        public var filePath: String?
         public var storeKitConfiguration: String?
         public var customLLDBInit: String?
         public var macroExpansion: String?
@@ -125,6 +126,7 @@ public struct Scheme: Equatable {
         public init(
             config: String,
             executable: String? = nil,
+            filePath: String? = nil,
             commandLineArguments: [String: Bool] = [:],
             preActions: [ExecutionAction] = [],
             postActions: [ExecutionAction] = [],
@@ -157,6 +159,7 @@ public struct Scheme: Equatable {
             self.storeKitConfiguration = storeKitConfiguration
             self.customLLDBInit = customLLDBInit
             self.macroExpansion = macroExpansion
+            self.filePath = filePath
         }
     }
 
@@ -389,6 +392,7 @@ extension Scheme.Run: JSONObjectConvertible {
         simulateLocation = jsonDictionary.json(atKeyPath: "simulateLocation")
         storeKitConfiguration = jsonDictionary.json(atKeyPath: "storeKitConfiguration")
         executable = jsonDictionary.json(atKeyPath: "executable")
+        filePath = jsonDictionary.json(atKeyPath: "filePath")
 
         // launchAutomaticallySubstyle is defined as a String in XcodeProj but its value is often
         // an integer. Parse both to be nice.
@@ -419,6 +423,7 @@ extension Scheme.Run: JSONEncodable {
             "askForAppToLaunch": askForAppToLaunch,
             "launchAutomaticallySubstyle": launchAutomaticallySubstyle,
             "executable": executable,
+            "filePath": filePath,
             "macroExpansion": macroExpansion
         ]
 

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -161,10 +161,14 @@ public class SchemeGenerator {
             return XCScheme.ExecutionAction(scriptText: action.script, title: action.name, environmentBuildable: environmentBuildable)
         }
 
-        let schemeTarget: Target?
-
-        if let targetName = scheme.run?.executable {
-            schemeTarget = project.getTarget(targetName)
+        var schemeTarget: Target? = nil
+        var pathRunnable: XCScheme.PathRunnable? = nil
+        
+        if let executable = scheme.run?.executable {
+            schemeTarget = project.getTarget(executable)
+        } else if let filePath = scheme.run?.filePath {
+            // Only use pathRunnable if no executable is provided.
+            pathRunnable = XCScheme.PathRunnable(filePath: filePath)
         } else {
             guard let firstTarget = scheme.build.targets.first else {
                 throw SchemeGenerationError.missingBuildTargets(scheme.name)
@@ -261,10 +265,11 @@ public class SchemeGenerator {
             buildConfiguration: scheme.run?.config ?? defaultDebugConfig.name,
             preActions: scheme.run?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.run?.postActions.map(getExecutionAction) ?? [],
-            macroExpansion: macroExpansion,
+            macroExpansion: scheme.run?.filePath == nil ? macroExpansion : nil,
             selectedDebuggerIdentifier: selectedDebuggerIdentifier(for: schemeTarget, run: scheme.run),
             selectedLauncherIdentifier: selectedLauncherIdentifier(for: schemeTarget, run: scheme.run),
             askForAppToLaunch: scheme.run?.askForAppToLaunch,
+            pathRunnable: pathRunnable,
             allowLocationSimulation: allowLocationSimulation,
             locationScenarioReference: locationScenarioReference,
             disableMainThreadChecker: scheme.run?.disableMainThreadChecker ?? Scheme.Run.disableMainThreadCheckerDefault,

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -167,7 +167,9 @@ public class SchemeGenerator {
         if let executable = scheme.run?.executable {
             schemeTarget = project.getTarget(executable)
         } else if let filePath = scheme.run?.filePath {
-            // Only use pathRunnable if no executable is provided.
+            guard Path(filePath).isAbsolute else {
+                throw SchemeGenerationError.pathNotAbsolute(filePath)
+            }
             pathRunnable = XCScheme.PathRunnable(filePath: filePath)
         } else {
             guard let firstTarget = scheme.build.targets.first else {
@@ -365,6 +367,7 @@ enum SchemeGenerationError: Error, CustomStringConvertible {
     case missingTarget(TargetReference, projectPath: String)
     case missingProject(String)
     case missingBuildTargets(String)
+    case pathNotAbsolute(String)
 
     var description: String {
         switch self {
@@ -374,6 +377,8 @@ enum SchemeGenerationError: Error, CustomStringConvertible {
             return "Unable to find project reference named \"\(project)\" in project.yml"
         case .missingBuildTargets(let name):
             return "Unable to find at least one build target in scheme \"\(name)\""
+        case .pathNotAbsolute(let path):
+            return "Provided filePath \"\(path)\" needs to be an absolute path"
         }
     }
 }

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -445,6 +445,31 @@ class SchemeGeneratorTests: XCTestCase {
                 let xcscheme = try unwrap(xcodeProject.sharedData?.schemes.first)
                 try expect(xcscheme.launchAction?.macroExpansion?.buildableName) == "MyApp.app"
             }
+            
+            $0.it("generates scheme with runnable path instead of executable") {
+                let app = Target(
+                    name: "MyApp",
+                    type: .application,
+                    platform: .macOS
+                )
+                
+                let appTarget = Scheme.BuildTarget(target: .local(app.name), buildTypes: [.running])
+                
+                let scheme = Scheme(
+                    name: "TestScheme",
+                    build: Scheme.Build(targets: [appTarget]),
+                    run: Scheme.Run(config: "Debug", filePath: "any/path", macroExpansion: "MyApp")
+                )
+                
+                let project = Project(
+                    name: "test",
+                    targets: [app],
+                    schemes: [scheme]
+                )
+                let xcodeProject = try project.generateXcodeProject()
+                let xcscheme = try unwrap(xcodeProject.sharedData?.schemes.first)
+                try expect(xcscheme.launchAction?.pathRunnable?.filePath) == "any/path"
+            }
         }
     }
     

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -458,7 +458,7 @@ class SchemeGeneratorTests: XCTestCase {
                 let scheme = Scheme(
                     name: "TestScheme",
                     build: Scheme.Build(targets: [appTarget]),
-                    run: Scheme.Run(config: "Debug", filePath: "any/path", macroExpansion: "MyApp")
+                    run: Scheme.Run(config: "Debug", filePath: "/any/path", macroExpansion: "MyApp")
                 )
                 
                 let project = Project(
@@ -468,7 +468,8 @@ class SchemeGeneratorTests: XCTestCase {
                 )
                 let xcodeProject = try project.generateXcodeProject()
                 let xcscheme = try unwrap(xcodeProject.sharedData?.schemes.first)
-                try expect(xcscheme.launchAction?.pathRunnable?.filePath) == "any/path"
+                try expect(xcscheme.launchAction?.pathRunnable?.filePath) == "/any/path"
+                try expect(xcscheme.launchAction?.runnable?.buildableReference).to.beNil()
             }
         }
     }


### PR DESCRIPTION
Fixes #1084

### Summary
Added ability to set executable to an external application by providing a `filePath` in the Run Action

### Changes
Added additional field `filePath` in the Run Action. If set, a `PathRunnable` will be created in the Run Action.

```yml
schemes:
  ExampleScheme:
    run:
      filePath: /Applications/Example.app
```