### PR TITLE
Fix logic related PBXVariantGroup

### DIFF
--- a/Sources/ProjectSpec/SourceType.swift
+++ b/Sources/ProjectSpec/SourceType.swift
@@ -11,4 +11,5 @@ public enum SourceType: String {
     case group
     case file
     case folder
+    case variantGroup
 }

--- a/Sources/XcodeGenKit/PBXVariantGroupGenerator.swift
+++ b/Sources/XcodeGenKit/PBXVariantGroupGenerator.swift
@@ -1,0 +1,148 @@
+import XcodeProj
+import ProjectSpec
+import PathKit
+import XcodeGenCore
+
+class PBXVariantGroupInfo {
+    let targetName: String
+    let variantGroup: PBXVariantGroup
+    var path: Path
+    
+    init(targetName: String, variantGroup: PBXVariantGroup, path: Path) {
+        self.targetName = targetName
+        self.variantGroup = variantGroup
+        self.path = path
+    }
+}
+
+class PBXVariantGroupGenerator: TargetSourceFilterable {
+    let pbxProj: PBXProj
+    let project: Project
+    
+    init(pbxProj: PBXProj, project: Project) {
+        self.pbxProj = pbxProj
+        self.project = project
+    }
+    
+    var alwaysStoredBaseExtensions: [String] {
+        [".xib", ".storyboard", ".intentdefinition"]
+    }
+    
+    func generate() throws -> [PBXVariantGroupInfo] {
+        var variantGroupInfoList: [PBXVariantGroupInfo] = []
+        
+        try project.targets.forEach { target in
+            try target.sources.forEach { targetSource in
+                let excludePaths = getSourceMatches(targetSource: targetSource,
+                                                    patterns: targetSource.excludes)
+                let includePaths = getSourceMatches(targetSource: targetSource,
+                                                    patterns: targetSource.includes)
+                
+                let path = project.basePath + targetSource.path
+                
+                try generateVarientGroup(targetName: target.name,
+                                         targetSource: targetSource,
+                                         path: path,
+                                         excludePaths: excludePaths,
+                                         includePaths: SortedArray(includePaths))
+            }
+        }
+        
+        func generateVarientGroup(targetName: String,
+                                  targetSource: TargetSource,
+                                  path: Path,
+                                  excludePaths: Set<Path>,
+                                  includePaths: SortedArray<Path>) throws {
+            guard path.exists && path.isDirectory && !Xcode.isDirectoryFileWrapper(path: path) else {
+                return
+            }
+            
+            let children = try getSourceChildren(targetSource: targetSource,
+                                                 dirPath: path,
+                                                 excludePaths: excludePaths,
+                                                 includePaths: includePaths)
+            
+            try children.forEach {
+                let excludePaths = getSourceMatches(targetSource: targetSource,
+                                                    patterns: targetSource.excludes)
+                let includePaths = getSourceMatches(targetSource: targetSource,
+                                                    patterns: targetSource.includes)
+                
+                try generateVarientGroup(targetName: targetName,
+                                         targetSource: targetSource,
+                                         path: $0,
+                                         excludePaths: excludePaths,
+                                         includePaths: SortedArray(includePaths))
+            }
+            
+            let localizeDirs: [Path] = children
+                .filter ({ $0.extension == "lproj" })
+            
+            guard localizeDirs.count > 0 else {
+                return
+            }
+            
+            try localizeDirs.forEach { localizedDir in
+                try localizedDir.children()
+                    .filter { self.isIncludedPath($0, excludePaths: excludePaths, includePaths: includePaths) }
+                    .sorted()
+                    .forEach { localizedDirChildPath in
+                        let fileReferencePath = try localizedDirChildPath.relativePath(from: path)
+                        let fileRef = PBXFileReference(
+                            sourceTree: .group,
+                            name: localizedDir.lastComponentWithoutExtension,
+                            lastKnownFileType: Xcode.fileType(path: localizedDirChildPath),
+                            path: fileReferencePath.string
+                        )
+                        pbxProj.add(object: fileRef)
+                        
+                        let variantGroupInfo = getVariantGroupInfo(targetName: targetName, localizedChildPath: localizedDirChildPath)
+                        
+                        if localizedDir.lastComponentWithoutExtension == "Base" || project.options.developmentLanguage == localizedDir.lastComponentWithoutExtension {
+                            
+                            variantGroupInfo.path = localizedDirChildPath
+                            variantGroupInfo.variantGroup.name = localizedDirChildPath.lastComponent
+                        }
+                        
+                        variantGroupInfo.variantGroup.children.append(fileRef)
+                    }
+            }
+        }
+        
+        func getVariantGroupInfo(targetName: String, localizedChildPath: Path) -> PBXVariantGroupInfo {
+            let pbxVariantGroupInfo = variantGroupInfoList
+                .filter { $0.targetName == targetName }
+                .first {
+                    let existsAlwaysStoredBaseFile = alwaysStoredBaseExtensions
+                        .reduce(into: [Bool]()) { $0.append(localizedChildPath.lastComponent.contains($1)) }
+                        .filter { $0 }
+                        .count > 0
+                    
+                    if existsAlwaysStoredBaseFile {
+                        return $0.path.lastComponentWithoutExtension == localizedChildPath.lastComponentWithoutExtension
+                    } else {
+                        return $0.path.lastComponent == localizedChildPath.lastComponent
+                    }
+                }
+            
+            if let pbxVariantGroupInfo = pbxVariantGroupInfo {
+                return pbxVariantGroupInfo
+            } else {
+                let variantGroup = PBXVariantGroup(
+                    sourceTree: .group,
+                    name: localizedChildPath.lastComponent
+                )
+                pbxProj.add(object: variantGroup)
+                
+                let pbxVariantGroupInfo = PBXVariantGroupInfo(targetName: targetName,
+                                                              variantGroup: variantGroup,
+                                                              path: localizedChildPath)
+                variantGroupInfoList.append(pbxVariantGroupInfo)
+                
+                return pbxVariantGroupInfo
+            }
+        }
+        
+        return variantGroupInfoList
+    }
+}

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -11,24 +11,17 @@ struct SourceFile {
     let buildPhase: BuildPhaseSpec?
 }
 
-class SourceGenerator {
+class SourceGenerator: TargetSourceFilterable {
 
     var rootGroups: Set<PBXFileElement> = []
     private let projectDirectory: Path?
     private var fileReferencesByPath: [String: PBXFileElement] = [:]
     private var groupsByPath: [Path: PBXGroup] = [:]
-    private var variantGroupsByPath: [Path: PBXVariantGroup] = [:]
+    private var pbxVariantGroupInfoList: [PBXVariantGroupInfo] = []
     private var localPackageGroup: PBXGroup?
 
-    private let project: Project
+    let project: Project
     let pbxProj: PBXProj
-
-    private var defaultExcludedFiles = [
-        ".DS_Store",
-    ]
-    private let defaultExcludedExtensions = [
-        "orig",
-    ]
 
     private(set) var knownRegions: Set<String> = []
 
@@ -90,16 +83,19 @@ class SourceGenerator {
     /// Collects an array complete of all `SourceFile` objects that make up the target based on the provided `TargetSource` definitions.
     ///
     /// - Parameters:
-    ///   - targetType: The type of target that the source files should belong to.
-    ///   - sources: The array of sources defined as part of the targets spec.
-    ///   - buildPhases: A dictionary containing any build phases that should be applied to source files at specific paths in the event that the associated `TargetSource` didn't already define a `buildPhase`. Values from this dictionary are used in cases where the project generator knows more about a file than the spec/filesystem does (i.e if the file should be treated as the targets Info.plist and so on).
-    func getAllSourceFiles(targetType: PBXProductType, sources: [TargetSource], buildPhases: [Path : BuildPhaseSpec]) throws -> [SourceFile] {
-        try sources.flatMap { try getSourceFiles(targetType: targetType, targetSource: $0, buildPhases: buildPhases) }
+    ///  - targetName: The name of target that the source files should belong to.
+    ///  - targetType: The type of target that the source files should belong to.
+    ///  - sources: The array of sources defined as part of the targets spec.
+    ///  - buildPhases: A dictionary containing any build phases that should be applied to source files at specific paths in the event that the associated `TargetSource` didn't already define a `buildPhase`. Values from this dictionary are used in cases where the project generator knows more about a file than the spec/filesystem does (i.e if the file should be treated as the targets Info.plist and so on).
+    ///  - pbxVariantGroupInfoList: An array of all PBXVariantGroup information expected to be added to the target
+    func getAllSourceFiles(targetName: String, targetType: PBXProductType, sources: [TargetSource], buildPhases: [Path : BuildPhaseSpec], pbxVariantGroupInfoList: [PBXVariantGroupInfo]) throws -> [SourceFile] {
+        self.pbxVariantGroupInfoList = pbxVariantGroupInfoList
+        return try sources.flatMap { try getSourceFiles(targetName: targetName, targetType: targetType, targetSource: $0, buildPhases: buildPhases) }
     }
 
     // get groups without build files. Use for Project.fileGroups
     func getFileGroups(path: String) throws {
-        _ = try getSourceFiles(targetType: .none, targetSource: TargetSource(path: path), buildPhases: [:])
+        _ = try getSourceFiles(targetName: "", targetType: .none, targetSource: TargetSource(path: path), buildPhases: [:])
     }
 
     func getFileType(path: Path) -> FileType? {
@@ -338,84 +334,9 @@ class SourceGenerator {
         return groupReference
     }
 
-    /// Creates a variant group or returns an existing one at the path
-    private func getVariantGroup(path: Path, inPath: Path) -> PBXVariantGroup {
-        let variantGroup: PBXVariantGroup
-        if let cachedGroup = variantGroupsByPath[path] {
-            variantGroup = cachedGroup
-        } else {
-            let group = PBXVariantGroup(
-                sourceTree: .group,
-                name: path.lastComponent
-            )
-            variantGroup = addObject(group)
-            variantGroupsByPath[path] = variantGroup
-        }
-        return variantGroup
-    }
-
-    /// Collects all the excluded paths within the targetSource
-    private func getSourceMatches(targetSource: TargetSource, patterns: [String]) -> Set<Path> {
-        let rootSourcePath = project.basePath + targetSource.path
-
-        return Set(
-            patterns.parallelMap { pattern in
-                guard !pattern.isEmpty else { return [] }
-                return Glob(pattern: "\(rootSourcePath)/\(pattern)")
-                    .map { Path($0) }
-                    .map {
-                        guard $0.isDirectory else {
-                            return [$0]
-                        }
-
-                        return (try? $0.recursiveChildren()) ?? []
-                    }
-                    .reduce([], +)
-            }
-            .reduce([], +)
-        )
-    }
-
-    /// Checks whether the path is not in any default or TargetSource excludes
-    func isIncludedPath(_ path: Path, excludePaths: Set<Path>, includePaths: SortedArray<Path>) -> Bool {
-        return !defaultExcludedFiles.contains(where: { path.lastComponent == $0 })
-            && !(path.extension.map(defaultExcludedExtensions.contains) ?? false)
-            && !excludePaths.contains(path)
-            // If includes is empty, it's included. If it's not empty, the path either needs to match exactly, or it needs to be a direct parent of an included path.
-            && (includePaths.value.isEmpty || _isIncludedPathSorted(path, sortedPaths: includePaths))
-    }
-    
-    private func _isIncludedPathSorted(_ path: Path, sortedPaths: SortedArray<Path>) -> Bool {
-        guard let idx = sortedPaths.firstIndex(where: { $0 >= path }) else { return false }
-        let foundPath = sortedPaths.value[idx]
-        return foundPath.description.hasPrefix(path.description)
-    }
-
-
-    /// Gets all the children paths that aren't excluded
-    private func getSourceChildren(targetSource: TargetSource, dirPath: Path, excludePaths: Set<Path>, includePaths: SortedArray<Path>) throws -> [Path] {
-        try dirPath.children()
-            .filter {
-                if $0.isDirectory {
-                    let children = try $0.children()
-
-                    if children.isEmpty {
-                        return project.options.generateEmptyDirectories
-                    }
-
-                    return !children
-                        .filter { self.isIncludedPath($0, excludePaths: excludePaths, includePaths: includePaths) }
-                        .isEmpty
-                } else if $0.isFile {
-                    return self.isIncludedPath($0, excludePaths: excludePaths, includePaths: includePaths)
-                } else {
-                    return false
-                }
-            }
-    }
-
     /// creates all the source files and groups they belong to for a given targetSource
     private func getGroupSources(
+        targetName: String,
         targetType: PBXProductType,
         targetSource: TargetSource,
         path: Path,
@@ -449,9 +370,6 @@ class SourceGenerator {
                 }
             }
 
-        let localisedDirectories = children
-            .filter { $0.extension == "lproj" }
-
         var groupChildren: [PBXFileElement] = filePaths.map { getFileReference(path: $0, inPath: path) }
         var allSourceFiles: [SourceFile] = filePaths.map {
             generateSourceFile(targetType: targetType, targetSource: targetSource, path: $0, buildPhases: buildPhases)
@@ -461,6 +379,7 @@ class SourceGenerator {
         for path in directories {
 
             let subGroups = try getGroupSources(
+                targetName: targetName,
                 targetType: targetType,
                 targetSource: targetSource,
                 path: path,
@@ -484,79 +403,36 @@ class SourceGenerator {
                 groups += subGroups.groups
             }
         }
-
-        // find the base localised directory
-        let baseLocalisedDirectory: Path? = {
-            func findLocalisedDirectory(by languageId: String) -> Path? {
-                localisedDirectories.first { $0.lastComponent == "\(languageId).lproj" }
-            }
-            return findLocalisedDirectory(by: "Base") ??
-                findLocalisedDirectory(by: NSLocale.canonicalLanguageIdentifier(from: project.options.developmentLanguage ?? "en"))
-        }()
-
-        knownRegions.formUnion(localisedDirectories.map { $0.lastComponentWithoutExtension })
-
-        // create variant groups of the base localisation first
-        var baseLocalisationVariantGroups: [PBXVariantGroup] = []
-
-        if let baseLocalisedDirectory = baseLocalisedDirectory {
-            let filePaths = try baseLocalisedDirectory.children()
+        
+        let localisedDirectories = children
+            .filter { $0.extension == "lproj" }
+        
+        for localizedDir in localisedDirectories {
+            
+            let localizedDirChildren = try localizedDir.children()
                 .filter { self.isIncludedPath($0, excludePaths: excludePaths, includePaths: includePaths) }
                 .sorted()
-            for filePath in filePaths {
-                let variantGroup = getVariantGroup(path: filePath, inPath: path)
-                groupChildren.append(variantGroup)
-                baseLocalisationVariantGroups.append(variantGroup)
-
+            
+            for localizedDirChildPath in localizedDirChildren {
+                
+                guard let variantGroupInfo = pbxVariantGroupInfoList
+                    .filter({ $0.targetName == targetName })
+                    .first(where: { $0.path == localizedDirChildPath }) else {
+                    break
+                }
+                groupChildren.append(variantGroupInfo.variantGroup)
+                
                 let sourceFile = generateSourceFile(targetType: targetType,
                                                     targetSource: targetSource,
-                                                    path: filePath,
-                                                    fileReference: variantGroup,
+                                                    path: localizedDirChildPath,
+                                                    fileReference: variantGroupInfo.variantGroup,
                                                     buildPhases: buildPhases)
                 allSourceFiles.append(sourceFile)
             }
         }
-
-        // add references to localised resources into base localisation variant groups
-        for localisedDirectory in localisedDirectories {
-            let localisationName = localisedDirectory.lastComponentWithoutExtension
-            let filePaths = try localisedDirectory.children()
-                .filter { self.isIncludedPath($0, excludePaths: excludePaths, includePaths: includePaths) }
-                .sorted { $0.lastComponent < $1.lastComponent }
-            for filePath in filePaths {
-                // find base localisation variant group
-                // ex: Foo.strings will be added to Foo.strings or Foo.storyboard variant group
-                let variantGroup = baseLocalisationVariantGroups
-                    .first {
-                        Path($0.name!).lastComponent == filePath.lastComponent
-
-                    } ?? baseLocalisationVariantGroups.first {
-                        Path($0.name!).lastComponentWithoutExtension == filePath.lastComponentWithoutExtension
-                    }
-
-                let fileReference = getFileReference(
-                    path: filePath,
-                    inPath: path,
-                    name: variantGroup != nil ? localisationName : filePath.lastComponent
-                )
-
-                if let variantGroup = variantGroup {
-                    if !variantGroup.children.contains(fileReference) {
-                        variantGroup.children.append(fileReference)
-                    }
-                } else {
-                    // add SourceFile to group if there is no Base.lproj directory
-                    let sourceFile = generateSourceFile(targetType: targetType,
-                                                        targetSource: targetSource,
-                                                        path: filePath,
-                                                        fileReference: fileReference,
-                                                        buildPhases: buildPhases)
-                    allSourceFiles.append(sourceFile)
-                    groupChildren.append(fileReference)
-                }
-            }
-        }
-
+        
+        knownRegions.formUnion(localisedDirectories.map { $0.lastComponentWithoutExtension })
+        
         let group = getGroup(
             path: path,
             mergingChildren: groupChildren,
@@ -573,7 +449,7 @@ class SourceGenerator {
     }
 
     /// creates source files
-    private func getSourceFiles(targetType: PBXProductType, targetSource: TargetSource, buildPhases: [Path: BuildPhaseSpec]) throws -> [SourceFile] {
+    private func getSourceFiles(targetName: String, targetType: PBXProductType, targetSource: TargetSource, buildPhases: [Path: BuildPhaseSpec]) throws -> [SourceFile] {
 
         // generate excluded paths
         let path = project.basePath + targetSource.path
@@ -642,6 +518,7 @@ class SourceGenerator {
             }
 
             let (groupSourceFiles, groups) = try getGroupSources(
+                targetName: targetName,
                 targetType: targetType,
                 targetSource: targetSource,
                 path: path,
@@ -659,6 +536,19 @@ class SourceGenerator {
 
             sourceFiles += groupSourceFiles
             sourceReference = group
+            
+        case .variantGroup:
+            let variantGroup: PBXVariantGroup? = pbxVariantGroupInfoList
+                .first { $0.path == path }?.variantGroup
+            
+            let sourceFile = generateSourceFile(targetType: targetType,
+                                                targetSource: targetSource,
+                                                path: path,
+                                                fileReference: variantGroup,
+                                                buildPhases: buildPhases)
+            
+            sourceFiles.append(sourceFile)
+            sourceReference = variantGroup!
         }
 
         if hasCustomParent {
@@ -675,7 +565,11 @@ class SourceGenerator {
     ///
     /// While `TargetSource` declares `type`, its optional and in the event that the value is not defined then we must resolve a sensible default based on the path of the source.
     private func resolvedTargetSourceType(for targetSource: TargetSource, at path: Path) -> SourceType {
-        return targetSource.type ?? (path.isFile || path.extension != nil ? .file : .group)
+        if targetSource.path.contains(".lproj") {
+            return .variantGroup
+        } else {
+            return targetSource.type ?? (path.isFile || path.extension != nil ? .file : .group)
+        }
     }
 
     private func createParentGroups(_ parentGroups: [String], for fileElement: PBXFileElement) {

--- a/Sources/XcodeGenKit/TargetSourceFilterable.swift
+++ b/Sources/XcodeGenKit/TargetSourceFilterable.swift
@@ -1,0 +1,79 @@
+import XcodeProj
+import ProjectSpec
+import PathKit
+import XcodeGenCore
+
+protocol TargetSourceFilterable {
+    var project: Project { get }
+    var defaultExcludedFiles: [String] { get }
+    var defaultExcludedExtensions: [String] { get }
+}
+
+extension TargetSourceFilterable {
+    
+    var defaultExcludedFiles: [String] {
+        [".DS_Store"]
+    }
+    
+    var defaultExcludedExtensions: [String] {
+        ["orig"]
+    }
+    
+    /// Gets all the children paths that aren't excluded
+    func getSourceChildren(targetSource: TargetSource, dirPath: Path, excludePaths: Set<Path>, includePaths: SortedArray<Path>) throws -> [Path] {
+        try dirPath.children()
+            .filter {
+                if $0.isDirectory {
+                    let children = try $0.children()
+                    
+                    if children.isEmpty {
+                        return project.options.generateEmptyDirectories
+                    }
+                    
+                    return !children
+                        .filter { self.isIncludedPath($0, excludePaths: excludePaths, includePaths: includePaths) }
+                        .isEmpty
+                } else if $0.isFile {
+                    return self.isIncludedPath($0, excludePaths: excludePaths, includePaths: includePaths)
+                } else {
+                    return false
+                }
+            }
+    }
+    
+    /// Checks whether the path is not in any default or TargetSource excludes
+    func isIncludedPath(_ path: Path, excludePaths: Set<Path>, includePaths: SortedArray<Path>) -> Bool {
+        return !defaultExcludedFiles.contains(where: { path.lastComponent == $0 })
+        && !(path.extension.map(defaultExcludedExtensions.contains) ?? false)
+        && !excludePaths.contains(path)
+        // If includes is empty, it's included. If it's not empty, the path either needs to match exactly, or it needs to be a direct parent of an included path.
+        && (includePaths.value.isEmpty || _isIncludedPathSorted(path, sortedPaths: includePaths))
+        
+        func _isIncludedPathSorted(_ path: Path, sortedPaths: SortedArray<Path>) -> Bool {
+            guard let idx = sortedPaths.firstIndex(where: { $0 >= path }) else { return false }
+            let foundPath = sortedPaths.value[idx]
+            return foundPath.description.hasPrefix(path.description)
+        }
+    }
+    
+    func getSourceMatches(targetSource: TargetSource, patterns: [String]) -> Set<Path> {
+        let rootSourcePath = project.basePath + targetSource.path
+        
+        return Set(
+            patterns.parallelMap { pattern in
+                guard !pattern.isEmpty else { return [] }
+                return Glob(pattern: "\(rootSourcePath)/\(pattern)")
+                    .map { Path($0) }
+                    .map {
+                        guard $0.isDirectory else {
+                            return [$0]
+                        }
+                        
+                        return (try? $0.recursiveChildren()) ?? []
+                    }
+                    .reduce([], +)
+            }
+                .reduce([], +)
+        )
+    }
+}

--- a/Tests/Fixtures/TestProject/App_Clip/en.lproj/Localizable.stringsdict
+++ b/Tests/Fixtures/TestProject/App_Clip/en.lproj/Localizable.stringsdict
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>StringKey</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@VARIABLE@</string>
+		<key>VARIABLE</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string></string>
+			<key>zero</key>
+			<string></string>
+			<key>one</key>
+			<string></string>
+			<key>two</key>
+			<string></string>
+			<key>few</key>
+			<string></string>
+			<key>many</key>
+			<string></string>
+			<key>other</key>
+			<string></string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		1E2A4D61E96521FF7123D7B0 /* XPC Service.xpc in CopyFiles */ = {isa = PBXBuildFile; fileRef = 22237B8EBD9E6BE8EBC8735F /* XPC Service.xpc */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1E457F55331FD2C3E8E00BE2 /* Result.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0C5AC2545AE4D4F7F44E2E9B /* Result.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1F9168A43FD8E2FCC2699E14 /* Documentation.docc in Sources */ = {isa = PBXBuildFile; fileRef = B5C943D39DD7812CAB94B614 /* Documentation.docc */; settings = {COMPILER_FLAGS = "-Werror"; }; };
+		20B51B15FDAA4B296642DB9D /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = E8222828982682ACB6942EC9 /* Localizable.stringsdict */; };
 		210B49C23B9717C668B40C8C /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
 		2116F89CF5A04EA0EFA30A89 /* TestProjectUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D88C6BF7355702B74396791 /* TestProjectUITests.swift */; };
 		212BCB51DAF3212993DDD49E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D51CC8BCCBD68A90E90A3207 /* Assets.xcassets */; };
@@ -87,6 +88,7 @@
 		58C18019E71E372F635A3FB4 /* MoreUnder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA8718C7CD3BE86D9B1F5120 /* MoreUnder.swift */; };
 		5D10822B0E7C33DD6979F656 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BD97AF0F94A15A5B7DDB7 /* Standalone.swift */; };
 		5E0369B907E239D1E6884ECF /* TestFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E43116070AFEF5D8C3A5A957 /* TestFramework.framework */; };
+		5E13975282BB84D5C33727B8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2FC2A8A829CE71B1CF415FF7 /* Main.storyboard */; };
 		61401517ECCEB2362582B5DA /* libEndpointSecurity.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BC75409252FF15F540FBB7B /* libEndpointSecurity.tbd */; };
 		61516CAC12B2843FBC4572E6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59DA55A04FA2366B5D0BEEFF /* Assets.xcassets */; };
 		61601545B6BE00CA74A4E38F /* SceneKitCatalog.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = C9E358FBE2B54D2B5C7FD609 /* SceneKitCatalog.scnassets */; };
@@ -157,6 +159,7 @@
 		CCA17097382757012B58C17C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1BC32A813B80A53962A1F365 /* Assets.xcassets */; };
 		D5458D67C3596943114C3205 /* Standalone.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BD97AF0F94A15A5B7DDB7 /* Standalone.swift */; };
 		D61BEABD5B26B2DE67D0C2EC /* FrameworkFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A5F527F2590C14956518174 /* FrameworkFile.swift */; };
+		D6312C8EBF458001D43FBDC2 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = E8222828982682ACB6942EC9 /* Localizable.stringsdict */; };
 		D8ED40ED61AD912385CFF5F0 /* StaticLibrary_ObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D0C79A8C750EC0DE748C463 /* StaticLibrary_ObjC.m */; };
 		DD5FBFC3C1B2DB3D0D1CF210 /* NetworkExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B785B1161553A7DD6DA4255 /* NetworkExtension.framework */; };
 		E0B27599D701E6BB0223D0A8 /* FilterDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16AA52945B70B1BF9E246350 /* FilterDataProvider.swift */; };
@@ -798,6 +801,7 @@
 		E43116070AFEF5D8C3A5A957 /* TestFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TestFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E55F45EACB0F382722D61C8D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E5E0A80CCE8F8DB662DCD2D0 /* EndpointSecuritySystemExtension.systemextension */ = {isa = PBXFileReference; explicitFileType = "wrapper.system-extension"; includeInIndex = 0; path = EndpointSecuritySystemExtension.systemextension; sourceTree = BUILT_PRODUCTS_DIR; };
+		E9182F7632482B8412DC5AE0 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = en; path = en.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		E9672EF8FE1DDC8DE0705129 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
 		EDCC70978B8AD49373DA0DE0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EE1343F2238429D4DA9D830B /* File1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = File1.swift; path = Group/File1.swift; sourceTree = "<group>"; };
@@ -1342,6 +1346,7 @@
 				1FA5E208EC184E3030D2A21D /* Clip.entitlements */,
 				6F165CDD5BCC13AFF50B65E2 /* Info.plist */,
 				79325B44B19B83EC6CEDBCC5 /* LaunchScreen.storyboard */,
+				E8222828982682ACB6942EC9 /* Localizable.stringsdict */,
 				2FC2A8A829CE71B1CF415FF7 /* Main.storyboard */,
 				DFE6A6FAAFF701FE729293DE /* ViewController.swift */,
 			);
@@ -1941,6 +1946,7 @@
 			buildConfigurationList = 129D9E77D45A66B1C78578F2 /* Build configuration list for PBXNativeTarget "App_Clip_UITests" */;
 			buildPhases = (
 				2E1429F0FB524A2BCFC61DF1 /* Sources */,
+				78249BAE6D3EE80459CF1FA9 /* Resources */,
 				05D615CB74F875917AA8C9B0 /* Embed Frameworks */,
 			);
 			buildRules = (
@@ -2306,6 +2312,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		78249BAE6D3EE80459CF1FA9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D6312C8EBF458001D43FBDC2 /* Localizable.stringsdict in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8508BA1B733839E314AF2853 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2317,6 +2331,7 @@
 				E5DD0AD6F7AE1DD4AF98B83E /* Localizable.stringsdict in Resources */,
 				2A7EB1A9A365A7EC5D49AFCF /* LocalizedStoryboard.storyboard in Resources */,
 				49A4B8937BB5520B36EA33F0 /* Main.storyboard in Resources */,
+				5E13975282BB84D5C33727B8 /* Main.storyboard in Resources */,
 				900CFAD929CAEE3861127627 /* MyBundle.bundle in Resources */,
 				C88598A49087A212990F4E8B /* ResourceFolder in Resources */,
 				61601545B6BE00CA74A4E38F /* SceneKitCatalog.scnassets in Resources */,
@@ -2341,6 +2356,7 @@
 			files = (
 				61516CAC12B2843FBC4572E6 /* Assets.xcassets in Resources */,
 				B18C121B0A4D43ED8149D8E2 /* LaunchScreen.storyboard in Resources */,
+				20B51B15FDAA4B296642DB9D /* Localizable.stringsdict in Resources */,
 				0F99AECCB4691803C791CDCE /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3079,6 +3095,14 @@
 				57FF8864B8EBAB5777DC12E6 /* Base */,
 			);
 			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		E8222828982682ACB6942EC9 /* Localizable.stringsdict */ = {
+			isa = PBXVariantGroup;
+			children = (
+				E9182F7632482B8412DC5AE0 /* en */,
+			);
+			name = Localizable.stringsdict;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -121,6 +121,7 @@ targets:
         resourceTags:
           - tag1
           - tag2
+      - path: App_Clip/Base.lproj/Main.storyboard
     settings:
       INFOPLIST_FILE: App_iOS/Info.plist
       PRODUCT_BUNDLE_IDENTIFIER: com.project.app
@@ -390,7 +391,9 @@ targets:
   App_Clip_UITests:
     type: bundle.ui-testing
     platform: iOS
-    sources: App_Clip_UITests
+    sources:
+     - path: App_Clip_UITests
+     - path: App_Clip/en.lproj/Localizable.stringsdict
     dependencies:
       - target: App_Clip
 # https://github.com/yonaskolb/XcodeGen/issues/1232


### PR DESCRIPTION
Fixed logic in PBXVariantgGroup to meet the requirements of one my project.

- Even if there is no localize file in Base.lproj, recognize localize file as PBXVarientGroup, generate appropriate PBXFileReference, and generate PBXBuildFile for appropriate target.  https://github.com/yonaskolb/XcodeGen/issues/763
- To be able to add a PBXVariantGroup of one target A to another B target
    - Add the path of the file that is the source of the PBXVariantGroup you want to add to source. (Please refer to the fix for Tests/Fixtures/TestProject/project.yml in this PR)

Also Please let us know if you have any other suggestions.
Thanks.