### PR TITLE
Add checks for duplicate dependencies in targets

### DIFF
--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -56,7 +56,7 @@ public struct Dependency: Equatable {
         public static let `default` = dynamic
     }
 
-    public enum DependencyType: Equatable {
+    public enum DependencyType: Equatable, Hashable {
         case target
         case framework
         case carthage(findFrameworks: Bool?, linkType: CarthageLinkType)

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -78,6 +78,14 @@ extension Project {
             errors += validateSettings(settings)
         }
 
+        for target in targets {
+            let dependencyMap = Dictionary(grouping: target.dependencies, by: { "\($0.type.hashValue)-\($0.reference)" })
+            let duplicates = dependencyMap.filter({ $1.count > 1 })
+            for duplicate in duplicates {
+                errors.append(.duplicateDependencies(target: target.name, dependencyReference: duplicate.1[0].reference))
+            }
+        }
+
         for target in projectTargets {
 
             for (config, configFile) in target.configFiles {

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -32,6 +32,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidPerConfigSettings
         case invalidProjectReference(scheme: String, reference: String)
         case invalidProjectReferencePath(ProjectReference)
+        case duplicateDependencies(target: String, dependencyReference: String)
 
         public var description: String {
             switch self {
@@ -79,6 +80,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Scheme \(scheme.quoted) has invalid project reference \(project.quoted)"
             case let .invalidProjectReferencePath(reference):
                 return "Project reference \(reference.name) has a project file path that doesn't exist \"\(reference.path)\""
+            case let .duplicateDependencies(target, dependencyReference):
+                return "Target \(target.quoted) has the dependency \(dependencyReference.quoted) multiple times"
             }
         }
     }


### PR DESCRIPTION
Dependencies can have multiple properties set on them, but having the same type and reference is a collision and could generate unexpected results.