### PR TITLE
allow aggregate targets to have project external targets

### DIFF
--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -147,7 +147,8 @@ extension Project {
 
         for target in aggregateTargets {
             for dependency in target.targets {
-                if getProjectTarget(dependency) == nil {
+                if getProjectTarget(dependency) == nil, let projectName = dependency.components(separatedBy: "/").first,
+                   (getPackage(projectName) == nil && getProjectReference(projectName) == nil) {
                     errors.append(.invalidTargetDependency(target: target.name, dependency: dependency))
                 }
             }

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -344,15 +344,13 @@ public class PBXProjGenerator {
                 , let projectName: String = tokens[0]
                 , let targetName: String = tokens[1] {
                 
-                
-                if let packageReference = packageReferences[dependency] {
+                if nil != project.packages[projectName] {
                     let productName = targetName
                     let packageDependency = addObject(
-                        XCSwiftPackageProductDependency(productName: productName, package: packageReference)
+                        XCSwiftPackageProductDependency(productName: productName)
                     )
                     
                     let targetDependency = addObject(
-                        //platformFilter: platform,
                         PBXTargetDependency( product: packageDependency)
                     )
                     return targetDependency

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -32,6 +32,7 @@ aggregateTargets:
   IncludedAggregateTarget:
     targets:
       - IncludedTarget
+      - AnotherProject/ExternalTarget
     configFiles:
       Config: config
     buildScripts:

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -97,7 +97,7 @@ class SpecLoadingTests: XCTestCase {
                 try expect(project.aggregateTargets) == [
                     AggregateTarget(
                         name: "IncludedAggregateTarget",
-                        targets: ["IncludedTarget"],
+                        targets: ["IncludedTarget", "ProjX/TestFramework"],
                         configFiles: ["Config": "paths_test/config"],
                         buildScripts: [BuildScript(script: .path("paths_test/buildScript"))]
                     ),


### PR DESCRIPTION
Sometimes it is necessary to include targets of an external project in an aggregate target. 
-> Aggregate targets, currently do not support the use of external targets.

With this PR I would like to add an initial version on how to include external targets.