### PR TITLE
Add `enable` option for `include` to enable optional including for addtional spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@
 ### Added
 
 - Add support for `mlmodelc` files #1236 @antonsergeev88
-- Add `enable` option for `include` #MMMM @freddi-kit
+- Add `enable` option for `include` #1242 @freddi-kit
 
 ### Fixed
-- Fix checking environment variable in `include` #MMMM @freddi-kit
+- Fix checking environment variable in `include` #1242 @freddi-kit
 
 ## 2.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 
 - Add support for `mlmodelc` files #1236 @antonsergeev88
+- Add `enable` option for `include` #MMMM @freddi-kit
+
+### Fixed
+- Fix checking environment variable in `include` #MMMM @freddi-kit
 
 ## 2.31.0
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -64,7 +64,7 @@ An include can be provided via a string (the path) or an object of the form:
 
 - [x] **path**: **String** - The path to the included file.
 - [ ] **relativePaths**: **Bool** - Dictates whether the included spec specifies paths relative to itself (the default) or the root spec file.
-- [ ] **enable**: **Bool** - Dictates whether the specified spec should be included or not. You can specify it by environment variable.
+- [ ] **enable**: **Bool** - Dictates whether the specified spec should be included or not. You can also specify it by environment variable.
 ```yaml
 include:
   - includedFile.yml

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -64,12 +64,13 @@ An include can be provided via a string (the path) or an object of the form:
 
 - [x] **path**: **String** - The path to the included file.
 - [ ] **relativePaths**: **Bool** - Dictates whether the included spec specifies paths relative to itself (the default) or the root spec file.
-
+- [ ] **enable**: **Bool** - Dictates whether the specified spec should be included or not. You can specify it by environment variable.
 ```yaml
 include:
   - includedFile.yml
   - path: path/to/includedFile.yml
     relativePaths: false
+    enable: ${INCLUDE_ADDITIONAL_YAML}
 ```
 
 By default specs are merged additively. That is for every value:

--- a/Sources/ProjectSpec/SpecFile.swift
+++ b/Sources/ProjectSpec/SpecFile.swift
@@ -28,8 +28,9 @@ public struct SpecFile {
                 let expandedDictionary = dictionary.expand(variables: variables)
                 guard let path = expandedDictionary["path"] as? String else { return nil }
                 self.path = Path(path)
-                relativePaths = expandedDictionary["relativePaths"] as? Bool ?? Include.defaultRelativePaths
-                enable = (expandedDictionary["enable"] as? NSString)?.boolValue ?? Include.defaultEnable
+
+                relativePaths = Self.resolveBoolean(expandedDictionary, key: "relativePaths") ?? Include.defaultRelativePaths
+                enable = Self.resolveBoolean(expandedDictionary, key: "enable") ?? Include.defaultEnable
             } else {
                 return nil
             }
@@ -43,6 +44,10 @@ public struct SpecFile {
             } else {
                 return []
             }
+        }
+
+        private static func resolveBoolean(_ dictionary: [String: Any], key: String) -> Bool? {
+            dictionary[key] as? Bool ?? (dictionary[key] as? NSString)?.boolValue
         }
     }
 

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -17,7 +17,7 @@ public class SpecLoader {
 
     public func loadProject(path: Path, projectRoot: Path? = nil, variables: [String: String] = [:]) throws -> Project {
         let spec = try SpecFile(path: path, variables: variables)
-        let resolvedDictionary = spec.resolvedDictionary(variables: variables)
+        let resolvedDictionary = spec.resolvedDictionary()
         let project = try Project(basePath: projectRoot ?? spec.basePath, jsonDictionary: resolvedDictionary)
 
         self.project = project

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -16,7 +16,7 @@ public class SpecLoader {
     }
 
     public func loadProject(path: Path, projectRoot: Path? = nil, variables: [String: String] = [:]) throws -> Project {
-        let spec = try SpecFile(path: path)
+        let spec = try SpecFile(path: path, variables: variables)
         let resolvedDictionary = spec.resolvedDictionary(variables: variables)
         let project = try Project(basePath: projectRoot ?? spec.basePath, jsonDictionary: resolvedDictionary)
 

--- a/Tests/Fixtures/include_test.yml
+++ b/Tests/Fixtures/include_test.yml
@@ -2,6 +2,10 @@ include:
     - included.yml
     - path: non-include.yml
       enable: ${INCLUDE_ADDTIONAL_YAML}
+packages:
+  Yams:
+    url: https://github.com/jpsim/Yams
+    majorVersion: 2.0.0
 name: NewName
 settingGroups:
   test:
@@ -22,3 +26,5 @@ targets:
     name: IncludedTargetNew
     platform: tvOS
     sources:REPLACE: NewSource
+    dependencies:
+      - package: Yams

--- a/Tests/Fixtures/include_test.yml
+++ b/Tests/Fixtures/include_test.yml
@@ -1,4 +1,7 @@
-include: [included.yml]
+include:
+    - included.yml
+    - path: non-include.yml
+      enable: ${INCLUDE_ADDTIONAL_YAML}
 name: NewName
 settingGroups:
   test:

--- a/Tests/Fixtures/include_test.yml
+++ b/Tests/Fixtures/include_test.yml
@@ -1,6 +1,6 @@
 include:
     - included.yml
-    - path: non-include.yml
+    - path: included_addtional.yml
       enable: ${INCLUDE_ADDTIONAL_YAML}
 packages:
   Yams:

--- a/Tests/Fixtures/included.yml
+++ b/Tests/Fixtures/included.yml
@@ -1,4 +1,8 @@
 name: Included
+packages:
+  SwiftPM:
+    url: https://github.com/apple/swift-package-manager
+    branch: swift-5.0-branch
 settingGroups:
   test:
     MY_SETTING1: VALUE1
@@ -12,6 +16,8 @@ targets:
     platform: iOS
     sources:
       - Target
+    dependencies:
+      - package: SwiftPM
 targetTemplates:
   IncludedTemplate:
     sources:

--- a/Tests/Fixtures/included.yml
+++ b/Tests/Fixtures/included.yml
@@ -1,8 +1,4 @@
 name: Included
-packages:
-  SwiftPM:
-    url: https://github.com/apple/swift-package-manager
-    branch: swift-5.0-branch
 settingGroups:
   test:
     MY_SETTING1: VALUE1
@@ -16,8 +12,6 @@ targets:
     platform: iOS
     sources:
       - Target
-    dependencies:
-      - package: SwiftPM
 targetTemplates:
   IncludedTemplate:
     sources:

--- a/Tests/Fixtures/included_addtional.yml
+++ b/Tests/Fixtures/included_addtional.yml
@@ -1,0 +1,12 @@
+name: Included_Addtional
+settingGroups:
+  test:
+    MY_SETTING5: ADDTIONAL
+packages:
+  SwiftPM:
+    url: https://github.com/apple/swift-package-manager
+    branch: swift-5.0-branch
+targets:
+  IncludedTarget:
+    dependencies:
+      - package: SwiftPM

--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -15,8 +15,8 @@ class GeneratedPerformanceTests: XCTestCase {
         try dumpYamlDictionary(project.toJSONDictionary(), path: specPath)
 
         measure {
-            let spec = try! SpecFile(path: specPath)
-            _ = spec.resolvedDictionary(variables: ProcessInfo.processInfo.environment)
+            let spec = try! SpecFile(path: specPath, variables: ProcessInfo.processInfo.environment)
+            _ = spec.resolvedDictionary()
         }
     }
 

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -59,6 +59,22 @@ class SpecLoadingTests: XCTestCase {
                 ]
             }
 
+            $0.it("merges includes without addtional one by environemnt variable") {
+                let path = fixturePath + "include_test.yml"
+                let project = try loadSpec(path: path, variables: ["INCLUDE_ADDTIONAL_YAML": "NO"])
+
+                try expect(project.name) == "NewName"
+                try expect(project.settingGroups) == [
+                    "test": Settings(dictionary: ["MY_SETTING1": "NEW VALUE", "MY_SETTING2": "VALUE2", "MY_SETTING3": "VALUE3", "MY_SETTING4": "${SETTING4}"]),
+                    "new": Settings(dictionary: ["MY_SETTING": "VALUE"]),
+                    "toReplace": Settings(dictionary: ["MY_SETTING2": "VALUE2"]),
+                ]
+                try expect(project.targets) == [
+                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"], dependencies: [Dependency(type: .package(product: nil), reference: "Yams")]),
+                    Target(name: "NewTarget", type: .application, platform: .iOS, sources: ["template", "target"]),
+                ]
+            }
+
             $0.it("expands directories") {
                 let path = fixturePath + "paths_test.yml"
                 let project = try loadSpec(path: path)

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -29,7 +29,7 @@ class SpecLoadingTests: XCTestCase {
         describe {
             $0.it("merges includes") {
                 let path = fixturePath + "include_test.yml"
-                let project = try loadSpec(path: path)
+                let project = try loadSpec(path: path, variables: ["INCLUDE_ADDTIONAL_YAML" : "NO"])
 
                 try expect(project.name) == "NewName"
                 try expect(project.settingGroups) == [

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -38,7 +38,7 @@ class SpecLoadingTests: XCTestCase {
                     "toReplace": Settings(dictionary: ["MY_SETTING2": "VALUE2"]),
                 ]
                 try expect(project.targets) == [
-                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"]),
+                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"], dependencies: [Dependency(type: .package(product: nil), reference: "SwiftPM"), Dependency(type: .package(product: nil), reference: "Yams")]),
                     Target(name: "NewTarget", type: .application, platform: .iOS, sources: ["template", "target"]),
                 ]
             }

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -29,11 +29,27 @@ class SpecLoadingTests: XCTestCase {
         describe {
             $0.it("merges includes") {
                 let path = fixturePath + "include_test.yml"
-                let project = try loadSpec(path: path, variables: ["INCLUDE_ADDTIONAL_YAML" : "NO"])
+                let project = try loadSpec(path: path, variables: [:])
 
                 try expect(project.name) == "NewName"
                 try expect(project.settingGroups) == [
                     "test": Settings(dictionary: ["MY_SETTING1": "NEW VALUE", "MY_SETTING2": "VALUE2", "MY_SETTING3": "VALUE3", "MY_SETTING4": "${SETTING4}"]),
+                    "new": Settings(dictionary: ["MY_SETTING": "VALUE"]),
+                    "toReplace": Settings(dictionary: ["MY_SETTING2": "VALUE2"]),
+                ]
+                try expect(project.targets) == [
+                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"], dependencies: [Dependency(type: .package(product: nil), reference: "Yams")]),
+                    Target(name: "NewTarget", type: .application, platform: .iOS, sources: ["template", "target"]),
+                ]
+            }
+
+            $0.it("merges includes with addtional one") {
+                let path = fixturePath + "include_test.yml"
+                let project = try loadSpec(path: path, variables: ["INCLUDE_ADDTIONAL_YAML": "YES"])
+
+                try expect(project.name) == "NewName"
+                try expect(project.settingGroups) == [
+                    "test": Settings(dictionary: ["MY_SETTING1": "NEW VALUE", "MY_SETTING2": "VALUE2", "MY_SETTING3": "VALUE3", "MY_SETTING4": "${SETTING4}", "MY_SETTING5": "ADDTIONAL"]),
                     "new": Settings(dictionary: ["MY_SETTING": "VALUE"]),
                     "toReplace": Settings(dictionary: ["MY_SETTING2": "VALUE2"]),
                 ]


### PR DESCRIPTION
# Motivation
Currently, we cannot disable the adding additional spec from other file, by `include` option so it is unable to generate variety project by XcodeGen.

For example, we cannot generate the project which has difference between Debug and Release. We may have the dependency which is not necessary for release environment, like debug logger framework.


# Achivement
By this PR, we can achive the such things by XcodeGen. For example,


```yml
include:
  - path: dependency_for_debug.yml
    enable: ${DEBUG_BUILD}
```

This yml files only imports debug dependency if DEBUG_BUILD environment object is defined as "YES".

We also can specify normal boolean literal.

```yml
include:
  - path: dependency_for_debug.yml
    enable: false
```


# Changes
- Add `enable` option for `include`
- Fix checking environment variable in `include`

# Test
Added to Tests/ProjectSpecTests/SpecLoadingTests.swift