### PR TITLE
Handle mlmodelc as a single unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+### Added
+
+- Add support for `mlmodelc` files #1236 @antonsergeev88
+
 ## 2.31.0
 
 ### Added

--- a/Sources/ProjectSpec/FileType.swift
+++ b/Sources/ProjectSpec/FileType.swift
@@ -87,6 +87,7 @@ extension FileType {
         "intentdefinition": FileType(buildPhase: .sources),
         "metal": FileType(buildPhase: .sources),
         "mlmodel": FileType(buildPhase: .sources),
+        "mlmodelc": FileType(buildPhase: .resources),
         "rcproject": FileType(buildPhase: .sources),
         "iig": FileType(buildPhase: .sources),
         "docc": FileType(buildPhase: .sources),

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -589,6 +589,7 @@ class SourceGeneratorTests: XCTestCase {
                     - file.xcassets
                     - file.metal
                     - file.mlmodel
+                    - file.mlmodelc
                     - Info.plist
                     - Intent.intentdefinition
                     - Configuration.storekit
@@ -647,6 +648,7 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFile(paths: ["C", "Info.plist"], buildPhase: BuildPhaseSpec.none)
                 try pbxProj.expectFile(paths: ["C", "file.metal"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["C", "file.mlmodel"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: ["C", "file.mlmodelc"], buildPhase: .resources)
                 try pbxProj.expectFile(paths: ["C", "Intent.intentdefinition"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["C", "Configuration.storekit"], buildPhase: .resources)
                 try pbxProj.expectFile(paths: ["C", "Settings.bundle"], buildPhase: .resources)


### PR DESCRIPTION
Fix #1236 
Handle mlmodelc file wrappers as single resource unit