### PR TITLE
Fix platformFilter for package dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Fix broken codesign option for bundle dependency [#1104](https://github.com/yonaskolb/XcodeGen/pull/1104) @kateinoigakukun
 - Ensure fileTypes are mapped to JSON value [#1112](https://github.com/yonaskolb/XcodeGen/pull/1112) @namolnad
+- Fix platform filter for package dependecies [#1123](https://github.com/yonaskolb/XcodeGen/pull/1123) @raptorxcz
 
 ## 2.24.0
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -925,9 +925,9 @@ public class PBXProjGenerator {
 
                 let link = dependency.link ?? (target.type != .staticLibrary)
                 if link {
-                    let buildFile = addObject(
-                        PBXBuildFile(product: packageDependency, settings: getDependencyFrameworkSettings(dependency: dependency))
-                    )
+                    let file = PBXBuildFile(product: packageDependency, settings: getDependencyFrameworkSettings(dependency: dependency))
+                    file.platformFilter = platform
+                    let buildFile = addObject(file)
                     targetFrameworkBuildFiles.append(buildFile)
                 } else {
                     let targetDependency = addObject(

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		09617AB755651FFEB2564CBC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F1A2F579A6F79C62DDA0571 /* AppDelegate.swift */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		0AB541AE3163B063E7012877 /* StaticLibrary_ObjC.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5A2B916A11DCC2565241359F /* StaticLibrary_ObjC.h */; };
 		0BDA156BEBFCB9E65910F838 /* MyFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A58A16491CDDF968B0D56DE /* MyFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0D0E2466833FC2636B92C43D /* Swinject in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = D7917D10F77DA9D69937D493 /* Swinject */; };
 		0F99AECCB4691803C791CDCE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2FC2A8A829CE71B1CF415FF7 /* Main.storyboard */; };
 		15129B8D9ED000BDA1FEEC27 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23A2F16890ECF2EE3FED72AE /* AppDelegate.swift */; };
 		1551370B0ACAC632E15C853B /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FF47010E7368583405AA50CB /* SwiftyJSON.framework */; };
@@ -822,6 +823,7 @@
 				2FAE950E8FF2E7C0F7FF1FE9 /* Framework.framework in Frameworks */,
 				B142965C5AE9C6200BF65802 /* Result.framework in Frameworks */,
 				B20617116B230DED1F7AF5E5 /* libStaticLibrary_ObjC.a in Frameworks */,
+				0D0E2466833FC2636B92C43D /* Swinject in Frameworks */,
 				1551370B0ACAC632E15C853B /* SwiftyJSON.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1606,6 +1608,9 @@
 				981D116D40DBA0407D0E0E94 /* PBXTargetDependency */,
 			);
 			name = App_iOS;
+			packageProductDependencies = (
+				D7917D10F77DA9D69937D493 /* Swinject */,
+			);
 			productName = App_iOS;
 			productReference = B1C33BB070583BE3B0EC0E68 /* App_iOS.app */;
 			productType = "com.apple.product-type.application";
@@ -2199,6 +2204,9 @@
 				en,
 			);
 			mainGroup = 293D0FF827366B513839236A;
+			packageReferences = (
+				4EDA79334592CBBA0E507AD2 /* XCRemoteSwiftPackageReference "Swinject" */,
+			);
 			projectDirPath = "";
 			projectReferences = (
 				{
@@ -8274,6 +8282,25 @@
 			defaultConfigurationName = "Production Debug";
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		4EDA79334592CBBA0E507AD2 /* XCRemoteSwiftPackageReference "Swinject" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Swinject/Swinject";
+			requirement = {
+				kind = exactVersion;
+				version = 2.8.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		D7917D10F77DA9D69937D493 /* Swinject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4EDA79334592CBBA0E507AD2 /* XCRemoteSwiftPackageReference "Swinject" */;
+			productName = Swinject;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		306796628DD52FA55E833B65 /* Model.xcdatamodeld */ = {

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -27,6 +27,10 @@ projectReferences:
     path: ./AnotherProject/AnotherProject.xcodeproj
 configFiles:
   Test Debug: Configs/config.xcconfig
+packages:
+  Swinject:
+    url: https://github.com/Swinject/Swinject
+    version: 2.8.0
 targets:
   Legacy:
     type: ""
@@ -139,6 +143,9 @@ targets:
       - { bundle: BundleY.bundle, codeSign: false }
       - target: AnotherProject/ExternalTarget
       - target: App_Clip
+      - package: Swinject
+        product: Swinject
+        platformFilter: iOS
     onlyCopyFilesOnInstall: true
     scheme:
       testTargets:

--- a/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
@@ -357,18 +357,23 @@ class PBXProjGeneratorTests: XCTestCase {
                 let dependency1 = Dependency(type: .target, reference: "TestAll", platformFilter: .all)
                 let dependency2 = Dependency(type: .target, reference: "TestiOS", platformFilter: .iOS)
                 let dependency3 = Dependency(type: .target, reference: "TestmacOS", platformFilter: .macOS)
-                let target = Target(name: "Test", type: .application, platform: .iOS, sources: ["Sources"], dependencies: [dependency1, dependency2, dependency3])
-                let project = Project(basePath: directoryPath, name: "Test", targets: [target, target1, target2, target3])
+                let dependency4 = Dependency(type: .package(product: "Swinject"), reference: "Swinject", platformFilter: .iOS)
+                let target = Target(name: "Test", type: .application, platform: .iOS, sources: ["Sources"], dependencies: [dependency1, dependency2, dependency3, dependency4])
+                let swinjectPackage = SwiftPackage.remote(url: "https://github.com/Swinject/Swinject", versionRequirement: .exact("2.8.0"))
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target, target1, target2, target3], packages: ["Swinject": swinjectPackage])
 
                 let pbxProj = try project.generatePbxProj()
 
                 let targets = pbxProj.projects.first?.targets
-                let testTargetDependencies = pbxProj.projects.first?.targets.first(where: { $0.name == "Test" })?.dependencies
+                let testTarget = pbxProj.projects.first?.targets.first(where: { $0.name == "Test" })
+                let testTargetDependencies = testTarget?.dependencies
                 try expect(targets?.count) == 4
                 try expect(testTargetDependencies?.count) == 3
                 try expect(testTargetDependencies?[0].platformFilter).beNil()
                 try expect(testTargetDependencies?[1].platformFilter) == "ios"
                 try expect(testTargetDependencies?[2].platformFilter) == "maccatalyst"
+                try expect(testTarget?.frameworksBuildPhase()?.files?.count) == 1
+                try expect(testTarget?.frameworksBuildPhase()?.files?[0].platformFilter) == "ios"
             }
         }
     }


### PR DESCRIPTION
If dependency is package then is not possible to set platformFilter. According to documentation it should be possible.

https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#dependency