### PR TITLE
Support Artifact Bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ xcuserdata
 *.xcuserstate
 XcodeGen.xcodeproj
 xcodegen.zip
+xcodegen.artifactbundle.zip
 .vscode/launch.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+### Added
+
+- Support Artifact Bundle # @freddi-kit
+
 ## 2.37.0
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Support Artifact Bundle # @freddi-kit
+- Support Artifact Bundle #1388 @freddi-kit
 
 ## 2.37.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 
 - Support Artifact Bundle #1388 @freddi-kit
 
-## 2.37.0
 ### Fixed
 
 - Fixed source file `includes` not working when no paths were found #1337 @shnhrrsn

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,5 @@ archive: build
 	swift package plugin --allow-writing-to-package-directory generate-artifact-bundle \
 		--package-version $(VERSION) \
 		--executable-name $(EXECUTABLE_NAME) \
-		--build-config release
+		--build-config release \
+		--include-resource-path LICENSE

--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ archive: build
 	swift package plugin --allow-writing-to-package-directory generate-artifact-bundle \
 		--package-version $(VERSION) \
 		--executable-name $(EXECUTABLE_NAME) \
-		--build-config release \
+		--build-config release

--- a/Makefile
+++ b/Makefile
@@ -50,5 +50,6 @@ archive: build
 	./scripts/archive.sh "$(EXECUTABLE_PATH)"
 	swift package plugin --allow-writing-to-package-directory generate-artifact-bundle \
 		--package-version $(VERSION) \
-		--executable-name xcodegen \
-		--build-config release
+		--executable-name $(EXECUTABLE_NAME) \
+		--build-config release \
+		--include-resource-path $(CURRENT_PATH)/SettingPresets

--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,3 @@ archive: build
 		--package-version $(VERSION) \
 		--executable-name $(EXECUTABLE_NAME) \
 		--build-config release \
-		--include-resource-path $(CURRENT_PATH)/SettingPresets

--- a/Makefile
+++ b/Makefile
@@ -48,3 +48,7 @@ brew:
 
 archive: build
 	./scripts/archive.sh "$(EXECUTABLE_PATH)"
+	swift package plugin --allow-writing-to-package-directory generate-artifact-bundle \
+		--package-version $(VERSION) \
+		--executable-name xcodegen \
+		--build-config release

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/freddi-kit/ArtifactBundleGen",
       "state" : {
-        "revision" : "0c5cdf2d8e522aaf32d2f441efd002b757c5a4d2",
-        "version" : "0.0.4"
+        "revision" : "58b31fd4b479290342da0788f795356bfdc06ee4",
+        "version" : "0.0.5"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/freddi-kit/ArtifactBundleGen",
       "state" : {
-        "revision" : "58b31fd4b479290342da0788f795356bfdc06ee4",
-        "version" : "0.0.5"
+        "revision" : "707e4ccc4b1c7e48e881cd5ea91e493a95df24bf",
+        "version" : "0.0.6"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/freddi-kit/ArtifactBundleGen",
       "state" : {
-        "revision" : "8e03c58cb2648276544bbd52fe2e18ef5a4fa5af",
-        "version" : "0.0.3"
+        "revision" : "0c5cdf2d8e522aaf32d2f441efd002b757c5a4d2",
+        "version" : "0.0.4"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/freddi-kit/ArtifactBundleGen",
       "state" : {
-        "revision" : "7289d921b07bcfc3c7bb0cec20df17bd5f0584ca",
-        "version" : "0.0.2"
+        "revision" : "8e03c58cb2648276544bbd52fe2e18ef5a4fa5af",
+        "version" : "0.0.3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "artifactbundlegen",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/freddi-kit/ArtifactBundleGen",
+      "state" : {
+        "revision" : "7289d921b07bcfc3c7bb0cec20df17bd5f0584ca",
+        "version" : "0.0.2"
+      }
+    },
+    {
       "identity" : "graphviz",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftDocOrg/GraphViz.git",

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,13 @@
 
 import PackageDescription
 
+let macOSOnlyDependency: [Package.Dependency]
+#if !os(Linux)
+    macOSOnlyDependency = [Package.Dependency.package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.2")]
+#else
+    macOSOnlyDependency = []
+#endif
+
 let package = Package(
     name: "XcodeGen",
     platforms: [.macOS(.v10_13)],
@@ -20,8 +27,7 @@ let package = Package(
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", exact: "0.2.0"),
-        .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.2"),
-    ],
+    ] + macOSOnlyDependency,
     targets: [
         .executableTarget(name: "XcodeGen", dependencies: [
             "XcodeGenCLI",

--- a/Package.swift
+++ b/Package.swift
@@ -20,8 +20,8 @@ let package = Package(
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", exact: "0.2.0"),
+        .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.2"),
     ],
-
     targets: [
         .executableTarget(name: "XcodeGen", dependencies: [
             "XcodeGenCLI",

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let macOSOnlyDependency: [Package.Dependency]
 #if !os(Linux)
-    macOSOnlyDependency = [Package.Dependency.package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.2")]
+    macOSOnlyDependency = [Package.Dependency.package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.3")]
 #else
     macOSOnlyDependency = []
 #endif

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 
 let macOSOnlyDependency: [Package.Dependency]
 #if !os(Linux)
-    macOSOnlyDependency = [Package.Dependency.package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.3")]
+    macOSOnlyDependency = [Package.Dependency.package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.4")]
 #else
     macOSOnlyDependency = []
 #endif
@@ -48,6 +48,8 @@ let package = Package(
             "PathKit",
             "XcodeGenCore",
             "GraphViz",
+        ], resources: [
+            .copy("SettingPresets")
         ]),
         .target(name: "ProjectSpec", dependencies: [
             "JSONUtilities",

--- a/Package.swift
+++ b/Package.swift
@@ -2,13 +2,6 @@
 
 import PackageDescription
 
-let macOSOnlyDependency: [Package.Dependency]
-#if !os(Linux)
-    macOSOnlyDependency = [Package.Dependency.package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.4")]
-#else
-    macOSOnlyDependency = []
-#endif
-
 let package = Package(
     name: "XcodeGen",
     platforms: [.macOS(.v10_13)],
@@ -27,7 +20,8 @@ let package = Package(
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", exact: "0.2.0"),
-    ] + macOSOnlyDependency,
+        .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.5")
+    ],
     targets: [
         .executableTarget(name: "XcodeGen", dependencies: [
             "XcodeGenCLI",

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
         .package(url: "https://github.com/SwiftDocOrg/GraphViz.git", exact: "0.2.0"),
-        .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.5")
+        .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.6")
     ],
     targets: [
         .executableTarget(name: "XcodeGen", dependencies: [

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,5 +7,5 @@
 1. Run `make release`
 1. Push commit and tag to github
 1. Create release from tag on GitHub using the version number and relevant changelog contents
-1. Run `make archive` and upload `xcodegen.zip` to the github release
+1. Run `make archive` and upload `xcodegen.zip` and `xcodegen.artifactbundle.zip` to the github release
 1. Run `make brew` which will open a PR on homebrew core

--- a/Sources/XcodeGenKit/SettingPresets
+++ b/Sources/XcodeGenKit/SettingPresets
@@ -1,0 +1,1 @@
+../../SettingPresets/

--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -202,6 +202,9 @@ extension SettingsPresetFile {
                 symlink.parent() + relativePath,
             ] + possibleSettingsPaths
         }
+        if let moduleResourcePath = Bundle.module.path(forResource: "SettingPresets", ofType: nil) {
+            possibleSettingsPaths.append(Path(moduleResourcePath) + "\(path).yml")
+        }
 
         guard let settingsPath = possibleSettingsPaths.first(where: { $0.exists }) else {
             switch self {


### PR DESCRIPTION
# Motivation
[SE-0305](https://github.com/apple/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md) is introduced and it is now important for build tools. 

Artifact Bundle helps to support Artifact bundle to not take time to making build binary. 

I developed new OSS tool named ArtifactBundleGen to create it easily.

# Changes
- Add Artifact Bundle creation flow

# Test
Run `make archive`