### PR TITLE
Add `--render-markdowns` command flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Config setting presets can now also be loaded from the main bundle when bundling XcodeGenKit #1135 @SofteqDG
 - Added ability to generate multiple projects in one XcodeGen launch #1270 @skofgar
 - Use memoization during recursive SpecFiles creation. This provides a drastic performance boost with lots of recursive includes #1275 @ma-oli
+- Added `--render-markdowns` command flag to generate the `.xcodesamplecode.plist` inside the project container and let Xcode render the markdown files with `md` extension.
 
 ### Fixed
 

--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -22,6 +22,9 @@ class GenerateCommand: ProjectCommand {
 
     @Flag("--only-plists", description: "Generate only plist files")
     var onlyPlists: Bool
+    
+    @Flag("--render-markdowns", description: "Render markdown files with `.md` extension")
+    var renderMarkdowns: Bool
 
     init(version: Version) {
         super.init(version: version,
@@ -114,6 +117,16 @@ class GenerateCommand: ProjectCommand {
             success("Created project at \(projectPath)")
         } catch {
             throw GenerationError.writingError(error)
+        }
+        
+        // add markdown renderer if needed
+        if renderMarkdowns {
+            do {
+                try fileWriter.writeMarkdownRendererPlist()
+                success("Created markdown renderer in the project file")
+            } catch {
+                throw GenerationError.writingError(error)
+            }
         }
 
         // write cache

--- a/Sources/XcodeGenKit/FileWriter.swift
+++ b/Sources/XcodeGenKit/FileWriter.swift
@@ -40,6 +40,10 @@ public class FileWriter {
             }
         }
     }
+    
+    public func writeMarkdownRendererPlist() throws {
+        try writePlist([:], path: project.defaultProjectPath.string.appending("/.xcodesamplecode.plist"))
+    }
 
     private func writePlist(_ plist: [String: Any], path: String) throws {
         let path = project.basePath + path


### PR DESCRIPTION
This flag generates the `.xcodesamplecode.plist` inside the project file and cause Xcode to render the markdown files with `.md` extension