### PR TITLE
Disallow the "watchOS" supported destination for multiplatform apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+### Fixed
+
+- Fixed `supportedDestinations` validation when it contains watchOS for multiplatform apps. #1470 @tatsuky
+
 ## 2.40.1
 
 ### Fixed

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -500,7 +500,7 @@ targets:
         destinationFilters: [iOS]
 ```
 
-Note that the definition of supported destinations can be applied to every type of bundle making everything more easy to manage (app targets, unit tests, UI tests etc).
+Note that the definition of supported destinations can be applied to almost every type of bundle making everything more easy to manage (app targets, unit tests, UI tests etc). App targets currently do not support the watchOS destination. Create a separate target using `platform` for watchOS apps. See Apple's [Configuring a multiplatform app](https://developer.apple.com/documentation/xcode/configuring-a-multiplatform-app-target) for details.
 
 ### Sources
 

--- a/Sources/ProjectSpec/SpecValidation.swift
+++ b/Sources/ProjectSpec/SpecValidation.swift
@@ -185,6 +185,12 @@ extension Project {
                 errors.append(.unexpectedTargetPlatformForSupportedDestinations(target: target.name, platform: target.platform))
             }
             
+            if let supportedDestinations = target.supportedDestinations,
+               target.type.isApp,
+               supportedDestinations.contains(.watchOS) {
+                errors.append(.containsWatchOSDestinationForMultiplatformApp(target: target.name))
+            }
+
             if target.supportedDestinations?.contains(.macOS) == true,
                target.supportedDestinations?.contains(.macCatalyst) == true {
                 

--- a/Sources/ProjectSpec/SpecValidationError.swift
+++ b/Sources/ProjectSpec/SpecValidationError.swift
@@ -19,6 +19,7 @@ public struct SpecValidationError: Error, CustomStringConvertible {
         case invalidTargetSchemeTest(target: String, testTarget: String)
         case invalidTargetPlatformForSupportedDestinations(target: String)
         case unexpectedTargetPlatformForSupportedDestinations(target: String, platform: Platform)
+        case containsWatchOSDestinationForMultiplatformApp(target: String)
         case multipleMacPlatformsInSupportedDestinations(target: String)
         case missingTargetPlatformInSupportedDestinations(target: String, platform: Platform)
         case invalidSchemeTarget(scheme: String, target: String, action: String)
@@ -66,6 +67,8 @@ public struct SpecValidationError: Error, CustomStringConvertible {
                 return "Target \(target.quoted) has multiple definitions of mac platforms in supported destinations"
             case let .missingTargetPlatformInSupportedDestinations(target, platform):
                 return "Target \(target.quoted) has platform \(platform.rawValue.quoted) that is missing in supported destinations"
+            case let .containsWatchOSDestinationForMultiplatformApp(target):
+                return "Multiplatform app \(target.quoted) cannot contain watchOS in \"supportedDestinations\". Create a separate target using \"platform\" for watchOS apps"
             case let .invalidConfigFile(configFile, config):
                 return "Invalid config file \(configFile.quoted) for config \(config.quoted)"
             case let .invalidSchemeTarget(scheme, target, action):

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -203,6 +203,32 @@ class ProjectSpecTests: XCTestCase {
                 try expectValidationError(project, .unexpectedTargetPlatformForSupportedDestinations(target: "target1", platform: .watchOS))
             }
             
+            $0.it("watchOS in multiplatform app's supported destinations") {
+                var project = baseProject
+                project.targets = [
+                    Target(
+                        name: "target1",
+                        type: .application,
+                        platform: .auto,
+                        supportedDestinations: [.watchOS]
+                    )
+                ]
+                try expectValidationError(project, .containsWatchOSDestinationForMultiplatformApp(target: "target1"))
+            }
+            
+            $0.it("watchOS in non-app's supported destinations") {
+                var project = baseProject
+                project.targets = [
+                    Target(
+                        name: "target1",
+                        type: .framework,
+                        platform: .auto,
+                        supportedDestinations: [.watchOS]
+                    )
+                ]
+                try expectNoValidationError(project, .containsWatchOSDestinationForMultiplatformApp(target: "target1"))
+            }
+            
             $0.it("multiple definitions of mac platform in supported destinations") {
                 var project = baseProject
                 project.targets = [

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -485,8 +485,8 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["CODE_SIGN_IDENTITY"] as? String) == "iPhone Developer"
             }
 
-            $0.it("supportedDestinations merges settings - iOS, watchOS") {
-                let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.iOS, .watchOS])
+            $0.it("supportedDestinations merges settings - iOS, watchOS (framework)") {
+                let target = Target(name: "Target", type: .framework, platform: .auto, supportedDestinations: [.iOS, .watchOS])
                 let project = Project(name: "", targets: [target])
 
                 let pbxProject = try project.generatePbxProj()
@@ -499,8 +499,8 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD"] as? Bool) == true
             }
 
-            $0.it("supportedDestinations merges settings - visionOS, watchOS") {
-                let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.visionOS, .watchOS])
+            $0.it("supportedDestinations merges settings - visionOS, watchOS (framework)") {
+                let target = Target(name: "Target", type: .framework, platform: .auto, supportedDestinations: [.visionOS, .watchOS])
                 let project = Project(name: "", targets: [target])
 
                 let pbxProject = try project.generatePbxProj()


### PR DESCRIPTION
This PR addresses #1463, where the "Embed Watch Content" build phase isn't automatically generated when a watchOS app is created using the `supportedDestinations` configuration.

According to Apple's [documentation](https://developer.apple.com/documentation/xcode/configuring-a-multiplatform-app-target):
> iOS, iPadOS, macOS, visionOS, and tvOS apps can share a single target. watchOS apps remain in a separate target.

Xcode 15.3 is also not capable of creating multiplatform apps that contain the watchOS supported destination. Such the option does not show up on the UI:

<img width="400" alt="The &quot;watchOS&quot; destination does not show up for multiplatform apps on Xcode 15.3" src="https://github.com/yonaskolb/XcodeGen/assets/28077639/98819d41-02c7-43e5-86e9-e386846f36cd">

Provided Xcode doesn't support it now, I had XcodeGen error out when `supportedDestinations` for an application contains watchOS. I added a new validation error case because I think this is an exceptional case that needs a special consideration.

We can continue to create a watchOS app as an independent target by using the `platform` configuration as before. This PR does not affect the configurations of non-application targets.

## Tests

You can use the following example specs to verify the changes.

<details>
<summary>A "success" case using <code>platform</code></summary>

<pre lang="yml"><code>
name: MyApp
options:
  bundleIdPrefix: com.myapp
targets:
  UniversalApp:
    dependencies:
      - target: WatchApp
    supportedDestinations: [iOS, macOS]
    type: application
    sources:
      - Universal
    settings:
      base:
        PRODUCT_BUNDLE_IDENTIFIER: com.myapp.UniversalApp
    info:
      path: Universal/Info.plist
  WatchApp:
    platform: watchOS
    type: application
    sources:
      - Watch
    settings:
      base:
        PRODUCT_BUNDLE_IDENTIFIER: com.myapp.UniversalApp.WatchApp
    info:
      path: Watch/Info.plist
      properties:
        WKCompanionAppBundleIdentifier: com.myapp.UniversalApp
        WKApplication: true
</code></pre>
</details>

<details>
<summary>An "error" case using <code>supportedDestinations</code></summary>

<pre lang="yml"><code>
name: MyApp
options:
  bundleIdPrefix: com.myapp
targets:
  UniversalApp:
    dependencies:
      - target: WatchApp
    supportedDestinations: [iOS, macOS]
    type: application
    sources:
      - Universal
    settings:
      base:
        PRODUCT_BUNDLE_IDENTIFIER: com.myapp.UniversalApp
    info:
      path: Universal/Info.plist
  WatchApp:
    supportedDestinations: [watchOS]
    type: application
    sources:
      - Watch
    settings:
      base:
        PRODUCT_BUNDLE_IDENTIFIER: com.myapp.UniversalApp.WatchApp
    info:
      path: Watch/Info.plist
      properties:
        WKCompanionAppBundleIdentifier: com.myapp.UniversalApp
        WKApplication: true
</code></pre>
</details>