### PR TITLE
Add Support for DocC in Xcode 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+### Added
+
+- Added support for DocC Catalogs [#----](https://github.com/yonaskolb/XcodeGen/pull/----) @brevansio
+
 ## 2.23.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added support for DocC Catalogs [#----](https://github.com/yonaskolb/XcodeGen/pull/----) @brevansio
+- Added support for DocC Catalogs [#1091](https://github.com/yonaskolb/XcodeGen/pull/1091) @brevansio
 
 ## 2.23.1
 

--- a/Sources/ProjectSpec/FileType.swift
+++ b/Sources/ProjectSpec/FileType.swift
@@ -111,5 +111,6 @@ extension FileType {
         "xcfilelist": FileType(buildPhase: BuildPhaseSpec.none),
         "apns": FileType(buildPhase: BuildPhaseSpec.none),
         "pch": FileType(buildPhase: BuildPhaseSpec.none),
+        "docc": FileType(buildPhase: BuildPhaseSpec.none),
     ]
 }

--- a/Tests/Fixtures/TestProject/App_iOS/Documentation.docc/Documentation.md
+++ b/Tests/Fixtures/TestProject/App_iOS/Documentation.docc/Documentation.md
@@ -1,0 +1,7 @@
+# ``App_Clip``
+
+Test
+
+## Overview
+
+Test

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -674,6 +674,7 @@
 		B198242976C3395E31FE000A /* MessagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesViewController.swift; sourceTree = "<group>"; };
 		B1C33BB070583BE3B0EC0E68 /* App_iOS.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = App_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B221F5A689AD7D3AD52F56B8 /* libStaticLibrary_ObjC.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libStaticLibrary_ObjC.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B5C943D39DD7812CAB94B614 /* Documentation.docc */ = {isa = PBXFileReference; path = Documentation.docc; sourceTree = "<group>"; };
 		B76E17CE3574081D5BF45B44 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
 		BA040F1F7D6CA08878323A55 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		BB178D03E75929F3F5B10C56 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Result.framework; sourceTree = "<group>"; };
@@ -862,6 +863,7 @@
 				7F1A2F579A6F79C62DDA0571 /* AppDelegate.swift */,
 				3797E591F302ECC0AA2FC607 /* Assets.xcassets */,
 				9D4AB3FCF725428EFB56F542 /* Configuration.storekit */,
+				B5C943D39DD7812CAB94B614 /* Documentation.docc */,
 				C9DDE1B06BCC1CDE0ECF1589 /* Info.plist */,
 				AAA49985DFFE797EE8416887 /* inputList.xcfilelist */,
 				CE1F06D99242F4223D081F0D /* LaunchScreen.storyboard */,

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -598,6 +598,7 @@ class SourceGeneratorTests: XCTestCase {
                       - Root.plist
                     - WithPeriod2.0:
                       - file.swift
+                    - Documentation.docc
                 """
                 try createDirectories(directories)
 
@@ -654,6 +655,7 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFileMissing(paths: ["C", "Settings.bundle", "Root.plist"])
                 try pbxProj.expectFileMissing(paths: ["C", "WithPeriod2.0"])
                 try pbxProj.expectFile(paths: ["C", "WithPeriod2.0", "file.swift"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: ["C", "Documentation.docc"], buildPhase: BuildPhaseSpec.none)
             }
 
             $0.it("only omits the defined Info.plist from resource build phases but not other plists") {


### PR DESCRIPTION
DocC "files" are actually folders `.docc` appended to the name, but Xcode 13 treats them differently. Therefore, we need to exclude them from the normal BuildPhase.

Resolves #1089

About the PR: 

I'm a little uneasy about the tests. First, I added to an existing test because it seems like the best fit and I have confirmed that it both fails/passes when it should. If I need to move the test code or create a new test instead of modifying the existing test, let me know. Second, I'm also completely lost on the `project.pbxproj` because I couldn't figure out how to get it to fail the diff, so if I did something wrong let me know.