### PR TITLE
Correct name of package in example yaml

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -1019,7 +1019,7 @@ packages:
   Yams:
     url: https://github.com/jpsim/Yams
     from: 2.0.0
-  Yams:
+  Ink:
     github: JohnSundell/Ink
     from: 0.5.0
   RxClient:


### PR DESCRIPTION
Hey there, I just noticed that one of the example yaml snippets had the wrong package name specified.