### PR TITLE
adding support for adding files that don't belong to a target

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -25,6 +25,7 @@
 - [Scheme](#scheme)
 - [Scheme Template](#scheme-template)
 - [Swift Package](#swift-package)
+- [Files](#files)
 
 ## General
 
@@ -1046,4 +1047,20 @@ schemes:
     build:
       targets:
         YamsProject/Yams: ["run"]
+```
+
+## Files
+
+Specify additional files to be included in the project. This can either be a single source or a list of sources. These files are not associated with a target.
+
+A source can be provided via a string (the path) or an object of the form of a [Target Source](#target-source) 
+
+```yml
+files:
+  - path: README.md
+  - path: project.yml
+  - path: Resources/Config
+    name: Config
+    includes:
+      - "*.json"
 ```

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -35,6 +35,7 @@ public struct Project: BuildSettingsContainer {
             projectReferencesMap = Dictionary(uniqueKeysWithValues: projectReferences.map { ($0.name, $0) })
         }
     }
+    public var files: [TargetSource]
 
     private var targetsMap: [String: Target]
     private var aggregateTargetsMap: [String: AggregateTarget]
@@ -54,7 +55,8 @@ public struct Project: BuildSettingsContainer {
         fileGroups: [String] = [],
         configFiles: [String: String] = [:],
         attributes: [String: Any] = [:],
-        projectReferences: [ProjectReference] = []
+        projectReferences: [ProjectReference] = [],
+        files: [TargetSource] = []
     ) {
         self.basePath = basePath
         self.name = name
@@ -73,6 +75,7 @@ public struct Project: BuildSettingsContainer {
         self.attributes = attributes
         self.projectReferences = projectReferences
         projectReferencesMap = Dictionary(uniqueKeysWithValues: self.projectReferences.map { ($0.name, $0) })
+        self.files = files
     }
 
     public func getProjectReference(_ projectName: String) -> ProjectReference? {
@@ -205,6 +208,7 @@ extension Project {
         targetsMap = Dictionary(uniqueKeysWithValues: targets.map { ($0.name, $0) })
         aggregateTargetsMap = Dictionary(uniqueKeysWithValues: aggregateTargets.map { ($0.name, $0) })
         projectReferencesMap = Dictionary(uniqueKeysWithValues: projectReferences.map { ($0.name, $0) })
+        files =  try jsonDictionary.json(atKeyPath: "files")
     }
 
     static func resolveProject(jsonDictionary: JSONDictionary) -> JSONDictionary {

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -26,6 +26,7 @@ public class PBXProjGenerator {
     var carthageFrameworksByPlatform: [String: Set<PBXFileElement>] = [:]
     var frameworkFiles: [PBXFileElement] = []
     var bundleFiles: [PBXFileElement] = []
+    var projectFiles: [PBXFileElement] = []
 
     var generated = false
 
@@ -107,7 +108,9 @@ public class PBXProjGenerator {
         )
 
         pbxProj.rootObject = pbxProject
-
+        
+        // Files that do not belong to a target
+        let sourceFiles = try sourceGenerator.getAllSourceFiles(targetType: .none, sources: project.files, buildPhases: [:]).sorted { $0.path.lastComponent < $1.path.lastComponent }
         for target in project.targets {
             let targetObject: PBXTarget
 


### PR DESCRIPTION
For some projects it might be helpful to add files to a project that don't belong to a specific target. 

For example, `README.md` files or the `project.yml`.


## Known Issues

* Currently I just use `TargetSources` to achieve this capability. If the general direction of this PR is acceptable, then I would - in a separate PR - rename `TargetSources` to `SourcesReference` (or something similar)
* I need to add unit tests for this