### PR TITLE
Update README for Xcode version

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ A project would be created with 2 connected targets, with all the required confi
 
 ## Installing
 
-Make sure Xcode 11 is installed first.
+Make sure the latest stable (non-beta) version of Xcode is installed first.
 
 ### [Mint](https://github.com/yonaskolb/mint)
 ```sh


### PR DESCRIPTION
Showing Xcode 11 in the README in 2023 does not instill confidence in the project.

Xcode 11 was released in 2019 and the latest dot version updated in 2020.  I am assuming that XcodeGen supports Xcode 14.x

Additionally, as you do for Swift Compatibility, it would be helpful to the community if the project shows what Xcode versions it works with.