### PR TITLE
Include folder (SPM packages) in group sorting logic

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -631,8 +631,8 @@ public class PBXProjGenerator {
         }
 
         if let order = groupOrdering?.order {
-            let files = group.children.filter { $0 is PBXFileReference }
-            var groups = group.children.filter { $0 is PBXGroup }
+            let files = group.children.filter { !$0.isGroupOrFolder }
+            var groups = group.children.filter {  $0.isGroupOrFolder }
 
             var filteredGroups = [PBXFileElement]()
 
@@ -1626,6 +1626,10 @@ extension Platform {
 }
 
 extension PBXFileElement {
+    /// - returns: `true` if the element is a group or a folder reference. Likely an SPM package.
+    var isGroupOrFolder: Bool {
+        self is PBXGroup || (self as? PBXFileReference)?.lastKnownFileType == "folder"
+    }
 
     public func getSortOrder(groupSortPosition: SpecOptions.GroupSortPosition) -> Int {
         if type(of: self).isa == "PBXGroup" {


### PR DESCRIPTION
Add ability to sort SPM packages within a project by allowing groupOrdering to apply to both groups and folders.

Same motivation as https://github.com/yonaskolb/XcodeGen/pull/1366