### PR TITLE
CI update to newer macOS and Xcode versions: updating to Xcode 13 and adding Xcode 14 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
 jobs:
   run:
-    runs-on: macos-11
+    runs-on: macos-12
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:
-        xcode: ["12.5.1", "14.0"]
+        xcode: ["13.4.1", "14.0"]
     steps:
     - uses: actions/checkout@master
     - name: Set Xcode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:
-        xcode: ["12.5.1", "13.0"]
+        xcode: ["12.5.1", "14.0"]
     steps:
     - uses: actions/checkout@master
     - name: Set Xcode


### PR DESCRIPTION
Upgrading Xcode and macOS versions:

1. Switch from Xcode `12.5.1` and `13.0` to Xcode `13.4.1` and `14.0`.
2. Also switching macOS version from 11 (Big Sur) to 12 (Monterey)

For more information see: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners