### PR TITLE
Allow lookup template variables from globalTemplateAttributes

### DIFF
--- a/Sources/ProjectSpec/Template.swift
+++ b/Sources/ProjectSpec/Template.swift
@@ -66,6 +66,10 @@ private func resolveTemplates(jsonDictionary: JSONDictionary, templateStructure:
             if let templateAttributes = reference["templateAttributes"] as? [String: String] {
                 reference = reference.expand(variables: templateAttributes)
             }
+
+            if let globalVariables = jsonDictionary["globalTemplateAttributes"] as? [String: String] {
+                reference = reference.expand(variables: globalVariables)
+            }
         }
         baseDictionary[referenceName] = reference
     }


### PR DESCRIPTION
For example, I have an iOS project with a network extension target. But I have some partners (Google, Facebook, etc.) and have Xcode configurations for each partner separately.
I have to create multiple xcodegen spec files to configure Google and Facebook.
Network extension reuse for every partner, then I create a file to reuse for every partner. But currently, xcodegen doesn't support a mechanism to import a config partner name from the xcodegen spec to the network extension spec.
Then I created a PR to allow xcodegen to lookup template attributes from `globalTemplateAttributes` spec.
Demo project for this situation: https://github.com/vikage/DemoXcodeGenGlobalTemplateAttribute

package-tunnel-target.yml
```
targetTemplates:
  PacketTunnelTemplate:
    platform: iOS
    type: app-extension
    settings:
      CODE_SIGN_IDENTITY: Apple Development
    dependencies:
      - sdk: NetworkExtension.framework
    configFiles:
      Debug: Partners/${partner}/PacketTunnel-Debug.xcconfig
      Release: Partners/${partner}/PacketTunnel-Release.xcconfig
    settings:
      CODE_SIGN_IDENTITY: Apple Development
    sources:
      - PacketTunnel

targets:
  PacketTunnel:
    templates:
      - PacketTunnelTemplate
 ```

google-project.yml
```
name: Demo

options:
  createIntermediateGroups: True
  
globalTemplateAttributes:
  partner: Google

include:
  - packet-tunnel-target.yml

targets:
  Demo:
    type: application
    platform: iOS
    deploymentTarget: "10.0"
    sources:
      - DemoXcodeGenGlobalTemplateAttribute
 ```