### PR TITLE
Faster directories traversing using enumeration and pre-cached isDirectory values

### DIFF
--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -4,6 +4,7 @@ import ProjectSpec
 import XcodeGenKit
 import XcodeProj
 import XCTest
+import XcodeGenCore
 
 class GeneratedPerformanceTests: XCTestCase {
 
@@ -78,3 +79,24 @@ class FixturePerformanceTests: XCTestCase {
         }
     }
 }
+
+#if os(macOS)
+class GlobPerformanceTests: XCTestCase {
+    let path = "/Applications/Xcode.app/**/*.*"
+    
+    
+    func testGlobSearchWithEnumeration() throws {
+        let options = XCTMeasureOptions.default
+        measure(options: options) {
+            _ = Glob(pattern: path, useEnumeration: true)
+        }
+    }
+    
+    func testGlobSearch() throws {
+        let options = XCTMeasureOptions.default
+        measure(options: options) {
+            _ = Glob(pattern: path, useEnumeration: false)
+        }
+    }
+}
+#endif


### PR DESCRIPTION
# What
Use faster directory traversing (using enumeration and preached values for `isDirectory` url values.

# Why
Just  to make traversing faster

P.S. Old implementation was left just for testing purposes.

![image](https://user-images.githubusercontent.com/119268/193424071-afb61fd5-59e9-428d-aa89-36b6fe326170.png)

