### PR TITLE
Fix profile action to not run frameworks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fix profile action to not run frameworks @SSheldon
+- Fix profile action to not run frameworks #1245 @SSheldon
 
 ## 2.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixed
 
-- Fix profile action to not run frameworks #1245 @SSheldon
+- Fix profile action for frameworks in Xcode 14 #1245 @SSheldon
 
 ## 2.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add support for `mlmodelc` files #1236 @antonsergeev88
 
+### Fixed
+
+- Fix profile action to not run frameworks @SSheldon
+
 ## 2.31.0
 
 ### Added

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -320,10 +320,11 @@ public class SchemeGenerator {
         )
 
         let profileAction = XCScheme.ProfileAction(
-            buildableProductRunnable: runnables.profile,
+            buildableProductRunnable: shouldExecuteOnLaunch ? runnables.profile : nil,
             buildConfiguration: scheme.profile?.config ?? defaultReleaseConfig.name,
             preActions: scheme.profile?.preActions.map(getExecutionAction) ?? [],
             postActions: scheme.profile?.postActions.map(getExecutionAction) ?? [],
+            macroExpansion: shouldExecuteOnLaunch ? nil : buildableReference,
             shouldUseLaunchSchemeArgsEnv: scheme.profile?.shouldUseLaunchSchemeArgsEnv ?? true,
             askForAppToLaunch: scheme.profile?.askForAppToLaunch,
             commandlineArguments: profileCommandLineArgs,

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
@@ -100,8 +100,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "AE3F93DB94E7208F2F1D9A78"
@@ -109,7 +108,7 @@
             BlueprintName = "Framework_iOS"
             ReferencedContainer = "container:Project.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Production Debug">


### PR DESCRIPTION
This change applies the logic added for the launch action in #328 to the profile action. Profile actions that attempt to run frameworks just crash instruments; for watchOS frameworks, they even cause Xcode 14 betas to fail to build, as described in #1226.

## Validation

Using Xcode 13.0, I created schemes for a bunch of different kinds of targets and observed the profile action in the scheme it generated. I then opened these schemes with Xcode 13.3 and 14.0b5 and confirmed the action didn't change.

The following types of targets had build product runnables in the profile scheme:
* ios app
* watch app
* extension
* command line tool

And the following types had buildable reference macro expansions: 
* framework
* library
* metal library
* bundle
* xpc service

These line up with the logic for `shouldExecuteOnLaunch` used for the launch action.

I also ran tests, confirmed they passed, and added the only fixture change.

Testing in the Xcode 14 betas has confirmed that a change like this to the scheme for a watchOS framework fixes the build issue.