### PR TITLE
Add support for .mlpackage bundles

### DIFF
--- a/Sources/ProjectSpec/FileType.swift
+++ b/Sources/ProjectSpec/FileType.swift
@@ -87,6 +87,7 @@ extension FileType {
         "intentdefinition": FileType(buildPhase: .sources),
         "metal": FileType(buildPhase: .sources),
         "mlmodel": FileType(buildPhase: .sources),
+        "mlpackage" : FileType(buildPhase: .sources),
         "mlmodelc": FileType(buildPhase: .resources),
         "rcproject": FileType(buildPhase: .sources),
         "iig": FileType(buildPhase: .sources),

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -589,6 +589,7 @@ class SourceGeneratorTests: XCTestCase {
                     - file.xcassets
                     - file.metal
                     - file.mlmodel
+                    - file.mlpackage
                     - file.mlmodelc
                     - Info.plist
                     - Intent.intentdefinition
@@ -648,6 +649,7 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFile(paths: ["C", "Info.plist"], buildPhase: BuildPhaseSpec.none)
                 try pbxProj.expectFile(paths: ["C", "file.metal"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["C", "file.mlmodel"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: ["C", "file.mlpackage"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["C", "file.mlmodelc"], buildPhase: .resources)
                 try pbxProj.expectFile(paths: ["C", "Intent.intentdefinition"], buildPhase: .sources)
                 try pbxProj.expectFile(paths: ["C", "Configuration.storekit"], buildPhase: .resources)


### PR DESCRIPTION
This change adds mlpackage bundles to the sources build phase.

Re: https://github.com/yonaskolb/XcodeGen/issues/1397