### PR TITLE
Fix issue that caused static framework target dependencies from having their default `link` value inferred as `true`

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -127,7 +127,7 @@ Note that target names can also be changed by adding a `name` property to a targ
 - [ ] **fileTypes**: **[String: [FileType](#filetype)]** - A list of default file options for specific file extensions across the project. Values in [Sources](#sources) will overwrite these settings.
 - [ ] **preGenCommand**: **String** - A bash command to run before the project has been generated. If the project isn't generated due to no changes when using the cache then this won't run. This is useful for running things like generating resources files before the project is regenerated.
 - [ ] **postGenCommand**: **String** - A bash command to run after the project has been generated. If the project isn't generated due to no changes when using the cache then this won't run. This is useful for running things like `pod install` only if the project is actually regenerated.
-- [ ] **useBaseInternationalization**: **Bool** If this is `false` and your project does not include resources located in a **Base.lproj** directory then `Base` will not be included in the projects 'known regions'. The default value is `true`. 
+- [ ] **useBaseInternationalization**: **Bool** If this is `false` and your project does not include resources located in a **Base.lproj** directory then `Base` will not be included in the projects 'known regions'. The default value is `true`.
 - [ ] **schemePathPrefix**: **String** - A path prefix for relative paths in schemes, such as StoreKitConfiguration. The default is `"../../"`, which is suitable for non-workspace projects. For use in workspaces, use `"../"`.
 
 ```yaml
@@ -147,7 +147,7 @@ Describe an order of groups. Available parameters:
 
 ```yaml
 options:
-  groupOrdering: 
+  groupOrdering:
     - order: [Sources, Resources, Tests, Support files, Configurations]
     - pattern: '^.*Screen$'
       order: [View, Presenter, Interactor, Entities, Assembly]
@@ -426,7 +426,7 @@ A dependency can be one of a 6 types:
 **Linking options**:
 
 - [ ] **embed**: **Bool** - Whether to embed the dependency. Defaults to true for application target and false for non application targets.
-- [ ] **link**: **Bool** - Whether to link the dependency. Defaults to `true` depending on the type of the dependency and the type of the target (e.g. static libraries will only link to executables by default).
+- [ ] **link**: **Bool** - Whether to link the dependency. Defaults to `true` depending on the type of the dependency and the type of the target (e.g. static libraries and frameworks will only link to executables by default).
 - [ ] **codeSign**: **Bool** - Whether the `codeSignOnCopy` setting is applied when embedding framework. Defaults to true
 - [ ] **removeHeaders**: **Bool** - Whether the `removeHeadersOnCopy` setting is applied when embedding the framework. Defaults to true
 - [ ] **weak**: **Bool** - Whether the `Weak` setting is applied when linking the framework. Defaults to false
@@ -525,7 +525,7 @@ packages:
 targets:
   App:
     dependencies:
-      - package: Yams 
+      - package: Yams
       - package: SwiftPM
         product: SPMUtility
 ```
@@ -730,7 +730,7 @@ Any attributes defined within a targets `templateAttributes` will be used to rep
 ```yaml
 targets:
   MyFramework:
-    templates: 
+    templates:
       - Framework
     templateAttributes:
       frameworkName: AwesomeFramework
@@ -845,7 +845,7 @@ A multiline script can be written using the various YAML multiline methods, for 
 
 
 ### Simulate Location
-- [x] **allow**: **Bool** - enable location simulation 
+- [x] **allow**: **Bool** - enable location simulation
 - [ ] **defaultLocation**: **String** - set the default location, possible values:
 	- `London, England`
 	- `Johannesburg, South Africa`
@@ -859,9 +859,9 @@ A multiline script can be written using the various YAML multiline methods, for 
 	- `Mexico City, Mexico`
 	- `New York, NY, USA`
 	- `Rio de Janeiro, Brazil`
-	- `<relative-path-to-gpx-file>` (e.g. ./location.gpx)   
+	- `<relative-path-to-gpx-file>` (e.g. ./location.gpx)
 	 Setting the **defaultLocation** to a custom gpx file, you also need to add that file to `fileGroups` for Xcode be able to use it:
-	 
+
 ```yaml
 targets:
   MyTarget:
@@ -897,8 +897,8 @@ schemes:
       coverageTargets:
         - MyTarget1
         - ExternalTarget/OtherTarget1
-      targets: 
-        - Tester1 
+      targets:
+        - Tester1
         - name: Tester2
           parallelizable: true
           randomExecutionOrder: true
@@ -966,7 +966,7 @@ Swift packages are defined at a project level, and then linked to individual tar
   - `branch: master`
   - `revision: xxxxxx`
 - [ ] **github** : **String**- this is an optional helper you can use for github repos. Instead of specifying the full url in `url` you can just specify the github org and repo
-  
+
 ### Local Package
 
 - [x] **path**: **String** - the path to the package in local. The path must be directory with a `Package.swift`.

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -708,7 +708,7 @@ public class PBXProjGenerator {
         func processTargetDependency(_ dependency: Dependency, dependencyTarget: Target, embedFileReference: PBXFileElement?, platform: String?) {
             let dependencyLinkage = dependencyTarget.defaultLinkage
             let link = dependency.link ??
-                ((dependencyLinkage == .dynamic && target.type != .staticLibrary) ||
+                ((dependencyLinkage == .dynamic && target.defaultLinkage != .static) ||
                     (dependencyLinkage == .static && target.type.isExecutable))
 
             if link, let dependencyFile = embedFileReference {

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		0927149520F12314CE8B4079 /* TestFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E43116070AFEF5D8C3A5A957 /* TestFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0932FB6FB887D7D6F7727CB7 /* Driver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 432E2C071A4B6B3757BEA13E /* Driver.cpp */; };
 		09617AB755651FFEB2564CBC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1A2F579A6F79C62DDA0571 /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		0A5DA755D93500431FA3A2C2 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0AB541AE3163B063E7012877 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359F /* StaticLibrary_ObjC.h */; };
 		0BDA156BEBFCB9E65910F838 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0F99AECCB4691803C791CDCE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2FC2A8A829CE71B1CF415FF7 /* Main.storyboard */; };
@@ -106,6 +107,7 @@
 		76DC6A4B18F434BAC239CC4A /* DriverKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0A428E67153BB40184F37BE /* DriverKit.framework */; };
 		778F71CA1CC4BEECDACAD8B9 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		77C3CB285572EA4BB7E201A7 /* App_Clip.app in Embed App Clips */ = {isa = PBXBuildFile; fileRef = 38DB679FF1CF4E379D1AB103 /* App_Clip.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		787568DA28690B22EA97A647 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7A0DABBEA55B06E148C665A8 /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC91042453E18DF74BA1C0F /* StaticLibrary.swift */; };
 		7A8C78212CEAC6452DFAB00E /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		7C8FF0B857E390417134C10F /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D296BB7355994040E197A1EE /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -114,12 +116,14 @@
 		818D448D4DDD6649B5B26098 /* example.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 28360ECA4D727FAA58557A81 /* example.mp4 */; settings = {ASSET_TAGS = (tag1, tag2, ); }; };
 		81DFAB3A7633CE97929B9B2A /* Framework.framework in Embed Dependencies */ = {isa = PBXBuildFile; fileRef = 41FC82ED1C4C3B7B3D7B2FB7 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8267B75289E9D6C7B38FC426 /* DriverKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0A428E67153BB40184F37BE /* DriverKit.framework */; };
+		859C935749C266DDD3800DA8 /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EF21DF245F66BEF5446AAEF /* Framework2.framework */; };
 		87927928A8A3460166ACB819 /* SwiftFileInDotPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F430AABE04B7499B458D9DB /* SwiftFileInDotPath.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		8C941A6EF08069CB3CB88FC1 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		900CFAD929CAEE3861127627 /* MyBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B5068D64404C61A67A18458 /* MyBundle.bundle */; };
 		94FD20C3EA5EBCEC8783740C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BDCA996D141DD8A16B18D68F /* GoogleService-Info.plist */; };
 		95DD9941E1529FD2AE1A191D /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359F /* StaticLibrary_ObjC.h */; };
 		96B55C0F660235FE6BDD8869 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		96F875FD0C6A377081214B59 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		998CCB995347CBB8EDC95FB5 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		9AB50B81C29243936BB419E4 /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		9C92B7C89E5F0A10A34F5AA4 /* Framework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8A9274BE42A03DC5DA1FAD04 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -149,6 +153,7 @@
 		C3672B561F456794151C047C /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C3FE6B986506724DAB5D0F /* ViewController.swift */; };
 		C400EBD25886ACB5CD9035EB /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D18 /* module.modulemap */; };
 		C4378E3DAF5E0B2F7AB60E03 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE6A6FAAFF701FE729293DE /* ViewController.swift */; };
+		C5C1699FCCA824F17D9BE230 /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EF21DF245F66BEF5446AAEF /* Framework2.framework */; };
 		C836F09B677937EFF69B1FCE /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C934C1F7A68CCD0AB6B38478 /* NotificationController.swift */; };
 		C88598A49087A212990F4E8B /* ResourceFolder in Resources */ = {isa = PBXBuildFile; fileRef = 6B1603BA83AA0C7B94E45168 /* ResourceFolder */; };
 		CAE18A2194B57C830A297F83 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6680EFE4E908CDBDCE405C8 /* main.swift */; };
@@ -163,6 +168,7 @@
 		E4B41CB5C796DD2C3C2E564C /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E4D0F435405DABCB51C5B684 /* TestFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E43116070AFEF5D8C3A5A957 /* TestFramework.framework */; };
 		E5DD0AD6F7AE1DD4AF98B83E /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = 65C8D6D1DDC1512D396C07B7 /* Localizable.stringsdict */; };
+		E5EFFDC9EFA488088F43C6CC /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		E7B40B34D8807F43A3805381 /* ExternalTarget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6ADE654A3459AFDA2CC0CD3 /* ExternalTarget.framework */; };
 		E8A135F768448632F8D77C8F /* StandaloneAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3571E41E19A5AB8AAAB04109 /* StandaloneAssets.xcassets */; };
 		EDB55692D392FD09C3FCFBF6 /* libStaticLibrary_ObjC.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 86169DEEDEAF09AB89C8A31D /* libStaticLibrary_ObjC.a */; };
@@ -225,6 +231,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 0867B0DACEF28C11442DE8F7;
 			remoteInfo = App_iOS;
+		};
+		3BEDE32249EDD84B7D761D48 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CE7D183D3752B5B35D2D8E6D;
+			remoteInfo = Framework2_iOS;
 		};
 		45907115465077029040BF29 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -303,6 +316,13 @@
 			remoteGlobalIDString = 53A3B531E3947D8A8722745E;
 			remoteInfo = Framework_macOS;
 		};
+		7FD805EDC469A9A577302404 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CE7D183D3752B5B35D2D8E6D;
+			remoteInfo = Framework2_iOS;
+		};
 		8BAA7F3717FCBE0B8D6669B3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
@@ -351,6 +371,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 0867B0DACEF28C11442DE8F7;
 			remoteInfo = App_iOS;
+		};
+		C9DD6F34368E555A9F20E552 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0FBAE303E3CFC2ABAC876A77 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CE7D183D3752B5B35D2D8E6D;
+			remoteInfo = Framework2_iOS;
 		};
 		CB8F4B3FDD84A2A6F3CA7F4C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -790,12 +817,14 @@
 		D8A016580A3B8F72B820BFBF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		DAA7880242A9DE61E68026CC /* Folder */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Folder; sourceTree = SOURCE_ROOT; };
 		DFE6A6FAAFF701FE729293DE /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		E03958429D2EA25E13A4F4DF /* FrameworkStatic.framework */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = FrameworkStatic.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3958AB20082EA12D4D5E60C /* BundleY.bundle */ = {isa = PBXFileReference; lastKnownFileType = wrapper.cfbundle; path = BundleY.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		E42335D1200CB7B8B91E962F /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = Base; path = Base.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		E43116070AFEF5D8C3A5A957 /* TestFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TestFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E55F45EACB0F382722D61C8D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E5E0A80CCE8F8DB662DCD2D0 /* EndpointSecuritySystemExtension.systemextension */ = {isa = PBXFileReference; explicitFileType = "wrapper.system-extension"; includeInIndex = 0; path = EndpointSecuritySystemExtension.systemextension; sourceTree = BUILT_PRODUCTS_DIR; };
 		E9672EF8FE1DDC8DE0705129 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
+		EA3B9EC2F76EEEAE28C965BA /* FrameworkWithStaticlibMatchOType.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FrameworkWithStaticlibMatchOType.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EDCC70978B8AD49373DA0DE0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EE1343F2238429D4DA9D830B /* File1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = File1.swift; path = Group/File1.swift; sourceTree = "<group>"; };
 		F0D48A913C087D049C8EDDD7 /* App.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
@@ -925,6 +954,22 @@
 			buildActionMask = 2147483647;
 			files = (
 				8267B75289E9D6C7B38FC426 /* DriverKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F062F57F00946DE894568D7A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C5C1699FCCA824F17D9BE230 /* Framework2.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB2304C5C470A5FD4BEB67C2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				859C935749C266DDD3800DA8 /* Framework2.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1282,6 +1327,8 @@
 				2233774B86539B1574D206B0 /* Framework2.framework */,
 				A0DC40025AB59B688E758829 /* Framework2.framework */,
 				AB055761199DF36DB0C629A6 /* Framework2.framework */,
+				E03958429D2EA25E13A4F4DF /* FrameworkStatic.framework */,
+				EA3B9EC2F76EEEAE28C965BA /* FrameworkWithStaticlibMatchOType.framework */,
 				9A87A926D563773658FB87FE /* iMessageApp.app */,
 				D629E142AB87C681D4EC90F7 /* iMessageExtension.appex */,
 				C53ACB2962FED621389C36A2 /* iMessageStickersExtension.appex */,
@@ -1476,6 +1523,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		678DC986851A2099BA3BAC9F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				787568DA28690B22EA97A647 /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		85324A7388DEC869665BFA99 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1490,6 +1545,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				0786F9C725AD215C4F915BB5 /* MyFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D1C23C7C51130F15198430A5 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A5DA755D93500431FA3A2C2 /* MyFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1666,6 +1729,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				A0B8F3A22F25118E70F81D65 /* PBXTargetDependency */,
 			);
 			name = StaticLibrary_Swift;
 			productName = StaticLibrary_Swift;
@@ -2128,6 +2192,42 @@
 			productReference = 22237B8EBD9E6BE8EBC8735F /* XPC Service.xpc */;
 			productType = "com.apple.product-type.xpc-service";
 		};
+		EC87E8E84A74226BDF19B68B /* FrameworkStatic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 37A23B9E298A43A241DD2E58 /* Build configuration list for PBXNativeTarget "FrameworkStatic" */;
+			buildPhases = (
+				D1C23C7C51130F15198430A5 /* Headers */,
+				24EB6BAACD2F34C1DFDB54A1 /* Sources */,
+				FB2304C5C470A5FD4BEB67C2 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C2B6EBFFC9B189C03AE4B796 /* PBXTargetDependency */,
+			);
+			name = FrameworkStatic;
+			productName = FrameworkStatic;
+			productReference = E03958429D2EA25E13A4F4DF /* FrameworkStatic.framework */;
+			productType = "com.apple.product-type.framework.static";
+		};
+		F07941085210A1CCBEB72EDB /* FrameworkWithStaticlibMatchOType */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DC00F79D2E5780C76B1CD2A6 /* Build configuration list for PBXNativeTarget "FrameworkWithStaticlibMatchOType" */;
+			buildPhases = (
+				678DC986851A2099BA3BAC9F /* Headers */,
+				D3399C3E3A574B2B179DC638 /* Sources */,
+				F062F57F00946DE894568D7A /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				1D9A6D7935A8F7C6007C9E31 /* PBXTargetDependency */,
+			);
+			name = FrameworkWithStaticlibMatchOType;
+			productName = FrameworkWithStaticlibMatchOType;
+			productReference = EA3B9EC2F76EEEAE28C965BA /* FrameworkWithStaticlibMatchOType.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		F674B2CFC4738EEC49BAD0DA /* App_iOS_UITests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 68CC35789B0DB020E2CFC517 /* Build configuration list for PBXNativeTarget "App_iOS_UITests" */;
@@ -2228,6 +2328,8 @@
 				FC26AF2506D3B2B40DE8A5F8 /* Framework2_macOS */,
 				8B9A14DC280CCE013CC86440 /* Framework2_tvOS */,
 				6ED01BC471A8C3642258E178 /* Framework2_watchOS */,
+				EC87E8E84A74226BDF19B68B /* FrameworkStatic */,
+				F07941085210A1CCBEB72EDB /* FrameworkWithStaticlibMatchOType */,
 				AE3F93DB94E7208F2F1D9A78 /* Framework_iOS */,
 				53A3B531E3947D8A8722745E /* Framework_macOS */,
 				536ACF18E4603B59207D43CE /* Framework_tvOS */,
@@ -2585,6 +2687,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		24EB6BAACD2F34C1DFDB54A1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96F875FD0C6A377081214B59 /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		2E1429F0FB524A2BCFC61DF1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2787,6 +2897,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D3399C3E3A574B2B179DC638 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E5EFFDC9EFA488088F43C6CC /* FrameworkFile.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DEB2782C650F563EB8C62B28 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2860,6 +2978,11 @@
 			target = 9F551F66949B55E8328EB995 /* EndpointSecuritySystemExtension */;
 			targetProxy = DD32A97CFD2016BF1477CF6C /* PBXContainerItemProxy */;
 		};
+		1D9A6D7935A8F7C6007C9E31 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CE7D183D3752B5B35D2D8E6D /* Framework2_iOS */;
+			targetProxy = 7FD805EDC469A9A577302404 /* PBXContainerItemProxy */;
+		};
 		2D1B4333107E10912508724E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 0636AAF06498C336E1CEEDE4 /* TestFramework */;
@@ -2925,6 +3048,11 @@
 			target = 834F55973F05AC8A18144DB0 /* iMessageApp */;
 			targetProxy = 57F1BE74D4C4252529F97984 /* PBXContainerItemProxy */;
 		};
+		A0B8F3A22F25118E70F81D65 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CE7D183D3752B5B35D2D8E6D /* Framework2_iOS */;
+			targetProxy = C9DD6F34368E555A9F20E552 /* PBXContainerItemProxy */;
+		};
 		A19BEE3154D879101F865BB2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = D137C04B64B7052419A2DF4E /* App_Clip */;
@@ -2950,6 +3078,11 @@
 			isa = PBXTargetDependency;
 			target = AE3F93DB94E7208F2F1D9A78 /* Framework_iOS */;
 			targetProxy = 7E37A3C0A67C3B6363029A18 /* PBXContainerItemProxy */;
+		};
+		C2B6EBFFC9B189C03AE4B796 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CE7D183D3752B5B35D2D8E6D /* Framework2_iOS */;
+			targetProxy = 3BEDE32249EDD84B7D761D48 /* PBXContainerItemProxy */;
 		};
 		CE96B0951433713033A03DCD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3516,6 +3649,29 @@
 				SDKROOT = macosx;
 			};
 			name = "Test Release";
+		};
+		12385B4E1357CE1DAD2673E2 /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkStatic;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
 		};
 		12BCDE0EFCEE621B881E424C /* Test Release */ = {
 			isa = XCBuildConfiguration;
@@ -4759,6 +4915,30 @@
 			};
 			name = "Production Release";
 		};
+		5871004CB8EEE89670160C2B /* Test Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkWithStaticlibMatchOType;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Debug";
+		};
 		5876AA17762F3248F4FD66E1 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4966,6 +5146,30 @@
 			};
 			name = "Staging Debug";
 		};
+		6629D3D6B3FB48E0469CAA62 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkWithStaticlibMatchOType;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
+		};
 		6645E6A343F71C3E91656BE9 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4995,6 +5199,29 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Staging Debug";
+		};
+		67BE8647DA01F4DF988A95E1 /* Staging Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkStatic;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Release";
 		};
 		6A11812952F34525D14A4104 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
@@ -5114,6 +5341,29 @@
 				SDKROOT = macosx;
 			};
 			name = "Staging Release";
+		};
+		77C889EB3D8CFD32B0A9F4AC /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkStatic;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
 		};
 		7931F229200F89B8CDC8A5E3 /* Test Debug */ = {
 			isa = XCBuildConfiguration;
@@ -6433,6 +6683,30 @@
 			};
 			name = "Test Release";
 		};
+		BDCD4A3E057389FEE0DF13A0 /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkWithStaticlibMatchOType;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
+		};
 		BF2F04729CC0602591655B25 /* Production Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6446,6 +6720,30 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = "Production Debug";
+		};
+		BFCE7920B9D3F6DEF267C5FE /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkWithStaticlibMatchOType;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
 		};
 		C00DBF60DC8C1A570738241F /* Test Release */ = {
 			isa = XCBuildConfiguration;
@@ -6874,6 +7172,29 @@
 			};
 			name = "Production Debug";
 		};
+		D7484559A7F3857CC2D13158 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkStatic;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
 		D8267FD376089FF4497ED3F1 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6940,6 +7261,29 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Test Release";
+		};
+		DB6CFB9D9E7669D0A33AD7AD /* Production Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkStatic;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Release";
 		};
 		DC80DC0AF0B4F2B51DAB0A52 /* Test Release */ = {
 			isa = XCBuildConfiguration;
@@ -7207,6 +7551,29 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = "Production Debug";
+		};
+		E5846629B2006519A9D30153 /* Staging Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkStatic;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Staging Debug";
 		};
 		E5854B94A71A091D61E6ACD3 /* Staging Debug */ = {
 			isa = XCBuildConfiguration;
@@ -7498,6 +7865,30 @@
 			};
 			name = "Staging Release";
 		};
+		F2144BEA8F6841152DE11387 /* Test Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkWithStaticlibMatchOType;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Test Release";
+		};
 		F3AC6A112F81D0958A316D82 /* Test Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -7554,6 +7945,30 @@
 				TEST_TARGET_NAME = App_Clip;
 			};
 			name = "Staging Debug";
+		};
+		F4EA092A68EE7A4C623E5426 /* Production Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Framework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACH_O_TYPE = staticlib;
+				PRODUCT_BUNDLE_IDENTIFIER = com.project.FrameworkWithStaticlibMatchOType;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = "Production Debug";
 		};
 		F75CC02D1BB9B39C329A9B43 /* Staging Release */ = {
 			isa = XCBuildConfiguration;
@@ -7840,6 +8255,19 @@
 				EBA3332D0144AAAA57630865 /* Staging Release */,
 				85E6B40848AC2A0B1F921553 /* Test Debug */,
 				B7EBD1A3A3A7E66100F5C845 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		37A23B9E298A43A241DD2E58 /* Build configuration list for PBXNativeTarget "FrameworkStatic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				77C889EB3D8CFD32B0A9F4AC /* Production Debug */,
+				DB6CFB9D9E7669D0A33AD7AD /* Production Release */,
+				E5846629B2006519A9D30153 /* Staging Debug */,
+				67BE8647DA01F4DF988A95E1 /* Staging Release */,
+				12385B4E1357CE1DAD2673E2 /* Test Debug */,
+				D7484559A7F3857CC2D13158 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";
@@ -8230,6 +8658,19 @@
 				7D73A7FB339A39293BD2DB9E /* Staging Release */,
 				B227B91964080DEF6C426483 /* Test Debug */,
 				BA21E149424C2D03E5E50EC1 /* Test Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "Production Debug";
+		};
+		DC00F79D2E5780C76B1CD2A6 /* Build configuration list for PBXNativeTarget "FrameworkWithStaticlibMatchOType" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F4EA092A68EE7A4C623E5426 /* Production Debug */,
+				BDCD4A3E057389FEE0DF13A0 /* Production Release */,
+				BFCE7920B9D3F6DEF267C5FE /* Staging Debug */,
+				6629D3D6B3FB48E0469CAA62 /* Staging Release */,
+				5871004CB8EEE89670160C2B /* Test Debug */,
+				F2144BEA8F6841152DE11387 /* Test Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "Production Debug";

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -116,7 +116,6 @@
 		818D448D4DDD6649B5B26098 /* example.mp4 in Resources */ = {isa = PBXBuildFile; fileRef = 28360ECA4D727FAA58557A81 /* example.mp4 */; settings = {ASSET_TAGS = (tag1, tag2, ); }; };
 		81DFAB3A7633CE97929B9B2A /* Framework.framework in Embed Dependencies */ = {isa = PBXBuildFile; fileRef = 41FC82ED1C4C3B7B3D7B2FB7 /* Framework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8267B75289E9D6C7B38FC426 /* DriverKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0A428E67153BB40184F37BE /* DriverKit.framework */; };
-		859C935749C266DDD3800DA8 /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EF21DF245F66BEF5446AAEF /* Framework2.framework */; };
 		87927928A8A3460166ACB819 /* SwiftFileInDotPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F430AABE04B7499B458D9DB /* SwiftFileInDotPath.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		8C941A6EF08069CB3CB88FC1 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		900CFAD929CAEE3861127627 /* MyBundle.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B5068D64404C61A67A18458 /* MyBundle.bundle */; };
@@ -153,7 +152,6 @@
 		C3672B561F456794151C047C /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C3FE6B986506724DAB5D0F /* ViewController.swift */; };
 		C400EBD25886ACB5CD9035EB /* module.modulemap in CopyFiles */ = {isa = PBXBuildFile; fileRef = F2950763C4C568CC85021D18 /* module.modulemap */; };
 		C4378E3DAF5E0B2F7AB60E03 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE6A6FAAFF701FE729293DE /* ViewController.swift */; };
-		C5C1699FCCA824F17D9BE230 /* Framework2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3EF21DF245F66BEF5446AAEF /* Framework2.framework */; };
 		C836F09B677937EFF69B1FCE /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C934C1F7A68CCD0AB6B38478 /* NotificationController.swift */; };
 		C88598A49087A212990F4E8B /* ResourceFolder in Resources */ = {isa = PBXBuildFile; fileRef = 6B1603BA83AA0C7B94E45168 /* ResourceFolder */; };
 		CAE18A2194B57C830A297F83 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6680EFE4E908CDBDCE405C8 /* main.swift */; };
@@ -954,22 +952,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8267B75289E9D6C7B38FC426 /* DriverKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F062F57F00946DE894568D7A /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				C5C1699FCCA824F17D9BE230 /* Framework2.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		FB2304C5C470A5FD4BEB67C2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				859C935749C266DDD3800DA8 /* Framework2.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2198,7 +2180,6 @@
 			buildPhases = (
 				D1C23C7C51130F15198430A5 /* Headers */,
 				24EB6BAACD2F34C1DFDB54A1 /* Sources */,
-				FB2304C5C470A5FD4BEB67C2 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2216,7 +2197,6 @@
 			buildPhases = (
 				678DC986851A2099BA3BAC9F /* Headers */,
 				D3399C3E3A574B2B179DC638 /* Sources */,
-				F062F57F00946DE894568D7A /* Frameworks */,
 			);
 			buildRules = (
 			);

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -270,6 +270,8 @@ targets:
     type: library.static
     platform: iOS
     sources: StaticLibrary_Swift
+    dependencies:
+      - target: Framework2_iOS
 
   Framework:
     type: framework
@@ -298,6 +300,30 @@ targets:
       - path: Framework
         excludes:
           - "*.xcodeproj"
+
+  FrameworkStatic:
+    type: framework.static
+    platform: iOS
+    sources:
+      - path: Framework
+        excludes:
+          - "*.xcodeproj"
+    dependencies:
+      - target: Framework2_iOS
+
+  FrameworkWithStaticlibMatchOType:
+    type: framework
+    platform: iOS
+    settings:
+      base:
+        MACH_O_TYPE: staticlib
+    sources:
+      - path: Framework
+        excludes:
+          - "*.xcodeproj"
+    dependencies:
+      - target: Framework2_iOS
+
   TestFramework:
     type: framework
     platform: iOS
@@ -411,7 +437,7 @@ schemes:
         defaultLocation: Honolulu, HI, USA
       customLLDBInit: ${SRCROOT}/.lldbinit
       storeKitConfiguration: "App_iOS/Configuration.storekit"
-      macroExpansion: App_iOS 
+      macroExpansion: App_iOS
     test:
       gatherCoverageData: true
       targets:


### PR DESCRIPTION
I'm updating our project to statically link some framework targets instead of using dynamic linking for everything and I spotted some warnings appearing in CI when doing do:

> [...]/usr/bin/libtool: file: /[...]/MyFramework1.framework/MyFramework1 is a dynamic library, not added to the static library

It appears that this happens when I have three targets:

1. `MyFramework1` - Dynamic Framework  (`framework`)
2. `MyFramework2` - Static Framework (`framework.static`) with dependency on `MyFramework1`
3. `MyApp` - iOS app target with dependency on `MyFramework2` (and a transitive dependency on `MyFramework1`)

In this setup, the `MyFramework2` target should not have a "Link Binary With Libraries" build phase because the libraries should be linked into the executable target `MyApp` instead. After looking at the docs, and digging into the current fixtures, it appeared that this was defaulting the `link` property to the correct value if `MyFramework2` was a static library (`library.static`) but not for `framework.static` or `framework` with the `MACH_O_TYPE` build setting set to `staticlib`.

After setting up some extra targets in the fixtures to reproduce the setup (1f391f1), i tracked the issue down to `PBXProjectGenerator` and updated it to use the `defaultLinkage` property that is also used for figuring out if the dependency should be embedded or not (159f719). You can find the fixtures regenerated after making the changes in 
8e19482.