### PR TITLE
Supports specifying multiple package products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed source file `includes` not working when no paths were found #1337 @shnhrrsn
+- Supports specifying multiple package products #1395 @simonbs
 
 ## 2.37.0
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -645,7 +645,7 @@ targets:
 ```
 
 **Package dependency**
-- [ ] **product**: **String** - The product to use from the package. This defaults to the package name, so is only required if a Package has multiple libraries or a library with a differing name
+- [ ] **product**: **String** - The product to use from the package. This defaults to the package name, so is only required if a Package has multiple libraries or a library with a differing name. Use this over `products` when you want to define different linking options per product.
 - [ ] **products**: **String** - A list of products to use from the package. This can be used when depending on multiple products from a package.
 
 ```yaml

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -646,6 +646,7 @@ targets:
 
 **Package dependency**
 - [ ] **product**: **String** - The product to use from the package. This defaults to the package name, so is only required if a Package has multiple libraries or a library with a differing name
+- [ ] **products**: **String** - A list of products to use from the package. This can be used when depending on multiple products from a package.
 
 ```yaml
 packages:
@@ -661,6 +662,21 @@ targets:
       - package: Yams 
       - package: SwiftPM
         product: SPMUtility
+```
+
+Depending on multiple products from a package:
+
+```yaml
+packages:
+  FooFeature:
+    path: Packages/FooFeature
+targets:
+  App:
+    dependencies:
+      - package: FooFeature
+        products:
+          - FooDomain
+          - FooUI
 ```
 
 ### Config Files

--- a/Sources/ProjectSpec/Dependency.swift
+++ b/Sources/ProjectSpec/Dependency.swift
@@ -61,7 +61,7 @@ public struct Dependency: Equatable {
         case framework
         case carthage(findFrameworks: Bool?, linkType: CarthageLinkType)
         case sdk(root: String?)
-        case package(product: String?)
+        case package(products: [String])
         case bundle
     }
 }
@@ -69,9 +69,9 @@ public struct Dependency: Equatable {
 extension Dependency {
     public var uniqueID: String {
         switch type {
-        case .package(let product):
-            if let product = product {
-                return "\(reference)/\(product)"
+        case .package(let products):
+            if !products.isEmpty {
+                return "\(reference)/\(products.joined(separator: ","))"
             } else {
                 return reference
             }
@@ -106,9 +106,16 @@ extension Dependency: JSONObjectConvertible {
             type = .sdk(root: sdkRoot)
             reference = sdk
         } else if let package: String = jsonDictionary.json(atKeyPath: "package") {
-            let product: String? = jsonDictionary.json(atKeyPath: "product")
-            type = .package(product: product)
-            reference = package
+            if let products: [String] = jsonDictionary.json(atKeyPath: "products") {
+                type = .package(products: products)
+                reference = package
+            } else if let product: String = jsonDictionary.json(atKeyPath: "product") {
+                type = .package(products: [product])
+                reference = package
+            } else {
+                type = .package(products: [])
+                reference = package
+            }
         } else if let bundle: String = jsonDictionary.json(atKeyPath: "bundle") {
             type = .bundle
             reference = bundle

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -928,7 +928,7 @@ public class PBXProjGenerator {
                     }
                 }
             // Embedding handled by iterating over `carthageDependencies` below
-            case .package(let product):
+            case .package(let products):
                 let packageReference = packageReferences[dependency.reference]
 
                 // If package's reference is none and there is no specified package in localPackages,
@@ -937,40 +937,49 @@ public class PBXProjGenerator {
                     continue
                 }
 
-                let productName = product ?? dependency.reference
-                let packageDependency = addObject(
-                    XCSwiftPackageProductDependency(productName: productName, package: packageReference)
-                )
-
-                // Add package dependency if linking is true.
-                if dependency.link ?? true {
-                    packageDependencies.append(packageDependency)
-                }
-
-                let link = dependency.link ?? (target.type != .staticLibrary)
-                if link {
-                    let file = PBXBuildFile(product: packageDependency, settings: getDependencyFrameworkSettings(dependency: dependency))
-                    file.platformFilter = platform
-                    let buildFile = addObject(file)
-                    targetFrameworkBuildFiles.append(buildFile)
-                } else {
-                    let targetDependency = addObject(
-                        PBXTargetDependency(platformFilter: platform, product: packageDependency)
+                func addPackageProductDependency(named productName: String) {
+                    let packageDependency = addObject(
+                        XCSwiftPackageProductDependency(productName: productName, package: packageReference)
                     )
-                    dependencies.append(targetDependency)
+
+                    // Add package dependency if linking is true.
+                    if dependency.link ?? true {
+                        packageDependencies.append(packageDependency)
+                    }
+
+                    let link = dependency.link ?? (target.type != .staticLibrary)
+                    if link {
+                        let file = PBXBuildFile(product: packageDependency, settings: getDependencyFrameworkSettings(dependency: dependency))
+                        file.platformFilter = platform
+                        let buildFile = addObject(file)
+                        targetFrameworkBuildFiles.append(buildFile)
+                    } else {
+                        let targetDependency = addObject(
+                            PBXTargetDependency(platformFilter: platform, product: packageDependency)
+                        )
+                        dependencies.append(targetDependency)
+                    }
+
+                    if dependency.embed == true {
+                        let pbxBuildFile = PBXBuildFile(product: packageDependency,
+                        settings: getEmbedSettings(dependency: dependency, codeSign: dependency.codeSign ?? true))
+                        pbxBuildFile.platformFilter = platform
+                        let embedFile = addObject(pbxBuildFile)
+
+                        if dependency.copyPhase != nil {
+                            customCopyDependenciesReferences.append(embedFile)
+                        } else {
+                            copyFrameworksReferences.append(embedFile)
+                        }
+                    }
                 }
 
-                if dependency.embed == true {
-                    let pbxBuildFile = PBXBuildFile(product: packageDependency,
-                    settings: getEmbedSettings(dependency: dependency, codeSign: dependency.codeSign ?? true))
-                    pbxBuildFile.platformFilter = platform
-                    let embedFile = addObject(pbxBuildFile)
-                    
-                    if dependency.copyPhase != nil {
-                        customCopyDependenciesReferences.append(embedFile)
-                    } else {
-                        copyFrameworksReferences.append(embedFile)
+                if !products.isEmpty {
+                    for product in products {
+                        addPackageProductDependency(named: product)
                     }
+                } else {
+                    addPackageProductDependency(named: dependency.reference)
                 }
             case .bundle:
                 // Static and dynamic libraries can't copy resources

--- a/Tests/Fixtures/SPM/FooFeature/Package.swift
+++ b/Tests/Fixtures/SPM/FooFeature/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "FooFeature",
+    products: [
+        .library(name: "FooDomain", targets: [
+            "FooDomain"
+        ]),
+        .library(name: "FooUI", targets: [
+            "FooUI"
+        ])
+    ],
+    targets: [
+        .target(name: "FooDomain"),
+        .target(name: "FooUI")
+    ]
+)

--- a/Tests/Fixtures/SPM/FooFeature/Sources/FooDomain/FooDomain.swift
+++ b/Tests/Fixtures/SPM/FooFeature/Sources/FooDomain/FooDomain.swift
@@ -1,0 +1,1 @@
+public struct FooDomain {}

--- a/Tests/Fixtures/SPM/FooFeature/Sources/FooUI/FooUI.swift
+++ b/Tests/Fixtures/SPM/FooFeature/Sources/FooUI/FooUI.swift
@@ -1,0 +1,1 @@
+public struct FooUI {}

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -9,10 +9,12 @@
 /* Begin PBXBuildFile section */
 		23C6626698DE560017A89F2F /* XcodeGen in Frameworks */ = {isa = PBXBuildFile; productRef = 6F7DEA2D82649EDF903FBDBD /* XcodeGen */; };
 		2DA7998902987953B119E4CE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F7EFEE613987D1E1258A60 /* AppDelegate.swift */; };
+		36CE2E6187D9709BAD9EF807 /* FooUI in Frameworks */ = {isa = PBXBuildFile; productRef = 927CB19D94339CC9960E930C /* FooUI */; };
 		3986ED6965842721C46C0452 /* SwiftRoaringDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */; };
 		4CC663B42B270404EF5FD037 /* libStaticLibrary.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CAB5625F6FEA668410ED5482 /* libStaticLibrary.a */; };
 		9AD886A88D3E4A1B5E900687 /* SPMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7970A2253B14A9B27C307FAC /* SPMTests.swift */; };
 		9C4AD0711D706FD3ED0E436D /* StaticLibrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C17B77601A9D1B7895AB42 /* StaticLibrary.swift */; };
+		AF8E362713B9D28EA9A5C9FC /* FooDomain in Frameworks */ = {isa = PBXBuildFile; productRef = 8D2DC638BEF7FDF23907E134 /* FooDomain */; };
 		B89EA0F3859878A1DCF7BAFD /* SwiftRoaringDynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE46CBA5671B951B546C8673 /* Codability in Frameworks */ = {isa = PBXBuildFile; productRef = 16E6FE01D5BD99F78D4A17E2 /* Codability */; settings = {ATTRIBUTES = (Weak, ); }; };
 		E368431019ABC696E4FFC0CF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E22B8BCC18A29EFE1DE3BE4 /* Assets.xcassets */; };
@@ -57,6 +59,7 @@
 		4E22B8BCC18A29EFE1DE3BE4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		61C17B77601A9D1B7895AB42 /* StaticLibrary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticLibrary.swift; sourceTree = "<group>"; };
 		7970A2253B14A9B27C307FAC /* SPMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SPMTests.swift; sourceTree = "<group>"; };
+		979AE1767E2AF6B3B9D7F13D /* FooFeature */ = {isa = PBXFileReference; lastKnownFileType = folder; name = FooFeature; path = FooFeature; sourceTree = SOURCE_ROOT; };
 		A9601593D0AD02931266A4E5 /* App.xctestplan */ = {isa = PBXFileReference; path = App.xctestplan; sourceTree = "<group>"; };
 		CAB5625F6FEA668410ED5482 /* libStaticLibrary.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = libStaticLibrary.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED284AB7C13DCC0A95DAA680 /* XcodeGen */ = {isa = PBXFileReference; lastKnownFileType = folder; name = XcodeGen; path = ../../..; sourceTree = SOURCE_ROOT; };
@@ -71,6 +74,8 @@
 				3986ED6965842721C46C0452 /* SwiftRoaringDynamic in Frameworks */,
 				4CC663B42B270404EF5FD037 /* libStaticLibrary.a in Frameworks */,
 				23C6626698DE560017A89F2F /* XcodeGen in Frameworks */,
+				AF8E362713B9D28EA9A5C9FC /* FooDomain in Frameworks */,
+				36CE2E6187D9709BAD9EF807 /* FooUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,6 +105,7 @@
 		218F6C96DF9E182F526258CF = {
 			isa = PBXGroup;
 			children = (
+				AD0F3623091EEA8D1EA3DFF8 /* Packages */,
 				17DD374CC81D710476AFF41C /* SPM */,
 				CF3BD77AEAA56553289456BA /* SPMTests */,
 				1FA59BFD192FB5A68D5F587C /* StaticLibrary */,
@@ -116,6 +122,14 @@
 			);
 			name = Products;
 			sourceTree = "<group>";
+		};
+		AD0F3623091EEA8D1EA3DFF8 /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				979AE1767E2AF6B3B9D7F13D /* FooFeature */,
+			);
+			name = Packages;
+			sourceTree = SOURCE_ROOT;
 		};
 		CF3BD77AEAA56553289456BA /* SPMTests */ = {
 			isa = PBXGroup;
@@ -157,12 +171,16 @@
 				D85FFB99444DD260A72DDDA7 /* PBXTargetDependency */,
 				DDD17C561AD5065DF4FA4072 /* PBXTargetDependency */,
 				C6360997FFC102F6725099D4 /* PBXTargetDependency */,
+				00B467060F3DEC027711F9C2 /* PBXTargetDependency */,
+				7EB17E90A4D8F26FEABEEDF6 /* PBXTargetDependency */,
 			);
 			name = StaticLibrary;
 			packageProductDependencies = (
 				AF233B61592982A7F6431FC6 /* Codability */,
 				C816AEB28ED71C3C47F31B98 /* SwiftRoaringDynamic */,
 				5A36E2FE69703FCAC0BE8064 /* XcodeGen */,
+				6B8A6E1EA485E607A1D1DCD1 /* FooDomain */,
+				15DB49096E2978F6BCA8D604 /* FooUI */,
 			);
 			productName = StaticLibrary;
 			productReference = CAB5625F6FEA668410ED5482 /* libStaticLibrary.a */;
@@ -188,6 +206,8 @@
 				16E6FE01D5BD99F78D4A17E2 /* Codability */,
 				DC73B269C8B0C0BF6912842C /* SwiftRoaringDynamic */,
 				6F7DEA2D82649EDF903FBDBD /* XcodeGen */,
+				8D2DC638BEF7FDF23907E134 /* FooDomain */,
+				927CB19D94339CC9960E930C /* FooUI */,
 			);
 			productName = App;
 			productReference = 097F2DB5622B591E21BC3C73 /* App.app */;
@@ -286,10 +306,18 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		00B467060F3DEC027711F9C2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 6B8A6E1EA485E607A1D1DCD1 /* FooDomain */;
+		};
 		078202CF7B08B66ACF7FEC23 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 3F8D94C4EFC431F646AAFB28 /* StaticLibrary */;
 			targetProxy = 29147E1DDAEB1AAC20CB0CF9 /* PBXContainerItemProxy */;
+		};
+		7EB17E90A4D8F26FEABEEDF6 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 15DB49096E2978F6BCA8D604 /* FooUI */;
 		};
 		8693351DA9DBE579AC9DD513 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -595,6 +623,10 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		15DB49096E2978F6BCA8D604 /* FooUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FooUI;
+		};
 		16E6FE01D5BD99F78D4A17E2 /* Codability */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5BA91390AE78D2EE15C60091 /* XCRemoteSwiftPackageReference "Codability" */;
@@ -604,9 +636,21 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = XcodeGen;
 		};
+		6B8A6E1EA485E607A1D1DCD1 /* FooDomain */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FooDomain;
+		};
 		6F7DEA2D82649EDF903FBDBD /* XcodeGen */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XcodeGen;
+		};
+		8D2DC638BEF7FDF23907E134 /* FooDomain */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FooDomain;
+		};
+		927CB19D94339CC9960E930C /* FooUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FooUI;
 		};
 		AF233B61592982A7F6431FC6 /* Codability */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Tests/Fixtures/SPM/project.yml
+++ b/Tests/Fixtures/SPM/project.yml
@@ -12,6 +12,8 @@ packages:
   XcodeGen:
     path: ../../.. #XcodeGen itself
     group: SPM
+  FooFeature:
+    path: FooFeature
 targets:
   App:
     type: application
@@ -32,6 +34,10 @@ targets:
         embed: true
       - target: StaticLibrary
       - package: XcodeGen
+      - package: FooFeature
+        products:
+          - FooDomain
+          - FooUI
   Tests:
     type: bundle.unit-test
     platform: iOS
@@ -47,3 +53,7 @@ targets:
       - package: SwiftRoaring
         product: SwiftRoaringDynamic
       - package: XcodeGen
+      - package: FooFeature
+        products:
+        - FooDomain
+        - FooUI

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -156,8 +156,8 @@ class ProjectSpecTests: XCTestCase {
                             Dependency(type: .framework, reference: "dependency2"),
 
                             // multiple package dependencies with different products should be allowed
-                            Dependency(type: .package(product: "one"), reference: "package1"),
-                            Dependency(type: .package(product: "two"), reference: "package1"),
+                            Dependency(type: .package(products: ["one"]), reference: "package1"),
+                            Dependency(type: .package(products: ["two"]), reference: "package1"),
                         ]
                     ),
                     Target(
@@ -205,7 +205,7 @@ class ProjectSpecTests: XCTestCase {
                     sources: ["invalidSource"],
                     dependencies: [
                         Dependency(type: .target, reference: "invalidDependency"),
-                        Dependency(type: .package(product: nil), reference: "invalidPackage"),
+                        Dependency(type: .package(products: []), reference: "invalidPackage"),
                     ],
                     preBuildScripts: [BuildScript(script: .path("invalidPreBuildScript"), name: "preBuildScript1")],
                     postCompileScripts: [BuildScript(script: .path("invalidPostCompileScript"))],

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -38,7 +38,7 @@ class SpecLoadingTests: XCTestCase {
                     "toReplace": Settings(dictionary: ["MY_SETTING2": "VALUE2"]),
                 ]
                 try expect(project.targets) == [
-                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"], dependencies: [Dependency(type: .package(product: nil), reference: "Yams")]),
+                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"], dependencies: [Dependency(type: .package(products: []), reference: "Yams")]),
                     Target(name: "NewTarget", type: .application, platform: .iOS, sources: ["template", "target"]),
                 ]
             }
@@ -54,7 +54,7 @@ class SpecLoadingTests: XCTestCase {
                     "toReplace": Settings(dictionary: ["MY_SETTING2": "VALUE2"]),
                 ]
                 try expect(project.targets) == [
-                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"], dependencies: [Dependency(type: .package(product: nil), reference: "SwiftPM"), Dependency(type: .package(product: nil), reference: "Yams")]),
+                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"], dependencies: [Dependency(type: .package(products: []), reference: "SwiftPM"), Dependency(type: .package(products: []), reference: "Yams")]),
                     Target(name: "NewTarget", type: .application, platform: .iOS, sources: ["template", "target"]),
                 ]
             }
@@ -70,7 +70,7 @@ class SpecLoadingTests: XCTestCase {
                     "toReplace": Settings(dictionary: ["MY_SETTING2": "VALUE2"]),
                 ]
                 try expect(project.targets) == [
-                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"], dependencies: [Dependency(type: .package(product: nil), reference: "Yams")]),
+                    Target(name: "IncludedTargetNew", type: .application, platform: .tvOS, sources: ["NewSource"], dependencies: [Dependency(type: .package(products: []), reference: "Yams")]),
                     Target(name: "NewTarget", type: .application, platform: .iOS, sources: ["template", "target"]),
                 ]
             }

--- a/Tests/XcodeGenKitTests/GraphVizGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/GraphVizGeneratorTests.swift
@@ -14,7 +14,7 @@ private let app = Target(
         Dependency(type: .carthage(findFrameworks: true, linkType: .static), reference: "MyStaticFramework"),
         Dependency(type: .carthage(findFrameworks: true, linkType: .dynamic), reference: "MyDynamicFramework"),
         Dependency(type: .framework, reference: "MyExternalFramework"),
-        Dependency(type: .package(product: "MyPackage"), reference: "MyPackage"),
+        Dependency(type: .package(products: ["MyPackage"]), reference: "MyPackage"),
         Dependency(type: .sdk(root: "MySDK"), reference: "MySDK"),
     ]
 )

--- a/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/PBXProjGeneratorTests.swift
@@ -357,7 +357,7 @@ class PBXProjGeneratorTests: XCTestCase {
                 let dependency1 = Dependency(type: .target, reference: "TestAll", platformFilter: .all)
                 let dependency2 = Dependency(type: .target, reference: "TestiOS", platformFilter: .iOS)
                 let dependency3 = Dependency(type: .target, reference: "TestmacOS", platformFilter: .macOS)
-                let dependency4 = Dependency(type: .package(product: "Swinject"), reference: "Swinject", platformFilter: .iOS)
+                let dependency4 = Dependency(type: .package(products: ["Swinject"]), reference: "Swinject", platformFilter: .iOS)
                 let target = Target(name: "Test", type: .application, platform: .iOS, sources: ["Sources"], dependencies: [dependency1, dependency2, dependency3, dependency4])
                 let swinjectPackage = SwiftPackage.remote(url: "https://github.com/Swinject/Swinject", versionRequirement: .exact("2.8.0"))
                 let project = Project(basePath: directoryPath, name: "Test", targets: [target, target1, target2, target3], packages: ["Swinject": swinjectPackage])

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -487,7 +487,7 @@ class SchemeGeneratorTests: XCTestCase {
                     type: .application,
                     platform: .iOS,
                     dependencies: [
-                        Dependency(type: .package(product: nil), reference: "XcodeGen")
+                        Dependency(type: .package(products: []), reference: "XcodeGen")
                     ],
                     scheme: targetScheme
                 )


### PR DESCRIPTION
Adds support for specifying multiple products for when adding a package dependency to a target.

With this change dependencies that were previously written as

```yaml
dependencies:
- package: FooFeature
  product: FooDomain
- package: FooFeature
  product: FooUI
```

can now be written as

```yaml
dependencies:
- package: FooFeature
  products: 
  - FooDomain
  - FooUI
```

This makes it easier to add multiple products of a single package.