### PR TITLE
[Feature] Add -k, --kinda-quiet flag to suppress all output except for the .xcodeproj path upon success

### DIFF
--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -11,6 +11,9 @@ class GenerateCommand: ProjectCommand {
     @Flag("-q", "--quiet", description: "Suppress all informational and success output")
     var quiet: Bool
 
+    @Flag("-k", "--kinda-quiet", description: "Only output project path upon success")
+    var kindaQuiet: Bool
+
     @Flag("-c", "--use-cache", description: "Use a cache for the xcodegen spec. This will prevent unnecessarily generating the project if nothing has changed")
     var useCache: Bool
 
@@ -111,7 +114,8 @@ class GenerateCommand: ProjectCommand {
         info("⚙️  Writing project...")
         do {
             try fileWriter.writeXcodeProject(xcodeProject, to: projectPath)
-            success("Created project at \(projectPath)")
+            let successStr = kindaQuiet ? projectPath.string : "Created project at \(projectPath)"
+            success(successStr)
         } catch {
             throw GenerationError.writingError(error)
         }
@@ -133,20 +137,20 @@ class GenerateCommand: ProjectCommand {
     }
 
     func info(_ string: String) {
-        if !quiet {
+        if !quiet && !kindaQuiet{
             stdout.print(string)
         }
     }
 
     func warning(_ string: String) {
-        if !quiet {
+        if !quiet && !kindaQuiet {
             stdout.print(string.yellow)
         }
     }
 
     func success(_ string: String) {
-        if !quiet {
-            stdout.print(string.green)
+        if !quiet || kindaQuiet {
+            stdout.print(kindaQuiet ? string : string.green)
         }
     }
 }


### PR DESCRIPTION
I'm open to suggestions on the flag name.  
 
### What?  
Adds a new flag that suppresses all output aside from the `.xcodeproj` path upon success. 
  
### Why?  
To allow for easier scripting.   
  
For example, I generally quit Xcode before running `xcodegen`, then use the `open` command to open the project like this:  
```zsh
tyler@mbp Example % xcodegen

⚙️  Generating plists...
⚙️  Generating project...
⚙️  Writing project...
Created project at /Users/tyler/Example/Example.xcodeproj
tyler@mbp Example % open Example.xcodeproj
```
Since having to always enter the same two commands is slightly annoying to me, I wanted to combine them into one command and use that in an alias.  
  
Without the flag I would need to do something like this:  
```zsh
xcodegen | grep "Created project at" | cut -d ' ' -f 4 | xargs -I project open project
```  
With the flag it can be simplified to just:  
```zsh
xcodegen -k | xargs -I project open project
```

### Example Use 
```zsh
tyler@mbp Example % xcodegen -k
/User/tyler/Example/Example.xcodeproj
```