### PR TITLE
Add Debug Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Allow specifying a `copy` setting for each dependency. [#1038](https://github.com/yonaskolb/XcodeGen/pull/1039) @JakubBednar
+- A `-d`/`--debug` flag is now available to render all debug logs when running the CLI tool. [#1128](https://github.com/yonaskolb/XcodeGen/pull/1128) @dalemyers
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Options:
 - **--spec**: An optional path to a `.yml` or `.json` project spec. Defaults to `project.yml`
 - **--project**: An optional path to a directory where the project will be generated. By default this is the directory the spec lives in.
 - **--quiet**: Suppress informational and success messages.
+- **--debug**: The opposite to `--quiet`: Show all debug messages (`--quiet` overrides `--debug`)
 - **--use-cache**: Used to prevent unnecessarily generating the project. If this is set, then a cache file will be written to when a project is generated. If `xcodegen` is later run but the spec and all the files it contains are the same, the project won't be generated.
 - **--cache-path**: A custom path to use for your cache file. This defaults to `~/.xcodegen/cache/{PROJECT_SPEC_PATH_HASH}`
 

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -1,6 +1,7 @@
 import Foundation
 import JSONUtilities
 import PathKit
+import XcodeGenCore
 import XcodeProj
 import Yams
 import Version
@@ -16,6 +17,7 @@ public class SpecLoader {
     }
 
     public func loadProject(path: Path, projectRoot: Path? = nil, variables: [String: String] = [:]) throws -> Project {
+        Logger.shared.debug("Loading project file (and includes): \(path)")
         let spec = try SpecFile(path: path)
         let resolvedDictionary = spec.resolvedDictionary(variables: variables)
         let project = try Project(basePath: projectRoot ?? spec.basePath, jsonDictionary: resolvedDictionary)

--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -34,6 +34,7 @@ class GenerateCommand: ProjectCommand {
         // validate project dictionary
         do {
             try specLoader.validateProjectDictionaryWarnings()
+            Logger.shared.debug("Validated project dictionary")
         } catch {
             Logger.shared.warning("\(error)")
         }
@@ -73,13 +74,16 @@ class GenerateCommand: ProjectCommand {
         // validate project
         do {
             try project.validateMinimumXcodeGenVersion(version)
+            Logger.shared.debug("Validated minimum Xcode version")
             try project.validate()
+            Logger.shared.debug("Validated project")
         } catch let error as SpecValidationError {
             throw GenerationError.validationError(error)
         }
 
         // run pre gen command
         if let command = project.options.preGenCommand {
+            Logger.shared.debug("Running pre-gen command: \(command)")
             try Task.run(bash: command, directory: projectDirectory.absolute().string)
         }
 
@@ -116,6 +120,7 @@ class GenerateCommand: ProjectCommand {
 
         // write cache
         if let cacheFile = cacheFile {
+            Logger.shared.debug("Writing cache...")
             do {
                 try cacheFilePath.parent().mkpath()
                 try cacheFilePath.write(cacheFile.string)
@@ -126,6 +131,7 @@ class GenerateCommand: ProjectCommand {
 
         // run post gen command
         if let command = project.options.postGenCommand {
+            Logger.shared.debug("Running post gen command: \(command)")
             try Task.run(bash: command, directory: projectDirectory.absolute().string)
         }
     }

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -50,6 +50,8 @@ class ProjectCommand: Command, LogRenderer {
 
         let projectSpecPath = (spec ?? "project.yml").absolute()
 
+        Logger.shared.debug("Checking for spec file: \(projectSpecPath)")
+
         if !projectSpecPath.exists {
             throw GenerationError.missingProjectSpec(projectSpecPath)
         }
@@ -64,6 +66,8 @@ class ProjectCommand: Command, LogRenderer {
         } catch {
             throw GenerationError.projectSpecParsingError(error)
         }
+
+        Logger.shared.debug("Loaded project")
 
         try execute(specLoader: specLoader, projectSpecPath: projectSpecPath, project: project)
     }

--- a/Sources/XcodeGenCore/Logger.swift
+++ b/Sources/XcodeGenCore/Logger.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+
+public protocol LogRenderer: AnyObject {
+    func debug(_ string: String)
+    func info(_ string: String, wasSuccess: Bool)
+    func warning(_ string: String)
+    func error(_ string: String)
+}
+
+public class Logger {
+
+    public enum LogLevel: Int {
+        case debug = 1
+        case info = 2
+        case warning = 3
+        case error = 4
+    }
+
+    public static let shared = Logger(.info)
+
+    public var logLevel: Logger.LogLevel
+    public weak var delegate: LogRenderer?
+
+    public init(_ logLevel: Logger.LogLevel) {
+        self.logLevel = logLevel
+    }
+
+    public func debug(_ string: String) {
+        if self.logLevel.rawValue <= LogLevel.debug.rawValue {
+            delegate?.debug(string)
+        }
+    }
+
+    public func info(_ string: String) {
+        if self.logLevel.rawValue <= LogLevel.info.rawValue {
+            delegate?.info(string, wasSuccess: false)
+        }
+    }
+
+    public func warning(_ string: String) {
+        if self.logLevel.rawValue <= LogLevel.warning.rawValue {
+            delegate?.warning(string)
+        }
+    }
+
+    public func error(_ string: String) {
+        if self.logLevel.rawValue <= LogLevel.error.rawValue {
+            delegate?.error(string)
+        }
+    }
+
+    public func success(_ string: String) {
+        if self.logLevel.rawValue <= LogLevel.info.rawValue {
+            delegate?.info(string, wasSuccess: true)
+        }
+    }
+}

--- a/Sources/XcodeGenKit/FileWriter.swift
+++ b/Sources/XcodeGenKit/FileWriter.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PathKit
 import ProjectSpec
+import XcodeGenCore
 import XcodeProj
 
 public class FileWriter {
@@ -31,11 +32,13 @@ public class FileWriter {
             // write Info.plist
             if let plist = target.info {
                 let properties = infoPlistGenerator.generateProperties(for: target).merged(plist.properties)
+                Logger.shared.debug("Writing plist: \(plist.path)")
                 try writePlist(properties, path: plist.path)
             }
 
             // write entitlements
             if let plist = target.entitlements {
+                Logger.shared.debug("Writing entitlements: \(plist.path)")
                 try writePlist(plist.properties, path: plist.path)
             }
         }

--- a/Sources/XcodeGenKit/ProjectGenerator.swift
+++ b/Sources/XcodeGenKit/ProjectGenerator.swift
@@ -2,6 +2,7 @@ import Foundation
 import JSONUtilities
 import PathKit
 import ProjectSpec
+import XcodeGenCore
 import XcodeProj
 import Yams
 
@@ -18,14 +19,20 @@ public class ProjectGenerator {
         // generate PBXProj
         let pbxProjGenerator = PBXProjGenerator(project: project,
                                                 projectDirectory: projectDirectory)
+        Logger.shared.debug("Generating project...")
         let pbxProj = try pbxProjGenerator.generate()
+        Logger.shared.debug("Project generated")
 
         // generate Schemes
         let schemeGenerator = SchemeGenerator(project: project, pbxProj: pbxProj)
+        Logger.shared.debug("Generating schemes...")
         let schemes = try schemeGenerator.generateSchemes()
+        Logger.shared.debug("Schemes generated")
 
         // generate Workspace
+        Logger.shared.debug("Generating workspace...")
         let workspace = try generateWorkspace()
+        Logger.shared.debug("Workspace generated")
 
         let sharedData = XCSharedData(schemes: schemes)
         return XcodeProj(workspace: workspace, pbxproj: pbxProj, sharedData: sharedData)

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import ProjectSpec
+import XcodeGenCore
 import XcodeProj
 import PathKit
 
@@ -141,6 +142,8 @@ public class SchemeGenerator {
             let buildableReference = try getBuildableReference(buildTarget.target)
             return XCScheme.BuildAction.Entry(buildableReference: buildableReference, buildFor: buildTarget.buildTypes)
         }
+
+        Logger.shared.debug("Generating scheme \(scheme.name)")
 
         let testTargets = scheme.test?.targets ?? []
         let testBuildTargets = testTargets.map {


### PR DESCRIPTION
We've run into an issue where we are getting some kind of race condition, so we increased logging to try and debug. It made sense to contribute it back. None of these messages (or the mechanism) are set in stone. 

Basically, `-q` works as it did before, but now `-d` displays all debug messages as well. If you specify both, `q` takes priority. 

Testing it on our project, there is no difference in run time to generate. 