### PR TITLE
Run target source pattern matching in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Fix Monterey macOS shell version, shell login flag for environments [#1167](https://github.com/yonaskolb/XcodeGen/issues/1167) @bimawa
 
+### Changed
+
+- Run target source pattern matching in parallel [#1197](https://github.com/yonaskolb/XcodeGen/pull/1197) @alvarhansen
+
 ## 2.27.0
 
 #### Added

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -349,7 +349,7 @@ class SourceGenerator {
         let rootSourcePath = project.basePath + targetSource.path
 
         return Set(
-            patterns.map { pattern in
+            patterns.parallelMap { pattern in
                 guard !pattern.isEmpty else { return [] }
                 return Glob(pattern: "\(rootSourcePath)/\(pattern)")
                     .map { Path($0) }


### PR DESCRIPTION
As this transform closure does not access anything outside of its
closure and does not mutate any singletons, then it seems to be safe
to run this mapping in parallel.

In our project with 47 Targets and ~7000 files across them, the project generation time went from 6s to 3.2s:
```
> hyperfine 'current_xcodegen' 'parallel_xcodegen'
Benchmark 1: current_xcodegen
  Time (mean ± σ):      5.917 s ±  0.123 s    [User: 5.374 s, System: 2.368 s]
  Range (min … max):    5.757 s …  6.078 s    10 runs
 
Benchmark 2: parallel_xcodegen
  Time (mean ± σ):      3.210 s ±  0.045 s    [User: 5.603 s, System: 1.439 s]
  Range (min … max):    3.135 s …  3.276 s    10 runs
 
Summary
  'parallel_xcodegen' ran
    1.84 ± 0.05 times faster than 'current_xcodegen'
```