### PR TITLE
Fix data races in SettingsBuilder.

### DIFF
--- a/Sources/XcodeGenKit/NSCacheExtensions.swift
+++ b/Sources/XcodeGenKit/NSCacheExtensions.swift
@@ -1,0 +1,37 @@
+import XcodeProj
+import Foundation
+
+enum Cached<T> {
+    case cached(T)
+    case nothing
+
+    var value: T? {
+        switch self {
+        case let .cached(value): return value
+        case .nothing: return nil
+        }
+    }
+}
+
+final class CacheContainer {
+    let value: Cached<BuildSettings>
+
+    init(value: Cached<BuildSettings>) {
+        self.value = value
+    }
+}
+
+extension NSCache where KeyType == NSString, ObjectType == CacheContainer {
+    subscript(aKey: String) -> Cached<BuildSettings>? {
+        get {
+            object(forKey: aKey as NSString)?.value
+        }
+        set {
+            if let value = newValue {
+                setObject(CacheContainer(value: value), forKey: aKey as NSString)
+            } else {
+                removeObject(forKey: aKey as NSString)
+            }
+        }
+    }
+}

--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -160,23 +160,11 @@ extension Project {
     }
 }
 
-private enum Cached<T> {
-    case cached(T)
-    case nothing
-
-    var value: T? {
-        switch self {
-        case let .cached(value): return value
-        case .nothing: return nil
-        }
-    }
-}
-
 // cached flattened xcconfig file settings
-private var configFileSettings: [String: Cached<BuildSettings>] = [:]
+private var configFileSettings = NSCache<NSString, CacheContainer>()
 
 // cached setting preset settings
-private var settingPresetSettings: [String: Cached<BuildSettings>] = [:]
+private var settingPresetSettings = NSCache<NSString, CacheContainer>()
 
 extension SettingsPresetFile {
 


### PR DESCRIPTION
**Reason:**
- `configFileSettings` and `settingPresetSettings` caches were just global dictionaries. Data races were taken place at these points when multiple projects are generated in parallel.

**Content:**
- Dictionaries for caches moved to NSCache which is thread safe.