### PR TITLE
Test action macroExpansion allows unavailable buildable reference.

### DIFF
--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -282,9 +282,11 @@ public class SchemeGenerator {
              XCScheme.TestPlanReference(reference: "container:\(testPlan.path)", default: defaultTestPlanIndex == index)
         } ?? []
 
+        let testMacroExpansionBuildableRef = testBuildTargetEntries.map(\.buildableReference).contains(buildableReference) ? buildableReference : testBuildTargetEntries.first?.buildableReference
+
         let testAction = XCScheme.TestAction(
             buildConfiguration: scheme.test?.config ?? defaultDebugConfig.name,
-            macroExpansion: buildableReference,
+            macroExpansion: testMacroExpansionBuildableRef,
             testables: testables,
             testPlans: testPlans.isEmpty ? nil : testPlans,
             preActions: scheme.test?.preActions.map(getExecutionAction) ?? [],

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -281,8 +281,8 @@ public class SchemeGenerator {
         let testPlans = scheme.test?.testPlans.enumerated().map { index, testPlan in
              XCScheme.TestPlanReference(reference: "container:\(testPlan.path)", default: defaultTestPlanIndex == index)
         } ?? []
-
-        let testMacroExpansionBuildableRef = testBuildTargetEntries.map(\.buildableReference).contains(buildableReference) ? buildableReference : testBuildTargetEntries.first?.buildableReference
+        let testBuildableEntries = buildActionEntries.filter({ $0.buildFor.contains(.testing) }) + testBuildTargetEntries
+        let testMacroExpansionBuildableRef = testBuildableEntries.map(\.buildableReference).contains(buildableReference) ? buildableReference : testBuildableEntries.first?.buildableReference
 
         let testAction = XCScheme.TestAction(
             buildConfiguration: scheme.test?.config ?? defaultDebugConfig.name,

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -479,6 +479,46 @@ class SchemeGeneratorTests: XCTestCase {
                 try expect(xcscheme.launchAction?.macroExpansion?.buildableName) == "MyApp.app"
             }
             
+            $0.it("generates scheme with macroExpansion from tests when the main target is not part of the scheme") {
+                let app = Target(
+                    name: "MyApp",
+                    type: .application,
+                    platform: .iOS,
+                    dependencies: []
+                )
+
+                let mockApp = Target(
+                    name: "MockApp",
+                    type: .application,
+                    platform: .iOS,
+                    dependencies: []
+                )
+
+                let testBundle = Target(
+                    name: "TestBundle",
+                    type: .unitTestBundle,
+                    platform: .iOS
+                )
+                let appTarget = Scheme.BuildTarget(target: .local(app.name), buildTypes: [.running])
+                let mockAppTarget = Scheme.BuildTarget(target: .local(mockApp.name), buildTypes: [.testing])
+                let testBundleTarget = Scheme.BuildTarget(target: .local(testBundle.name), buildTypes: [.testing])
+
+                let scheme = Scheme(
+                    name: "TestScheme",
+                    build: Scheme.Build(targets: [appTarget, mockAppTarget, testBundleTarget]),
+                    run: Scheme.Run(config: "Debug", macroExpansion: "MyApp")
+                )
+                let project = Project(
+                    name: "test",
+                    targets: [app, mockApp, testBundle],
+                    schemes: [scheme]
+                )
+                let xcodeProject = try project.generateXcodeProject()
+
+                let xcscheme = try unwrap(xcodeProject.sharedData?.schemes.first)
+                try expect(xcscheme.testAction?.macroExpansion?.buildableName) == "MockApp.app"
+            }
+
             $0.it("generates scheme with test target of local swift package") {
                 let targetScheme = TargetScheme(
                     testTargets: [Scheme.Test.TestTarget(targetReference: TestableTargetReference(name: "XcodeGenKitTests", location: .package("XcodeGen")))])


### PR DESCRIPTION
Relates to: https://github.com/yonaskolb/XcodeGen/pull/1468

Since the buildableReference passed to the test action macroExpansion param is literally the first buildable reference, there's a chance that buildable reference is not part of the test buildable references, so "Expand Variables Based On" defaults to None (for the test action)

<img width="562" alt="Screenshot 2024-04-20 at 7 51 21 PM" src="https://github.com/yonaskolb/XcodeGen/assets/1932403/eb81cfd7-5184-487c-b645-4b0f5a0e3435">

A potential solution is to use the first buildable reference from `testBuildTargetEntries` instead if the buildableReference is not part of (testBuildTargetEntries).