### PR TITLE
Fix docc support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+#### Fixed
+
+- Fixed an issue where DocC was not added to source file list #1202 @hiragram
+
 ## 2.28.0
 
 #### Added

--- a/Sources/ProjectSpec/FileType.swift
+++ b/Sources/ProjectSpec/FileType.swift
@@ -89,6 +89,7 @@ extension FileType {
         "mlmodel": FileType(buildPhase: .sources),
         "rcproject": FileType(buildPhase: .sources),
         "iig": FileType(buildPhase: .sources),
+        "docc": FileType(buildPhase: .sources),
 
         // headers
         "h": FileType(buildPhase: .headers),
@@ -113,6 +114,5 @@ extension FileType {
         "xcfilelist": FileType(buildPhase: BuildPhaseSpec.none),
         "apns": FileType(buildPhase: BuildPhaseSpec.none),
         "pch": FileType(buildPhase: BuildPhaseSpec.none),
-        "docc": FileType(buildPhase: BuildPhaseSpec.none),
     ]
 }

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		1E03FC7312293997599C6435 /* Empty.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 068EDF47F0B087F6A4052AC0 /* Empty.h */; };
 		1E2A4D61E96521FF7123D7B0 /* XPC Service.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = 22237B8EBD9E6BE8EBC8735F /* XPC Service.xpc */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1E457F55331FD2C3E8E00BE2 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1F9168A43FD8E2FCC2699E14 /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = B5C943D39DD7812CAB94B614 /* Documentation.docc */; settings = {COMPILER_FLAGS = "-Werror"; }; };
 		210B49C23B9717C668B40C8C /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		2116F89CF5A04EA0EFA30A89 /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D88C6BF7355702B74396791 /* TestProjectUITests.swift */; };
 		212BCB51DAF3212993DDD49E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D51CC8BCCBD68A90E90A3207 /* Assets.xcassets */; };
@@ -2655,6 +2656,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				09617AB755651FFEB2564CBC /* AppDelegate.swift in Sources */,
+				1F9168A43FD8E2FCC2699E14 /* Documentation.docc in Sources */,
 				666DEC173BC78C7641AB22EC /* File1.swift in Sources */,
 				339578307B9266AB3D7722D9 /* File2.swift in Sources */,
 				F788A3FA1CE6489BC257C1C3 /* Model.xcdatamodeld in Sources */,

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -655,7 +655,7 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFileMissing(paths: ["C", "Settings.bundle", "Root.plist"])
                 try pbxProj.expectFileMissing(paths: ["C", "WithPeriod2.0"])
                 try pbxProj.expectFile(paths: ["C", "WithPeriod2.0", "file.swift"], buildPhase: .sources)
-                try pbxProj.expectFile(paths: ["C", "Documentation.docc"], buildPhase: BuildPhaseSpec.none)
+                try pbxProj.expectFile(paths: ["C", "Documentation.docc"], buildPhase: .sources)
             }
 
             $0.it("only omits the defined Info.plist from resource build phases but not other plists") {


### PR DESCRIPTION
Current implementation for DocC support looks incorrect.

A DocC newly created in Xcode is a member of its target and appears in "Build Phases -> Compile Sources".

<img width="260" alt="スクリーンショット 2022-04-01 5 08 50" src="https://user-images.githubusercontent.com/3433324/161141515-c8af2b9d-3118-4907-a4a1-6aca77f37bd4.png">

But running latest XcodeGen removes DocC from the target and Xcode will not compile it anymore. 