### PR TITLE
Add watchOS as a supported destination

### DIFF
--- a/SettingPresets/SupportedDestinations/watchOS.yml
+++ b/SettingPresets/SupportedDestinations/watchOS.yml
@@ -1,0 +1,2 @@
+SUPPORTED_PLATFORMS: watchos watchsimulator
+TARGETED_DEVICE_FAMILY: '4'

--- a/Sources/ProjectSpec/SupportedDestination.swift
+++ b/Sources/ProjectSpec/SupportedDestination.swift
@@ -5,6 +5,7 @@ public enum SupportedDestination: String, CaseIterable {
     case tvOS
     case macOS
     case macCatalyst
+    case watchOS
     case visionOS
 }
 
@@ -20,6 +21,8 @@ extension SupportedDestination {
             return "macos"
         case .macCatalyst:
             return "maccatalyst"
+        case .watchOS:
+            return "watchos"
         case .visionOS:
             return "xros"
         }
@@ -40,6 +43,8 @@ extension SupportedDestination {
             return 3
         case .macCatalyst:
             return 4
+        case .watchOS:
+            return 5
         }
     }
 }

--- a/Sources/ProjectSpec/SupportedDestination.swift
+++ b/Sources/ProjectSpec/SupportedDestination.swift
@@ -37,13 +37,13 @@ extension SupportedDestination {
             return 0
         case .tvOS:
             return 1
-        case .visionOS:
-            return 2
-        case .macOS:
-            return 3
-        case .macCatalyst:
-            return 4
         case .watchOS:
+            return 2
+        case .visionOS:
+            return 3
+        case .macOS:
+            return 4
+        case .macCatalyst:
             return 5
         }
     }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -484,7 +484,33 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["ASSETCATALOG_COMPILER_APPICON_NAME"] as? String) == "AppIcon"
                 try expect(targetConfig1.buildSettings["CODE_SIGN_IDENTITY"] as? String) == "iPhone Developer"
             }
-            
+
+            $0.it("supportedDestinations merges settings - iOS, watchOS") {
+                let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.iOS, .watchOS])
+                let project = Project(name: "", targets: [target])
+
+                let pbxProject = try project.generatePbxProj()
+                let targetConfig1 = try unwrap(pbxProject.nativeTargets.first?.buildConfigurationList?.buildConfigurations.first)
+
+                try expect(targetConfig1.buildSettings["SUPPORTED_PLATFORMS"] as? String) == "iphoneos iphonesimulator watchos watchsimulator"
+                try expect(targetConfig1.buildSettings["TARGETED_DEVICE_FAMILY"] as? String) == "1,2,4"
+                try expect(targetConfig1.buildSettings["SUPPORTS_MACCATALYST"] as? Bool) == false
+                try expect(targetConfig1.buildSettings["SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD"] as? Bool) == true
+                try expect(targetConfig1.buildSettings["SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD"] as? Bool) == true
+            }
+
+            $0.it("supportedDestinations merges settings - visionOS, watchOS") {
+                let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.visionOS, .watchOS])
+                let project = Project(name: "", targets: [target])
+
+                let pbxProject = try project.generatePbxProj()
+                let targetConfig1 = try unwrap(pbxProject.nativeTargets.first?.buildConfigurationList?.buildConfigurations.first)
+
+                try expect(targetConfig1.buildSettings["SUPPORTED_PLATFORMS"] as? String) == "watchos watchsimulator xros xrsimulator"
+                try expect(targetConfig1.buildSettings["TARGETED_DEVICE_FAMILY"] as? String) == "4,7"
+                try expect(targetConfig1.buildSettings["SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD"] as? Bool) == false
+            }
+
             $0.it("generates dependencies") {
                 let pbxProject = try project.generatePbxProj()
 

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -336,7 +336,7 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig.buildSettings["TVOS_DEPLOYMENT_TARGET"]).beNil()
             }
             
-            $0.it("supportedPlaforms merges settings - iOS, tvOS") {
+            $0.it("supportedDestinations merges settings - iOS, tvOS") {
                 let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.tvOS, .iOS])
                 let project = Project(name: "", targets: [target])
                 
@@ -355,7 +355,7 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["CODE_SIGN_IDENTITY"] as? String) == "iPhone Developer"
             }
             
-            $0.it("supportedPlaforms merges settings - iOS, visionOS") {
+            $0.it("supportedDestinations merges settings - iOS, visionOS") {
                 let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.visionOS, .iOS])
                 let project = Project(name: "", targets: [target])
                 
@@ -374,7 +374,7 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["CODE_SIGN_IDENTITY"] as? String) == "iPhone Developer"
             }
             
-            $0.it("supportedPlaforms merges settings - iOS, tvOS, macOS") {
+            $0.it("supportedDestinations merges settings - iOS, tvOS, macOS") {
                 let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.iOS, .tvOS, .macOS])
                 let project = Project(name: "", targets: [target])
                 
@@ -393,7 +393,7 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["CODE_SIGN_IDENTITY"] as? String) == "iPhone Developer"
             }
             
-            $0.it("supportedPlaforms merges settings - iOS, tvOS, macCatalyst") {
+            $0.it("supportedDestinations merges settings - iOS, tvOS, macCatalyst") {
                 let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.iOS, .tvOS, .macCatalyst])
                 let project = Project(name: "", targets: [target])
                 
@@ -412,7 +412,7 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["CODE_SIGN_IDENTITY"] as? String) == "iPhone Developer"
             }
             
-            $0.it("supportedPlaforms merges settings - iOS, macOS") {
+            $0.it("supportedDestinations merges settings - iOS, macOS") {
                 let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.iOS, .macOS])
                 let project = Project(name: "", targets: [target])
                 
@@ -431,7 +431,7 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["CODE_SIGN_IDENTITY"] as? String) == "iPhone Developer"
             }
             
-            $0.it("supportedPlaforms merges settings - tvOS, macOS") {
+            $0.it("supportedDestinations merges settings - tvOS, macOS") {
                 let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.tvOS, .macOS])
                 let project = Project(name: "", targets: [target])
                 
@@ -449,7 +449,7 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME"] as? String) == "LaunchImage"
             }
             
-            $0.it("supportedPlaforms merges settings - visionOS, macOS") {
+            $0.it("supportedDestinations merges settings - visionOS, macOS") {
                 let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.visionOS, .macOS])
                 let project = Project(name: "", targets: [target])
                 
@@ -466,7 +466,7 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["ASSETCATALOG_COMPILER_APPICON_NAME"] as? String) == "AppIcon"
             }
             
-            $0.it("supportedPlaforms merges settings - iOS, macCatalyst") {
+            $0.it("supportedDestinations merges settings - iOS, macCatalyst") {
                 let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.iOS, .macCatalyst])
                 let project = Project(name: "", targets: [target])
                 


### PR DESCRIPTION
Hi, I'm new to this project. This PR adds the watchOS support for the `supportedDestinations` configuration, initially added in #1336.

<img src="https://github.com/yonaskolb/XcodeGen/assets/28077639/955be6fc-e5c6-43ed-bde0-7a95e73313d6" width="400">

## Changes

- Added the `watchOS` case to the `SupportedDestination` enum.
- Added a configuration template for watchOS.
- Added test cases.

## Tests

You can use the following example spec to verify the changes.

```yml
name: MyProject
options:
  bundleIdPrefix: com.myapp
targets:
  MyWatchKitApp:
    type: application
    platform: watchOS
    sources: [MyWatchKitApp]
    settings:
      MARKETING_VERSION: 1
      CURRENT_PROJECT_VERSION: 1
    dependencies:
      - target: MyFramework
    info:
      path: MyWatchKitApp/Info.plist
      properties:
        WKCompanionAppBundleIdentifier: com.myapp
        WKApplication: true
  MyFramework:
    type: framework
    supportedDestinations: [iOS, watchOS]
    platform: iOS
    sources: [MyFramework]
    settings:
      GENERATE_INFOPLIST_FILE: YES
```

Thanks.