### PR TITLE
Delete ignored `try` keyword.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix scheme not being generated for aggregate targets #1250 @CraigSiemens
 - Fix recursive include path when relativePath is not set #1275 @ma-oli
 - Include projectRoot in include paths #1275 @ma-oli
+- Delete ignored `try` keyword #1298 @s2mr
 
 ## 2.32.0
 

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -409,7 +409,7 @@ class ProjectSpecTests: XCTestCase {
                     platform: .iOS
                 )]
 
-                let testPlan = try TestPlan(path: "does-not-exist.xctestplan")
+                let testPlan = TestPlan(path: "does-not-exist.xctestplan")
 
                 let scheme = Scheme(
                     name: "xctestplan-scheme",
@@ -437,8 +437,8 @@ class ProjectSpecTests: XCTestCase {
                     platform: .iOS
                 )]
 
-                let testPlan1 = try TestPlan(path: "\(fixturePath.string)/TestProject/App_iOS/App_iOS.xctestplan", defaultPlan: true)
-                let testPlan2 = try TestPlan(path: "\(fixturePath.string)/TestProject/App_iOS/App_iOS.xctestplan", defaultPlan: true)
+                let testPlan1 = TestPlan(path: "\(fixturePath.string)/TestProject/App_iOS/App_iOS.xctestplan", defaultPlan: true)
+                let testPlan2 = TestPlan(path: "\(fixturePath.string)/TestProject/App_iOS/App_iOS.xctestplan", defaultPlan: true)
 
                 let scheme = Scheme(
                     name: "xctestplan-scheme",


### PR DESCRIPTION
`try` keyword is ignored, Xcode shows warning.