### PR TITLE
Remove the prefix v for the semantic version if necessary

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -1228,7 +1228,7 @@ Swift packages are defined at a project level, and then linked to individual tar
 ### Remote Package
 
 - [x] **url**: **URL** - the url to the package
-- [x] **version**: **String** - the version of the package to use. It can take a few forms:
+- [x] **version**: **String** - the version of the package to use. It can take a few forms (it doesn't matter if it has the prefix v):
   - `majorVersion: 1.2.0` or `from: 1.2.0`
   - `minorVersion: 1.2.1`
   - `exactVersion: 1.2.1` or `version: 1.2.1`

--- a/Sources/ProjectSpec/SwiftPackage.swift
+++ b/Sources/ProjectSpec/SwiftPackage.swift
@@ -105,25 +105,39 @@ extension SwiftPackage.VersionRequirement: JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
         if jsonDictionary["exactVersion"] != nil {
-            self = try .exact(jsonDictionary.json(atKeyPath: "exactVersion"))
+            let version = Self.removePrefixVIfNeeded(version: try jsonDictionary.json(atKeyPath: "exactVersion"))
+            self = .exact(version)
         } else if jsonDictionary["version"] != nil {
-            self = try .exact(jsonDictionary.json(atKeyPath: "version"))
+            let version = Self.removePrefixVIfNeeded(version: try jsonDictionary.json(atKeyPath: "version"))
+            self = .exact(version)
         } else if jsonDictionary["revision"] != nil {
             self = try .revision(jsonDictionary.json(atKeyPath: "revision"))
         } else if jsonDictionary["branch"] != nil {
             self = try .branch(jsonDictionary.json(atKeyPath: "branch"))
         } else if jsonDictionary["minVersion"] != nil && jsonDictionary["maxVersion"] != nil {
-            let minimum: String = try jsonDictionary.json(atKeyPath: "minVersion")
-            let maximum: String = try jsonDictionary.json(atKeyPath: "maxVersion")
+            let minimum = Self.removePrefixVIfNeeded(version: try jsonDictionary.json(atKeyPath: "minVersion"))
+            let maximum = Self.removePrefixVIfNeeded(version: try jsonDictionary.json(atKeyPath: "maxVersion"))
             self = .range(from: minimum, to: maximum)
         } else if jsonDictionary["minorVersion"] != nil {
-            self = try .upToNextMinorVersion(jsonDictionary.json(atKeyPath: "minorVersion"))
+            let version = Self.removePrefixVIfNeeded(version: try jsonDictionary.json(atKeyPath: "minorVersion"))
+            self = .upToNextMinorVersion(version)
         } else if jsonDictionary["majorVersion"] != nil {
-            self = try .upToNextMajorVersion(jsonDictionary.json(atKeyPath: "majorVersion"))
+            let version = Self.removePrefixVIfNeeded(version: try jsonDictionary.json(atKeyPath: "majorVersion"))
+            self = .upToNextMajorVersion(version)
         } else if jsonDictionary["from"] != nil {
-            self = try .upToNextMajorVersion(jsonDictionary.json(atKeyPath: "from"))
+            let version = Self.removePrefixVIfNeeded(version: try jsonDictionary.json(atKeyPath: "from"))
+            self = .upToNextMajorVersion(version)
         } else {
             throw SpecParsingError.unknownPackageRequirement(jsonDictionary)
         }
+    }
+
+    /// Remove the "v" prefix (for "version")
+    private static func removePrefixVIfNeeded(version: String) -> String {
+        if version.hasPrefix("v") {
+            let startIndex = version.index(version.startIndex, offsetBy: 1)
+            return String(version[startIndex...])
+        }
+        return version
     }
 }

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -1484,11 +1484,12 @@ class SpecLoadingTests: XCTestCase {
                     "package5": .remote(url: "package.git", versionRequirement: .revision("x")),
                     "package6": .remote(url: "package.git", versionRequirement: .range(from: "1.2.0", to: "1.2.5")),
                     "package7": .remote(url: "package.git", versionRequirement: .exact("1.2.2")),
-                    "package8": .remote(url: "package.git", versionRequirement: .upToNextMajorVersion("4.0.0-beta.5")),
-                    "package9": .local(path: "package/package", group: nil),
-                    "package10": .remote(url: "https://github.com/yonaskolb/XcodeGen", versionRequirement: .exact("1.2.2")),
+                    "package8": .remote(url: "package.git", versionRequirement: .exact("1.2.2")),
+                    "package9": .remote(url: "package.git", versionRequirement: .upToNextMajorVersion("4.0.0-beta.5")),
+                    "package10": .local(path: "package/package", group: nil),
+                    "package11": .remote(url: "https://github.com/yonaskolb/XcodeGen", versionRequirement: .exact("1.2.2")),
                     "XcodeGen": .local(path: "../XcodeGen", group: nil),
-                    "package11": .local(path: "../XcodeGen", group: "Packages/Feature"),
+                    "package12": .local(path: "../XcodeGen", group: "Packages/Feature"),
                 ], options: .init(localPackagesGroup: "MyPackages"))
 
                 let dictionary: [String: Any] = [
@@ -1504,10 +1505,11 @@ class SpecLoadingTests: XCTestCase {
                         "package5": ["url": "package.git", "revision": "x"],
                         "package6": ["url": "package.git", "minVersion": "1.2.0", "maxVersion": "1.2.5"],
                         "package7": ["url": "package.git", "version": "1.2.2"],
-                        "package8": ["url": "package.git", "majorVersion": "4.0.0-beta.5"],
-                        "package9": ["path": "package/package"],
-                        "package10": ["github": "yonaskolb/XcodeGen", "exactVersion": "1.2.2"],
-                        "package11": ["path": "../XcodeGen", "group": "Packages/Feature"],
+                        "package8": ["url": "package.git", "version": "v1.2.2"],
+                        "package9": ["url": "package.git", "majorVersion": "4.0.0-beta.5"],
+                        "package10": ["path": "package/package"],
+                        "package11": ["github": "yonaskolb/XcodeGen", "exactVersion": "1.2.2"],
+                        "package12": ["path": "../XcodeGen", "group": "Packages/Feature"],
                     ],
                     "localPackages": ["../XcodeGen"],
                 ]


### PR DESCRIPTION
## Describe your changes
- Remove the prefix v for the semantic version in SPM if necessary, as in v2.2.0.
  - Libraries that include the prefix v in tags are [Quick](https://github.com/Quick/Quick/releases), [Nimble](https://github.com/Quick/Nimble/releases), [socket.io-client-swift](https://github.com/socketio/socket.io-client-swift/releases)

## Issue ticket number and link
- None. (as far as I've seen)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have added tests.

Thanks!
