### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Options:
 - **--use-cache**: Used to prevent unnecessarily generating the project. If this is set, then a cache file will be written to when a project is generated. If `xcodegen` is later run but the spec and all the files it contains are the same, the project won't be generated.
 - **--cache-path**: A custom path to use for your cache file. This defaults to `~/.xcodegen/cache/{PROJECT_SPEC_PATH_HASH}`
 
-There are other commands as well such as `xcodegen dump` which lets out output the resolved spec in many different formats, or write it to a file. Use `xcodegen help` to see more detailed usage information.
+There are other commands as well such as `xcodegen dump` which lets one output the resolved spec in many different formats, or write it to a file. Use `xcodegen help` to see more detailed usage information.
 
 ## Dependency Diagrams
 <details>


### PR DESCRIPTION
"...which lets **out** output the resolved spec..." --> "...which lets **one** output the resolved spec..."

Could also change to "...which **outputs** the resolved spec..."