### PR TITLE
Fix includes related issues and improve their performances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@
 - Added support for `enableGPUFrameCaptureMode` #1251 @bsudekum
 - Config setting presets can now also be loaded from the main bundle when bundling XcodeGenKit #1135 @SofteqDG
 - Added ability to generate multiple projects in one XcodeGen launch #1270 @skofgar
+- Use memoization during recursive SpecFiles creation. This provides a drastic performance boost with lots of recursive includes #1275 @ma-oli
 
 ### Fixed
 
 - Fix scheme not being generated for aggregate targets #1250 @CraigSiemens
+- Fix recursive include path when relativePath is not set #1275 @ma-oli
+- Include projectRoot in include paths #1275 @ma-oli
 
 ## 2.32.0
 

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -155,12 +155,14 @@ extension Project: Equatable {
 extension Project {
 
     public init(path: Path) throws {
-        let spec = try SpecFile(filePath: path, basePath: path.parent())
+        var cachedSpecFiles: [Path: SpecFile] = [:]
+        let spec = try SpecFile(filePath: path, basePath: path.parent(), cachedSpecFiles: &cachedSpecFiles)
         try self.init(spec: spec)
     }
 
     public init(path: Path, basePath: Path) throws {
-        let spec = try SpecFile(filePath: path, basePath: basePath)
+        var cachedSpecFiles: [Path: SpecFile] = [:]
+        let spec = try SpecFile(filePath: path, basePath: basePath, cachedSpecFiles: &cachedSpecFiles)
         try self.init(spec: spec)
     }
 

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -155,7 +155,12 @@ extension Project: Equatable {
 extension Project {
 
     public init(path: Path) throws {
-        let spec = try SpecFile(path: path)
+        let spec = try SpecFile(filePath: path, basePath: path.parent())
+        try self.init(spec: spec)
+    }
+
+    public init(path: Path, basePath: Path) throws {
+        let spec = try SpecFile(filePath: path, basePath: basePath)
         try self.init(spec: spec)
     }
 

--- a/Sources/ProjectSpec/SpecFile.swift
+++ b/Sources/ProjectSpec/SpecFile.swift
@@ -68,7 +68,7 @@ public struct SpecFile {
         try self.init(filePath: includePath, basePath: basePath, variables: variables, relativePath: relativePath)
     }
 
-    private init(filePath: Path, basePath: Path, variables: [String: String], relativePath: Path = "") throws {
+    public init(filePath: Path, basePath: Path, variables: [String: String] = [:], relativePath: Path = "") throws {
         let jsonDictionary = try SpecFile.loadDictionary(path: filePath).expand(variables: variables)
 
         let includes = Include.parse(json: jsonDictionary["include"])

--- a/Sources/ProjectSpec/SpecFile.swift
+++ b/Sources/ProjectSpec/SpecFile.swift
@@ -61,15 +61,15 @@ public struct SpecFile {
     }
 
     private init(include: Include, basePath: Path, relativePath: Path, variables: [String: String]) throws {
-        let basePath = include.relativePaths ? (basePath + relativePath) : (basePath + relativePath + include.path.parent())
+        let basePath = include.relativePaths ? (basePath + relativePath) : basePath
         let relativePath = include.relativePaths ? include.path.parent() : Path()
+        let includePath = include.relativePaths ? basePath + relativePath + include.path.lastComponent : basePath + include.path
 
-        try self.init(filePath: include.path, basePath: basePath, variables: variables, relativePath: relativePath)
+        try self.init(filePath: includePath, basePath: basePath, variables: variables, relativePath: relativePath)
     }
 
     private init(filePath: Path, basePath: Path, variables: [String: String], relativePath: Path = "") throws {
-        let path = basePath + relativePath + filePath.lastComponent
-        let jsonDictionary = try SpecFile.loadDictionary(path: path).expand(variables: variables)
+        let jsonDictionary = try SpecFile.loadDictionary(path: filePath).expand(variables: variables)
 
         let includes = Include.parse(json: jsonDictionary["include"])
         let subSpecs: [SpecFile] = try includes

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -16,7 +16,8 @@ public class SpecLoader {
     }
 
     public func loadProject(path: Path, projectRoot: Path? = nil, variables: [String: String] = [:]) throws -> Project {
-        let spec = try SpecFile(filePath: path, basePath: projectRoot ?? path.parent(), variables: variables)
+        var cachedSpecFiles: [Path: SpecFile] = [:]
+        let spec = try SpecFile(filePath: path, basePath: projectRoot ?? path.parent(), cachedSpecFiles: &cachedSpecFiles, variables: variables)
         let resolvedDictionary = spec.resolvedDictionary()
         let project = try Project(basePath: projectRoot ?? spec.basePath, jsonDictionary: resolvedDictionary)
 

--- a/Sources/ProjectSpec/SpecLoader.swift
+++ b/Sources/ProjectSpec/SpecLoader.swift
@@ -16,7 +16,7 @@ public class SpecLoader {
     }
 
     public func loadProject(path: Path, projectRoot: Path? = nil, variables: [String: String] = [:]) throws -> Project {
-        let spec = try SpecFile(path: path, variables: variables)
+        let spec = try SpecFile(filePath: path, basePath: projectRoot ?? path.parent(), variables: variables)
         let resolvedDictionary = spec.resolvedDictionary()
         let project = try Project(basePath: projectRoot ?? spec.basePath, jsonDictionary: resolvedDictionary)
 

--- a/Tests/Fixtures/legacy_paths_test/legacy_included_paths_test.yml
+++ b/Tests/Fixtures/legacy_paths_test/legacy_included_paths_test.yml
@@ -1,5 +1,8 @@
 configFiles:
   IncludedConfig: config
+include:
+  - path: legacy_paths_test/recursive_include.yml
+    relativePaths: false
 options:
   carthageBuildPath: carthage_build
   carthageExecutablePath: carthage_executable
@@ -9,8 +12,6 @@ targets:
     platform: tvOS
     configFiles:
       Config: config
-    sources:
-      - source
     dependencies:
       - framework: Framework
     info:

--- a/Tests/Fixtures/legacy_paths_test/recursive_include.yml
+++ b/Tests/Fixtures/legacy_paths_test/recursive_include.yml
@@ -1,0 +1,4 @@
+targets:
+  IncludedTarget:
+    sources:
+      - source

--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -13,9 +13,12 @@ class GeneratedPerformanceTests: XCTestCase {
         let project = try Project.testProject(basePath: basePath)
         let specPath = basePath + "project.yaml"
         try dumpYamlDictionary(project.toJSONDictionary(), path: specPath)
+        var cachedSpecFiles: [Path: SpecFile] = [:]
 
         measure {
-            let spec = try! SpecFile(path: specPath, variables: ProcessInfo.processInfo.environment)
+            let spec = try! SpecFile(path: specPath,
+                                     cachedSpecFiles: &cachedSpecFiles,
+                                     variables: ProcessInfo.processInfo.environment)
             _ = spec.resolvedDictionary()
         }
     }


### PR DESCRIPTION
This pull request includes the following changes, related to the way XcodeGen processes includes:
- Fix recursive include path when relativePath is not set
- Include projectRoot in include paths
- Use memoization during recursive SpecFiles creation. This fixes the poor performance with lots of recursive includes.