### PR TITLE
Remove SPM configurations warning from ProjectSpec

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -997,8 +997,6 @@ The result will be a scheme that builds `MyModule` when you request a build, and
 ## Swift Package
 Swift packages are defined at a project level, and then linked to individual targets via a [Dependency](#dependency).
 
-> Note that Swift Packages don't work in projects with configurations other than `Debug` and `Release`. That limitation is tracked here bugs.swift.org/browse/SR-10927
-
 ### Remote Package
 
 - [x] **url**: **URL** - the url to the package


### PR DESCRIPTION
ProjectSpec states that Swift Packages don't work in projects with configurations other than `Debug` and `Release`. It provides a link to Swift bugtracker to issue marked as duplicate. Original issue that it points to is closed and fixed since 2020 with Xcode 12.

Let's remove misleading note from ProjectSpec.

https://github.com/apple/swift-package-manager/issues/4674