### PR TITLE
Fix typo in 'fixtures'

### DIFF
--- a/scripts/diff-fixtures.sh
+++ b/scripts/diff-fixtures.sh
@@ -3,7 +3,7 @@ set -e
 
 if [[ `git status --porcelain Tests/Fixtures` ]]; then
   echo ""
-  echo "⚠️  Generated fixturess have changed."
+  echo "⚠️  Generated fixtures have changed."
   echo "⚠️  If this is a valid change please run the tests and commit the updates."
   echo ""
   git --no-pager diff --color=always Tests/Fixtures


### PR DESCRIPTION
This PR:
- Fixes a typo (`fixturess` to `fixtures`)