### PR TITLE
Add LD_RUNPATH_SEARCH_PATHS to extensionkit-extension preset

### DIFF
--- a/SettingPresets/Products/extensionkit-extension.yml
+++ b/SettingPresets/Products/extensionkit-extension.yml
@@ -1,0 +1,1 @@
+LD_RUNPATH_SEARCH_PATHS: ["$(inherited)", "@executable_path/Frameworks", "@executable_path/../../Frameworks"]


### PR DESCRIPTION
Add `LD_RUNPATH_SEARCH_PATHS` option as it is for other types of extensions (e.g. app extension).
I followed the same logic of #272, copying the value from the current version of [SettingPresets/Products/app-extension.yml](https://github.com/yonaskolb/XcodeGen/blob/master/SettingPresets/Products/app-extension.yml) 