### PR TITLE
[bug fix] Ensure fileTypes are mapped to JSON value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixed
 
 - Fix broken codesign option for bundle dependency [#1104](https://github.com/yonaskolb/XcodeGen/pull/1104) @kateinoigakukun
+- Ensure fileTypes are mapped to JSON value [#1112](https://github.com/yonaskolb/XcodeGen/pull/1112) @namolnad
 
 ## 2.24.0
 

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -187,7 +187,7 @@ extension SpecOptions: JSONEncodable {
             "localPackagesGroup": localPackagesGroup,
             "preGenCommand": preGenCommand,
             "postGenCommand": postGenCommand,
-            "fileTypes": fileTypes
+            "fileTypes": fileTypes.mapValues { $0.toJSONValue() }
         ]
 
         if settingPresets != SpecOptions.settingPresetsDefault {


### PR DESCRIPTION
After finding out that #1111 was already possible via `xcodegen dump`, I tried it out for my project, but noticed that there was an error for my project when trying to use the `parsed-yaml` or the `parsed-json` options. It turns out there was a JSON/Yaml serialization error due to `fileTypes` still being the raw Swift type vs the JSON value.