### PR TITLE
Use produce name from settings as the reference name if present

### DIFF
--- a/Sources/ProjectSpec/Target.swift
+++ b/Sources/ProjectSpec/Target.swift
@@ -173,18 +173,23 @@ extension Target {
                     let newTargetName = platformPrefix + targetName + platformSuffix
 
                     var settings = platformTarget["settings"] as? JSONDictionary ?? [:]
+                    var newProductName: String?
                     if settings["configs"] != nil || settings["groups"] != nil || settings["base"] != nil {
                         var base = settings["base"] as? JSONDictionary ?? [:]
-                        if base["PRODUCT_NAME"] == nil {
+                        if let baseProductName = base["PRODUCT_NAME"] as? String {
+                            newProductName = baseProductName
+                        } else {
                             base["PRODUCT_NAME"] = targetName
                         }
                         settings["base"] = base
                     } else {
-                        if settings["PRODUCT_NAME"] == nil {
+                        if let productName = settings["PRODUCT_NAME"] as? String {
+                            newProductName = productName
+                        } else {
                             settings["PRODUCT_NAME"] = targetName
                         }
                     }
-                    platformTarget["productName"] = targetName
+                    platformTarget["productName"] = newProductName ?? targetName
                     platformTarget["settings"] = settings
                     if let deploymentTargets = target["deploymentTarget"] as? [String: Any] {
                         platformTarget["deploymentTarget"] = deploymentTargets[platform]


### PR DESCRIPTION
I love xcodegen, but when using multiplatform target generation I've always yearned for the ability to change the generated name in the Products group.
![image](https://user-images.githubusercontent.com/8052613/148421840-49b935b1-0273-41c7-a376-4e84c0633c5f.png)
This PR sets the productName to PRODUCT_NAME when present, otherwise targetName
![image](https://user-images.githubusercontent.com/8052613/148421919-df173a78-fb40-4fb1-b5dc-c81f9503af4d.png)
