### PR TITLE
Fix link to an example project spec

### DIFF
--- a/Docs/Examples.md
+++ b/Docs/Examples.md
@@ -2,7 +2,7 @@
 
 These are a bunch of real world examples of XcodeGen project specs. Feel free to add your own via PR.
 
-- [num42/RxUserDefaults](https://github.com/num42/RxUserDefaults/blob/master/project.yml)
+- [num42/RxUserDefaults](https://github.com/num42/RxUserDefaults/blob/master/Examples/CocoaPodsExample.yml)
 - [toshi0383/Bitrise-iOS](https://github.com/toshi0383/Bitrise-iOS/blob/master/project.yml)
 - [johndpope/swift-models](https://github.com/johndpope/swift-models/tree/stable/Inference)
 - [atelier-socle/AppRepositoryTemplate](https://github.com/atelier-socle/AppRepositoryTemplate/blob/master/project.yml)


### PR DESCRIPTION
The previous linked file (`project.yml`) doesn't exist anymore in RxUserDefaults - the link is broken. Instead, `Examples/CocoaPodExample.yml` is an example spec in RxUserDefaults.