### PR TITLE
allow multiple spec files to be provided to XcodeGen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added support for `enableGPUFrameCaptureMode` #1251 @bsudekum
+- Added ability to generate multiple projects in one XcodeGen launch #1270 @skofgar
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This will look for a project spec in the current directory called `project.yml` 
 
 Options:
 
-- **--spec**: An optional path to a `.yml` or `.json` project spec. Defaults to `project.yml`
+- **--spec**: An optional path to a `.yml` or `.json` project spec. Defaults to `project.yml`. (It is also possible to link to multiple spec files by comma separating them. Note that all other flags will be the same.)
 - **--project**: An optional path to a directory where the project will be generated. By default this is the directory the spec lives in.
 - **--quiet**: Suppress informational and success messages.
 - **--use-cache**: Used to prevent unnecessarily generating the project. If this is set, then a cache file will be written to when a project is generated. If `xcodegen` is later run but the spec and all the files it contains are the same, the project won't be generated.

--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -64,7 +64,7 @@ class GenerateCommand: ProjectCommand {
             do {
                 let existingCacheFile: String = try cacheFilePath.read()
                 if cacheFile.string == existingCacheFile {
-                    info("Project has not changed since cache was written")
+                    info("Project \(project.name) has not changed since cache was written")
                     return
                 }
             } catch {

--- a/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/ProjectCommand.swift
@@ -12,7 +12,7 @@ class ProjectCommand: Command {
     let name: String
     let shortDescription: String
 
-    @Key("-s", "--spec", description: "The path to the project spec file. Defaults to project.yml")
+    @Key("-s", "--spec", description: "The path to the project spec file. Defaults to project.yml. (It is also possible to link to multiple spec files by comma separating them. Note that all other flags will be the same.)")
     var spec: String?
 
     @Key("-r", "--project-root", description: "The path to the project root directory. Defaults to the directory containing the project spec.")


### PR DESCRIPTION
**TL;DR: Generate 10 projects in less than 1 second instead of 8 by allowing XcodeGen to accept multiple project files instead of generating them one by one.**

When generating multiple projects it can take a long time. For example, when generating 10 projects by invoking XcodeGen 10 times sequentially via bash, the script takes about `8 seconds`, even with caching turned on. 

## Why is this a problem?

When switching branches and checking out new branches of a repo that contains multiple XcodeGen project files, this causes substantial delays and slows down engineers.

## Investigation

Looking at the profiler, it looks like the slowest part is just starting up XcodeGen. The "initialization" period can take up to `0.5 seconds`.

## Proposed Solution

Allowing XcodeGen to accept multiple spec files, can significantly speed up the generation. In our tests generation of the same 8 projects was less than `3 seconds` without caching and with caching less than `1 second` (sometimes just 0.2 seconds).


## Approach

 * allow specs to be provided as a comma separated list of specs instead of just one

```
xcodegen --spec path/to/first/project.yml,path/to/another/project.yml --use-cache
```