### PR TITLE
Update package version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,26 +8,26 @@ jobs:
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:
-        xcode: ["14.3.1"]
+        xcode: ["15.3"]
         include:
-        - xcode: "14.3.1"
-          macos: macos-13
+          - xcode: "15.3"
+            macos: macos-14
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     steps:
-    - uses: actions/checkout@master
-    - name: Resolve
-      run: swift package resolve
-    - name: Build
-      run: swift build
-    - name: Test
-      run: set -o pipefail && swift test 2>&1 | xcpretty
-    - name: Gen fixtures
-      run: scripts/gen-fixtures.sh
-    - name: Check fixtures
-      run: scripts/diff-fixtures.sh
-    - name: Build fixtures
-      run: scripts/build-fixtures.sh
+      - uses: actions/checkout@master
+      - name: Resolve
+        run: swift package resolve
+      - name: Build
+        run: swift build
+      - name: Test
+        run: set -o pipefail && swift test 2>&1 | xcpretty
+      - name: Gen fixtures
+        run: scripts/gen-fixtures.sh
+      - name: Check fixtures
+        run: scripts/diff-fixtures.sh
+      - name: Build fixtures
+        run: scripts/build-fixtures.sh
   run-linux:
     runs-on: ubuntu-latest
     name: Linux

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Next Version
 
+### Fixed
+
+- Require swift-tools-version 5.9. #1489 @0111b
+
 ## 2.42.0
 
 ### Added

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 
 import PackageDescription
 
@@ -24,69 +24,69 @@ let package = Package(
     targets: [
         .executableTarget(name: "XcodeGen", dependencies: [
             "XcodeGenCLI",
-            "Version",
+            .product(name: "Version", package: "Version"),
         ]),
         .target(name: "XcodeGenCLI", dependencies: [
             "XcodeGenKit",
             "ProjectSpec",
-            "SwiftCLI",
-            "Rainbow",
-            "PathKit",
-            "Version",
+            .product(name: "SwiftCLI", package: "SwiftCLI"),
+            .product(name: "Rainbow", package: "Rainbow"),
+            .product(name: "PathKit", package: "PathKit"),
+            .product(name: "Version", package: "Version"),
         ]),
         .target(name: "XcodeGenKit", dependencies: [
             "ProjectSpec",
-            "JSONUtilities",
-            "XcodeProj",
-            "PathKit",
+            .product(name: "JSONUtilities", package: "JSONUtilities"),
+            .product(name: "XcodeProj", package: "XcodeProj"),
+            .product(name: "PathKit", package: "PathKit"),
             "XcodeGenCore",
         ], resources: [
             .copy("SettingPresets")
         ]),
         .target(name: "ProjectSpec", dependencies: [
-            "JSONUtilities",
-            "XcodeProj",
-            "Yams",
+            .product(name: "JSONUtilities", package: "JSONUtilities"),
+            .product(name: "XcodeProj", package: "XcodeProj"),
+            .product(name: "Yams", package: "yams"),
             "XcodeGenCore",
-            "Version",
+            .product(name: "Version", package: "Version"),
         ]),
         .target(name: "XcodeGenCore", dependencies: [
-            "PathKit",
-            "Yams",
+            .product(name: "PathKit", package: "PathKit"),
+            .product(name: "Yams", package: "yams"),
         ]),
         .target(name: "TestSupport", dependencies: [
-            "XcodeProj",
-            "Spectre",
-            "PathKit",
+            .product(name: "XcodeProj", package: "XcodeProj"),
+            .product(name: "Spectre", package: "Spectre"),
+            .product(name: "PathKit", package: "PathKit"),
         ]),
         .testTarget(name: "XcodeGenKitTests", dependencies: [
             "XcodeGenKit",
-            "Spectre",
-            "PathKit",
+            .product(name: "Spectre", package: "Spectre"),
+            .product(name: "PathKit", package: "PathKit"),
             "TestSupport",
         ]),
         .testTarget(name: "FixtureTests", dependencies: [
             "XcodeGenKit",
-            "Spectre",
-            "PathKit",
+            .product(name: "Spectre", package: "Spectre"),
+            .product(name: "PathKit", package: "PathKit"),
             "TestSupport",
         ]),
         .testTarget(name: "XcodeGenCoreTests", dependencies: [
             "XcodeGenCore",
-            "Spectre",
-            "PathKit",
+            .product(name: "Spectre", package: "Spectre"),
+            .product(name: "PathKit", package: "PathKit"),
             "TestSupport",
         ]),
         .testTarget(name: "ProjectSpecTests", dependencies: [
             "ProjectSpec",
-            "Spectre",
-            "PathKit",
+            .product(name: "Spectre", package: "Spectre"),
+            .product(name: "PathKit", package: "PathKit"),
             "TestSupport",
         ]),
         .testTarget(name: "PerformanceTests", dependencies: [
             "XcodeGenKit",
-            "Spectre",
-            "PathKit",
+            .product(name: "Spectre", package: "Spectre"),
+            .product(name: "PathKit", package: "PathKit"),
             "TestSupport",
         ]),
     ]


### PR DESCRIPTION
When XcodeGen used as a dependency in the project with same dependencies package definition became invalid.
This PR fixes this issue.

<img width="940" alt="Screenshot 2024-07-26 at 15 19 08" src="https://github.com/user-attachments/assets/cd2c8bbe-918a-4ae7-9af6-c0db53655497">

Fixes #1490 