### PR TITLE
Display absolute path for invalidBuildScriptPath and invalidTargetConfigFile error print.

### DIFF
--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -81,8 +81,9 @@ extension Project {
         for target in projectTargets {
 
             for (config, configFile) in target.configFiles {
-                if !options.disabledValidations.contains(.missingConfigFiles) && !(basePath + configFile).exists {
-                    errors.append(.invalidTargetConfigFile(target: target.name, configFile: configFile, config: config))
+                let configPath = basePath + configFile
+                if !options.disabledValidations.contains(.missingConfigFiles) && !configPath.exists {
+                    errors.append(.invalidTargetConfigFile(target: target.name, configFile: configPath.string, config: config))
                 }
                 if !options.disabledValidations.contains(.missingConfigs) && getConfig(config) == nil {
                     errors.append(.invalidConfigFileConfig(config))

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -137,7 +137,7 @@ extension Project {
                 if case let .path(pathString) = script.script {
                     let scriptPath = basePath + pathString
                     if !scriptPath.exists {
-                        errors.append(.invalidBuildScriptPath(target: target.name, name: script.name, path: pathString))
+                        errors.append(.invalidBuildScriptPath(target: target.name, name: script.name, path: scriptPath.string))
                     }
                 }
             }

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -46,7 +46,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
             case let .invalidTargetDependency(target, dependency):
                 return "Target \(target.quoted) has invalid dependency: \(dependency.quoted)"
             case let .invalidTargetConfigFile(target, configFile, config):
-                return "Target \(target.quoted) has invalid config file \(configFile.quoted) for config \(config.quoted)"
+                return "Target \(target.quoted) has invalid config file path \(configFile.quoted) for config \(config.quoted)"
             case let .invalidTargetSource(target, source):
                 return "Target \(target.quoted) has a missing source directory \(source.quoted)"
             case let .invalidTargetSchemeConfigVariant(target, configVariant, configType):


### PR DESCRIPTION
With previous implementation, the error message was not clear for end user:
`  Spec validation error: Target "Project" has a script "SwiftLint" which has a path that doesn't exist "../../wrong-dir/scripts/run_swiftlint_in_xcode_wrapper.sh"`

With new implementation with absolute path, it is easier to validate what is wrong with path:
`  Spec validation error: Target "Project" has a script "SwiftLint" which has a path that doesn't exist "/Users/SomeUser/dev/fancy-project/wrong-dir/scripts/run_swiftlint_in_xcode_wrapper.sh"`