### PR TITLE
Added support for `Build Tool Plug-ins` in AggregateTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+### Added
+
+- Added support for `Build Tool Plug-ins` in `AggregateTarget` #1390 @BarredEwe
+
 ### Fixed
 
 - Fixed source file `includes` not working when no paths were found #1337 @shnhrrsn

--- a/Sources/ProjectSpec/AggregateTarget.swift
+++ b/Sources/ProjectSpec/AggregateTarget.swift
@@ -8,6 +8,7 @@ public struct AggregateTarget: ProjectTarget {
     public var targets: [String]
     public var settings: Settings
     public var buildScripts: [BuildScript]
+    public var buildToolPlugins: [BuildToolPlugin]
     public var configFiles: [String: String]
     public var scheme: TargetScheme?
     public var attributes: [String: Any]
@@ -18,6 +19,7 @@ public struct AggregateTarget: ProjectTarget {
         settings: Settings = .empty,
         configFiles: [String: String] = [:],
         buildScripts: [BuildScript] = [],
+        buildToolPlugins: [BuildToolPlugin] = [],
         scheme: TargetScheme? = nil,
         attributes: [String: Any] = [:]
     ) {
@@ -26,6 +28,7 @@ public struct AggregateTarget: ProjectTarget {
         self.settings = settings
         self.configFiles = configFiles
         self.buildScripts = buildScripts
+        self.buildToolPlugins = buildToolPlugins
         self.scheme = scheme
         self.attributes = attributes
     }
@@ -46,6 +49,7 @@ extension AggregateTarget: Equatable {
             lhs.settings == rhs.settings &&
             lhs.configFiles == rhs.configFiles &&
             lhs.buildScripts == rhs.buildScripts &&
+            lhs.buildToolPlugins == rhs.buildToolPlugins &&
             lhs.scheme == rhs.scheme &&
             NSDictionary(dictionary: lhs.attributes).isEqual(to: rhs.attributes)
     }
@@ -59,6 +63,7 @@ extension AggregateTarget: NamedJSONDictionaryConvertible {
         settings = jsonDictionary.json(atKeyPath: "settings") ?? .empty
         configFiles = jsonDictionary.json(atKeyPath: "configFiles") ?? [:]
         buildScripts = jsonDictionary.json(atKeyPath: "buildScripts") ?? []
+        buildToolPlugins = jsonDictionary.json(atKeyPath: "buildToolPlugins") ?? []
         scheme = jsonDictionary.json(atKeyPath: "scheme")
         attributes = jsonDictionary.json(atKeyPath: "attributes") ?? [:]
     }
@@ -72,6 +77,7 @@ extension AggregateTarget: JSONEncodable {
             "configFiles": configFiles,
             "attributes": attributes,
             "buildScripts": buildScripts.map { $0.toJSONValue() },
+            "buildToolPlugins": buildToolPlugins.map { $0.toJSONValue() },
             "scheme": scheme?.toJSONValue(),
         ] as [String: Any?]
     }

--- a/Sources/ProjectSpec/ProjectTarget.swift
+++ b/Sources/ProjectSpec/ProjectTarget.swift
@@ -6,6 +6,7 @@ public protocol ProjectTarget: BuildSettingsContainer {
     var name: String { get }
     var type: PBXProductType { get }
     var buildScripts: [BuildScript] { get }
+    var buildToolPlugins: [BuildToolPlugin] { get }
     var scheme: TargetScheme? { get }
     var attributes: [String: Any] { get }
 }

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -144,6 +144,12 @@ extension Project {
             }
 
             errors += validateSettings(target.settings)
+
+            for buildToolPlugin in target.buildToolPlugins {
+                if packages[buildToolPlugin.package] == nil {
+                    errors.append(.invalidPluginPackageReference(plugin: buildToolPlugin.plugin, package: buildToolPlugin.package))
+                }
+            }
         }
 
         for target in aggregateTargets {
@@ -172,12 +178,6 @@ extension Project {
                 let sourcePath = basePath + source.path
                 if !source.optional && !sourcePath.exists {
                     errors.append(.invalidTargetSource(target: target.name, source: sourcePath.string))
-                }
-            }
-
-            for buildToolPlugin in target.buildToolPlugins {
-                if packages[buildToolPlugin.package] == nil {
-                    errors.append(.invalidPluginPackageReference(plugin: buildToolPlugin.plugin, package: buildToolPlugin.package))
                 }
             }
         }

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 54;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		ADD3CE771A0D5E996031A193 /* AggTarget */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = A7ABF1B35D9170092F822790 /* Build configuration list for PBXAggregateTarget "AggTarget" */;
+			buildPhases = (
+			);
+			dependencies = (
+				D287BAAB664D1A024D9DD57E /* PBXTargetDependency */,
+			);
+			name = AggTarget;
+			productName = AggTarget;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		23C6626698DE560017A89F2F /* XcodeGen in Frameworks */ = {isa = PBXBuildFile; productRef = 6F7DEA2D82649EDF903FBDBD /* XcodeGen */; };
 		2DA7998902987953B119E4CE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F7EFEE613987D1E1258A60 /* AppDelegate.swift */; };
@@ -221,6 +235,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				ADD3CE771A0D5E996031A193 /* AggTarget */,
 				C99E3C420D63D5219CE57E33 /* App */,
 				3F8D94C4EFC431F646AAFB28 /* StaticLibrary */,
 				339863E54E2D955C00B56802 /* Tests */,
@@ -300,6 +315,10 @@
 			isa = PBXTargetDependency;
 			productRef = 5A36E2FE69703FCAC0BE8064 /* XcodeGen */;
 		};
+		D287BAAB664D1A024D9DD57E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 896D1E2063A93D40F04D7864 /* PrefirePlaybookPlugin */;
+		};
 		D85FFB99444DD260A72DDDA7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			productRef = AF233B61592982A7F6431FC6 /* Codability */;
@@ -315,6 +334,12 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0C023F1AE037C42683029CE9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
 		0CCC06807E5CD8361D899B7F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -359,6 +384,12 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
+		};
+		5E087A904FBC0E623E672507 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
 		};
 		7A384B9B9CF42FCF9EF02057 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -565,6 +596,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
+		A7ABF1B35D9170092F822790 /* Build configuration list for PBXAggregateTarget "AggTarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0C023F1AE037C42683029CE9 /* Debug */,
+				5E087A904FBC0E623E672507 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
@@ -607,6 +647,11 @@
 		6F7DEA2D82649EDF903FBDBD /* XcodeGen */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XcodeGen;
+		};
+		896D1E2063A93D40F04D7864 /* PrefirePlaybookPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 348C81C327DB1710B742C370 /* XCRemoteSwiftPackageReference "Prefire" */;
+			productName = "plugin:PrefirePlaybookPlugin";
 		};
 		AF233B61592982A7F6431FC6 /* Codability */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,106 +1,122 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "AEXML",
-        "repositoryURL": "https://github.com/tadija/AEXML",
-        "state": {
-          "branch": null,
-          "revision": "e4d517844dd03dac557e35d77a8e9ab438de91a6",
-          "version": "4.4.0"
-        }
-      },
-      {
-        "package": "Codability",
-        "repositoryURL": "https://github.com/yonaskolb/Codability",
-        "state": {
-          "branch": null,
-          "revision": "eb5bac78e0679f521c3f058c1eb9be0dd657dadd",
-          "version": "0.2.1"
-        }
-      },
-      {
-        "package": "JSONUtilities",
-        "repositoryURL": "https://github.com/yonaskolb/JSONUtilities.git",
-        "state": {
-          "branch": null,
-          "revision": "128d2ffc22467f69569ef8ff971683e2393191a0",
-          "version": "4.2.0"
-        }
-      },
-      {
-        "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit.git",
-        "state": {
-          "branch": null,
-          "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
-          "version": "1.0.0"
-        }
-      },
-      {
-        "package": "Rainbow",
-        "repositoryURL": "https://github.com/onevcat/Rainbow.git",
-        "state": {
-          "branch": null,
-          "revision": "9c52c1952e9b2305d4507cf473392ac2d7c9b155",
-          "version": "3.1.5"
-        }
-      },
-      {
-        "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
-        "state": {
-          "branch": null,
-          "revision": "f14ff47f45642aa5703900980b014c2e9394b6e5",
-          "version": "0.9.0"
-        }
-      },
-      {
-        "package": "SwiftCLI",
-        "repositoryURL": "https://github.com/jakeheis/SwiftCLI.git",
-        "state": {
-          "branch": null,
-          "revision": "c72c4564f8c0a24700a59824880536aca45a4cae",
-          "version": "6.0.1"
-        }
-      },
-      {
-        "package": "SwiftRoaring",
-        "repositoryURL": "https://github.com/piotte13/SwiftRoaring",
-        "state": {
-          "branch": null,
-          "revision": "9104cf3f35e7a38c9fb633084c7adb63a9f27f8b",
-          "version": "1.0.4"
-        }
-      },
-      {
-        "package": "Version",
-        "repositoryURL": "https://github.com/mxcl/Version",
-        "state": {
-          "branch": null,
-          "revision": "a94b48f36763c05629fc102837398505032dead9",
-          "version": "2.0.0"
-        }
-      },
-      {
-        "package": "XcodeProj",
-        "repositoryURL": "https://github.com/tuist/XcodeProj.git",
-        "state": {
-          "branch": null,
-          "revision": "f32704e01d2752bdc17cde3963bee4256c1f4df4",
-          "version": "7.8.0"
-        }
-      },
-      {
-        "package": "Yams",
-        "repositoryURL": "https://github.com/jpsim/Yams.git",
-        "state": {
-          "branch": null,
-          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
-          "version": "2.0.0"
-        }
+  "pins" : [
+    {
+      "identity" : "aexml",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tadija/AEXML.git",
+      "state" : {
+        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
+        "version" : "4.6.1"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "codability",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yonaskolb/Codability",
+      "state" : {
+        "revision" : "eb5bac78e0679f521c3f058c1eb9be0dd657dadd",
+        "version" : "0.2.1"
+      }
+    },
+    {
+      "identity" : "graphviz",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SwiftDocOrg/GraphViz.git",
+      "state" : {
+        "revision" : "70bebcf4597b9ce33e19816d6bbd4ba9b7bdf038",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "jsonutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/yonaskolb/JSONUtilities.git",
+      "state" : {
+        "revision" : "128d2ffc22467f69569ef8ff971683e2393191a0",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "pathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/PathKit.git",
+      "state" : {
+        "revision" : "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
+        "version" : "1.0.1"
+      }
+    },
+    {
+      "identity" : "prefire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/BarredEwe/Prefire",
+      "state" : {
+        "revision" : "abb8dfa44391b4f47edb4937a4ba124e76270a87",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "rainbow",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/onevcat/Rainbow.git",
+      "state" : {
+        "revision" : "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "spectre",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kylef/Spectre.git",
+      "state" : {
+        "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
+        "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "swiftcli",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jakeheis/SwiftCLI.git",
+      "state" : {
+        "revision" : "2e949055d9797c1a6bddcda0e58dada16cc8e970",
+        "version" : "6.0.3"
+      }
+    },
+    {
+      "identity" : "swiftroaring",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/piotte13/SwiftRoaring",
+      "state" : {
+        "revision" : "9104cf3f35e7a38c9fb633084c7adb63a9f27f8b",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "version",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mxcl/Version",
+      "state" : {
+        "revision" : "1fe824b80d89201652e7eca7c9252269a1d85e25",
+        "version" : "2.0.1"
+      }
+    },
+    {
+      "identity" : "xcodeproj",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tuist/XcodeProj.git",
+      "state" : {
+        "revision" : "6e60fb55271c80f83a186c9b1b4982fd991cfc0a",
+        "version" : "8.13.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "0d9ee7ea8c4ebd4a489ad7a73d5c6cad55d6fed3",
+        "version" : "5.0.6"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Tests/Fixtures/SPM/project.yml
+++ b/Tests/Fixtures/SPM/project.yml
@@ -12,6 +12,11 @@ packages:
   XcodeGen:
     path: ../../.. #XcodeGen itself
     group: SPM
+aggregateTargets:
+  AggTarget:
+    buildToolPlugins:
+      - plugin: PrefirePlaybookPlugin
+        package: Prefire
 targets:
   App:
     type: application


### PR DESCRIPTION
# Short description 📝
Added support for `BuildTool Plug-ins` in `AggregateTarget`.

# Details ⚙️
`AggregateTarget` should support working with plugins as well as regular `Target`. I added this.

To connect, you need to use the same syntax as the usual `Target`:
```swift
aggregateTargets:
  AggTarget:
    buildToolPlugins:
      - plugin: PrefirePlaybookPlugin
        package: Prefire
```