### PR TITLE
Speed up path checking

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -374,7 +374,7 @@ class SourceGenerator {
             // If includes is empty, it's included. If it's not empty, the path either needs to match exactly, or it needs to be a direct parent of an included path.
             && (includePaths.isEmpty || includePaths.contains(where: { includedFile in
                 if path == includedFile { return true }
-                return includedFile.description.contains(path.description)
+                return includedFile.description.hasPrefix(path.description)
             }))
     }
 


### PR DESCRIPTION
For checking if path is subpath of another, we don't actually need to use `contains` method.
`hasPrefix` will do all the job and will be faster to check.

This is because in the method, when we're checking paths, we're operating with full path's, so using `contains` is not only slower, but can also get false positives in some rare cases

Using this fix only, decreased project generation from about 14s to 5s on my project.

## Before
![image](https://user-images.githubusercontent.com/119268/130847779-75b27809-f389-42c0-a66d-90b8a8554225.png)

## After
![image](https://user-images.githubusercontent.com/119268/130847784-60c07c56-518c-429d-a2ab-e1e18b482535.png)
