### PR TITLE
Update ProjectSpec.md to use true/false for boolean default values

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -712,9 +712,9 @@ Each script can contain:
 - [ ] **inputFileLists**: **[String]** - list of input .xcfilelist
 - [ ] **outputFileLists**: **[String]** - list of output .xcfilelist
 - [ ] **shell**: **String** - shell used for the script. Defaults to `/bin/sh`
-- [ ] **showEnvVars**: **Bool** - whether the environment variables accessible to the script show be printed to the build log. Defaults to yes
-- [ ] **runOnlyWhenInstalling**: **Bool** - whether the script is only run when installing (`runOnlyForDeploymentPostprocessing`). Defaults to no
-- [ ] **basedOnDependencyAnalysis**: **Bool** - whether to skip the script if inputs, context, or outputs haven't changed. Defaults to yes
+- [ ] **showEnvVars**: **Bool** - whether the environment variables accessible to the script show be printed to the build log. Defaults to `true`
+- [ ] **runOnlyWhenInstalling**: **Bool** - whether the script is only run when installing (`runOnlyForDeploymentPostprocessing`). Defaults to `false`
+- [ ] **basedOnDependencyAnalysis**: **Bool** - whether to skip the script if inputs, context, or outputs haven't changed. Defaults to `true`
 - [ ] **discoveredDependencyFile**: **String** - discovered dependency .d file. Defaults to none
 
 Either a **path** or **script** must be defined, the rest are optional.


### PR DESCRIPTION
## Changes

- Updates ProjectSpec.md.  Uses true or false instead of yes or no, for boolean default values in the Build Script options.
  - I confirmed that these values are equal to the default values defined [here](https://github.com/yonaskolb/XcodeGen/blob/master/Sources/ProjectSpec/BuildScript.swift#L5-L7) in the source code.
