### PR TITLE
[PBXProjGenerator] Speed up `PBXProjGenerator.generate()`

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -276,7 +276,7 @@ public class PBXProjGenerator {
             derivedGroups.append(group)
         }
 
-        mainGroup.children = Array(sourceGenerator.rootGroups)
+        mainGroup.children = sourceGenerator.rootGroupsArray
         sortGroups(group: mainGroup)
         setupGroupOrdering(group: mainGroup)
         // add derived groups at the end

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -1569,7 +1569,7 @@ private extension Dependency {
     }
 }
 
-private let concurrentForEachErrorQueue = DispatchQueue(label: "com.xcodegen.PBXProjGenerator.mutationQueue")
+private let concurrentForEachErrorQueue = DispatchQueue(label: "com.xcodegen.concurrentForEachErrorQueue")
 
 private extension Collection where Index == Int {
     func concurrentForEach(_ body: (Element) throws -> Void) throws {

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -225,7 +225,10 @@ public class PBXProjGenerator {
             pbxProject.projects = subprojects
         }
 
-        try project.targets.concurrentForEach { target in
+        // TODO: Generate targets concurrently
+        // At the moment, there's some non-determinism involved, leading to different framework orders in the
+        // generated project.
+        try project.targets.forEach { target in
             try generateTarget(target)
         }
 

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -613,7 +613,9 @@ class SourceGenerator {
             )
 
             if !(createIntermediateGroups || hasCustomParent) || path.parent() == project.basePath {
-                rootGroups.insert(fileReference)
+                _ = mutationQueue.sync {
+                    rootGroups.insert(fileReference)
+                }
             }
 
             let sourceFile = generateSourceFile(targetType: targetType, targetSource: targetSource, path: path, buildPhases: buildPhases)
@@ -632,7 +634,9 @@ class SourceGenerator {
             } else if parentPath == project.basePath {
                 sourcePath = path
                 sourceReference = fileReference
-                rootGroups.insert(fileReference)
+                _ = mutationQueue.sync {
+                    rootGroups.insert(fileReference)
+                }
             } else {
                 let parentGroup = getGroup(
                     path: parentPath,

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -14,7 +14,13 @@ struct SourceFile {
 
 class SourceGenerator {
 
-    var rootGroups: Set<PBXFileElement> = []
+    private var rootGroups: Set<PBXFileElement> = []
+    var rootGroupsArray: [PBXFileElement] {
+        mutationQueue.sync {
+            Array(rootGroups)
+        }
+    }
+
     private let projectDirectory: Path?
     private var fileReferencesByPath: [String: PBXFileElement] = [:]
     private var groupsByPath: [Path: PBXGroup] = [:]
@@ -60,7 +66,9 @@ class SourceGenerator {
         if localPackageGroup == nil {
             let groupName = project.options.localPackagesGroup ?? "Packages"
             localPackageGroup = addObject(PBXGroup(sourceTree: .sourceRoot, name: groupName))
-            rootGroups.insert(localPackageGroup!)
+            _ = mutationQueue.sync {
+                rootGroups.insert(localPackageGroup!)
+            }
         }
 
         let absolutePath = project.basePath + path.normalize()


### PR DESCRIPTION
By processing file groups and target generation concurrently leveraging `DispatchQueue.concurrentPerform(...)`.

On one particularly large project I benchmarked, this speeds up total generation time by 57%:

| | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| Before | 46.247 ± 4.589 | 39.267 | 53.397 | 1.57 ± 0.16 |
| After | 29.412 ± 0.773 | 28.487 | 31.060 | 1.00 |

I found and fixed data races one at a time by running XcodeGen with Thread Sanitizer enabled.

This is really just a proof of concept rather than something we can merge as-is for a few reasons:

1. ~I had to disable error propagation for getting file groups and target generation.~ Update: fixed in 2f75c953aa2d2126202ac6d83d74909b7d24557d
2. The mutation that happens in concurrent steps is hard to reason about. This was already the case before, but this change makes it worse. It's not easy to understand which mutations need to be performed on the mutation queue. This could be improved by using value types instead of reference types and performing copies rather than in-place mutation.