### PR TITLE
Reuse ReferenceProxy references when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 ## Next Version
 
+### Added
+
+### Fixed
+
+- Fix external dependecies been removed by Xcode #1354 @OdNairy
+
 ## 2.35.0
 
 ### Added
 
 - Added support for shared breakpoints #177 @alexruperez @myihsan
-- Added support for `putResourcesBeforeSourcesBuildPhase` in a target #1351 @mat1th 
+- Added support for `putResourcesBeforeSourcesBuildPhase` in a target #1351 @mat1th
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- Fix external dependecies been removed by Xcode #1354 @OdNairy
+- Fix external dependencies from being removed by Xcode #1354 @OdNairy
 
 ## 2.35.0
 

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -423,16 +423,32 @@ public class PBXProjGenerator {
             path = "lib\(tmpPath)"
         }
 
-        let productReferenceProxy = addObject(
-            PBXReferenceProxy(
-                fileType: targetObject.productNameWithExtension().flatMap { Xcode.fileType(path: Path($0)) },
-                path: path,
-                remote: productProxy,
-                sourceTree: .buildProductsDir
-            )
-        )
+        let productReferenceProxyFileType = targetObject.productNameWithExtension()
+            .flatMap { Xcode.fileType(path: Path($0)) }
 
-        productsGroup.children.append(productReferenceProxy)
+        let existingValue = self.pbxProj.referenceProxies.first { referenceProxy in
+            referenceProxy.path == path &&
+            referenceProxy.remote == productProxy &&
+            referenceProxy.sourceTree == .buildProductsDir &&
+            referenceProxy.fileType == productReferenceProxyFileType
+        }
+
+        let productReferenceProxy: PBXReferenceProxy
+        if let existingValue = existingValue {
+            productReferenceProxy = existingValue
+        } else {
+            productReferenceProxy = addObject(
+                PBXReferenceProxy(
+                    fileType: productReferenceProxyFileType,
+                    path: path,
+                    remote: productProxy,
+                    sourceTree: .buildProductsDir
+                )
+            )
+
+            productsGroup.children.append(productReferenceProxy)
+        }
+
 
         let targetDependency = addObject(
             PBXTargetDependency(


### PR DESCRIPTION
XcodeGen should reuse `PBXReferenceProxy` for external targets when possible. In the current state, Xcode will remove all duplicated dependencies as soon as any change in pbxproj happens. 


https://user-images.githubusercontent.com/735178/235425213-eba0bdda-8caf-4b14-9f4a-7244ddb7c030.mov


