### PR TITLE
add external xcode and spm project and use their targets in testable

### DIFF
--- a/Tests/Fixtures/MigrationTestProject/MigrationTestProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/MigrationTestProject/MigrationTestProject.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		566B1C7B0D39BF3A11552878 /* Pods-MigrationTestProjectTests.debug2.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MigrationTestProjectTests.debug2.xcconfig"; path = "Target Support Files/Pods-MigrationTestProjectTests/Pods-MigrationTestProjectTests.debug2.xcconfig"; sourceTree = "<group>"; };
 		568B909CEE0C7F9F12ACD764 /* Pods-MigrationTestProject.debug2.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MigrationTestProject.debug2.xcconfig"; path = "Target Support Files/Pods-MigrationTestProject/Pods-MigrationTestProject.debug2.xcconfig"; sourceTree = "<group>"; };
 		66F5BEAC7F35B64781832095 /* Pods-ExampleFramework.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFramework.release.xcconfig"; path = "Target Support Files/Pods-ExampleFramework/Pods-ExampleFramework.release.xcconfig"; sourceTree = "<group>"; };
+		678E967428AF1485006F06D2 /* SPM-project */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = "SPM-project"; path = "../SPM-project"; sourceTree = "<group>"; };
 		73FC1184ACCE8E5FC651CA81 /* Pods-ExampleFramework.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFramework.adhoc.xcconfig"; path = "Target Support Files/Pods-ExampleFramework/Pods-ExampleFramework.adhoc.xcconfig"; sourceTree = "<group>"; };
 		7C3BDAF0C1634E298DC42D1E /* Pods-ExampleFramework-ExampleFrameworkTests.debug2.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFramework-ExampleFrameworkTests.debug2.xcconfig"; path = "Target Support Files/Pods-ExampleFramework-ExampleFrameworkTests/Pods-ExampleFramework-ExampleFrameworkTests.debug2.xcconfig"; sourceTree = "<group>"; };
 		852055E33EDB0B4F05F5CCCA /* Pods-MigrationTestProject.adhoc.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MigrationTestProject.adhoc.xcconfig"; path = "Target Support Files/Pods-MigrationTestProject/Pods-MigrationTestProject.adhoc.xcconfig"; sourceTree = "<group>"; };
@@ -189,6 +190,14 @@
 			path = Pods;
 			sourceTree = "<group>";
 		};
+		678E967328AF1485006F06D2 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				678E967428AF1485006F06D2 /* SPM-project */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
 		D9B458342545207400C2DB2E /* ObjC */ = {
 			isa = PBXGroup;
 			children = (
@@ -201,6 +210,7 @@
 		D9BD31DD24BAE14A0056ACD2 = {
 			isa = PBXGroup;
 			children = (
+				678E967328AF1485006F06D2 /* Packages */,
 				D9BD31E824BAE14A0056ACD2 /* MigrationTestProject */,
 				D9BD31FF24BAE14C0056ACD2 /* MigrationTestProjectTests */,
 				D9BD321124BAE38F0056ACD2 /* ExampleFramework */,

--- a/Tests/Fixtures/MigrationTestProject/MigrationTestProject.xcodeproj/xcshareddata/xcschemes/MigrationTestProject.xcscheme
+++ b/Tests/Fixtures/MigrationTestProject/MigrationTestProject.xcodeproj/xcshareddata/xcschemes/MigrationTestProject.xcscheme
@@ -48,6 +48,26 @@
                ReferencedContainer = "container:MigrationTestProject.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "339863E54E2D955C00B56802"
+               BuildableName = "Tests.xctest"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:../SPM/SPM.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "spm-projectTests"
+               BuildableName = "spm-projectTests"
+               BlueprintName = "spm-projectTests"
+               ReferencedContainer = "container:../SPM-project">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Tests/Fixtures/MigrationTestProject/MigrationTestProject.xcworkspace/contents.xcworkspacedata
+++ b/Tests/Fixtures/MigrationTestProject/MigrationTestProject.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,7 @@
    <FileRef
       location = "group:Pods/Pods.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:../SPM/SPM.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/Tests/Fixtures/SPM-project/.gitignore
+++ b/Tests/Fixtures/SPM-project/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/Fixtures/SPM-project/Package.swift
+++ b/Tests/Fixtures/SPM-project/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "spm-project",
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .executableTarget(
+            name: "spm-project",
+            dependencies: []),
+        .testTarget(
+            name: "spm-projectTests",
+            dependencies: ["spm-project"]),
+    ]
+)

--- a/Tests/Fixtures/SPM-project/README.md
+++ b/Tests/Fixtures/SPM-project/README.md
@@ -1,0 +1,3 @@
+# spm-project
+
+A description of this package.

--- a/Tests/Fixtures/SPM-project/Sources/spm-project/spm_project.swift
+++ b/Tests/Fixtures/SPM-project/Sources/spm-project/spm_project.swift
@@ -1,0 +1,8 @@
+@main
+public struct spm_project {
+    public private(set) var text = "Hello, World!"
+
+    public static func main() {
+        print(spm_project().text)
+    }
+}

--- a/Tests/Fixtures/SPM-project/Tests/spm-projectTests/spm_projectTests.swift
+++ b/Tests/Fixtures/SPM-project/Tests/spm-projectTests/spm_projectTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import spm_project
+
+final class spm_projectTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+        XCTAssertEqual(spm_project().text, "Hello, World!")
+    }
+}

--- a/Tests/XcodeGenKitTests/SpecGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SpecGeneratorTests.swift
@@ -58,6 +58,21 @@ class SpecGeneratorTests: XCTestCase {
                 try expect (project.schemes.count) == 3
             }
             
+            $0.it("check scheme names") {
+                try expect(project.schemes[0].name) == "ExampleFramework"
+                try expect(project.schemes[1].name) == "ExampleScheme"
+                try expect(project.schemes[2].name) == "MigrationTestProject"
+            }
+            
+            $0.it("check scheme test targets") {
+                try expect(project.schemes[2].test?.targets.count) == 4
+                try expect(project.schemes[2].test?.targets[0].name) == "MigrationTestProjectTests"
+                try expect(project.schemes[2].test?.targets[1].name) == "ExampleFrameworkTests"
+                try expect(project.schemes[2].test?.targets[2].name) == "Tests"
+                try expect(project.schemes[2].test?.targets[3].name) == "spm-projectTests"
+                //try expect(project.schemes[2].test?.targets[3].targetReference) == "spm-projectTests"
+            }
+            
             $0.it("deintegrates Cocoapods") {
                 for target in project.targets {
                     try expect(target.buildScripts.allSatisfy { !($0.name ?? "").starts(with: "[CP]") }).to.beTrue()


### PR DESCRIPTION
I want to test if [external test targets](https://github.com/yonaskolb/XcodeGen/pull/1169) can be generated with spec-generation. In order for this to work it's important to create example fixtures for this scenario.