### PR TITLE
Add support for relative paths for exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+### Fixed
+
+- Fixed exclusion of relative paths when including a relative path in target sources #1454 @dalemyers
+
 ## 2.39.1
 
 ### Added

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -376,7 +376,7 @@ class SourceGenerator {
             patterns.parallelMap { pattern in
                 guard !pattern.isEmpty else { return [] }
                 return Glob(pattern: "\(rootSourcePath)/\(pattern)")
-                    .map { Path($0) }
+                    .map { Path($0).absolute() }
                     .map {
                         guard $0.isDirectory else {
                             return [$0]


### PR DESCRIPTION
Includes already support relative paths, but excludes don't. This means if you did something like

```
targets:
  Foo:
    sources:
      path: ../Foo
      excludes:
        - ../Foo/Bar
```

then it wouldn't work. This fix corrects that issue.