### PR TITLE
Make asyncMap to prevent from race-condition

### DIFF
--- a/Sources/ProjectSpec/Decoding.swift
+++ b/Sources/ProjectSpec/Decoding.swift
@@ -12,16 +12,14 @@ extension Dictionary where Key: JSONKey {
             let defaultError = NSError(domain: "Unspecified error", code: 0, userInfo: nil)
             let keys = Array(dictionary.keys)
             var itemResults: [Result<T, Error>] = Array(repeating: .failure(defaultError), count: keys.count)
-            itemResults.withUnsafeMutableBufferPointer { buffer in
-                DispatchQueue.concurrentPerform(iterations: dictionary.count) { idx in
-                    do {
-                        let key = keys[idx]
-                        let jsonDictionary: JSONDictionary = try dictionary.json(atKeyPath: .key(key))
-                        let item = try T(name: key, jsonDictionary: jsonDictionary)
-                        buffer[idx] = .success(item)
-                    } catch {
-                        buffer[idx] = .failure(error)
-                    }
+            DispatchQueue.concurrentPerform(iterations: dictionary.count) { idx in
+                do {
+                    let key = keys[idx]
+                    let jsonDictionary: JSONDictionary = try dictionary.json(atKeyPath: .key(key))
+                    let item = try T(name: key, jsonDictionary: jsonDictionary)
+                    itemResults[idx] = .success(item)
+                } catch {
+                    itemResults[idx] = .failure(error)
                 }
             }
             return try itemResults.map { try $0.get() }

--- a/Sources/XcodeGenCore/ArrayExtensions.swift
+++ b/Sources/XcodeGenCore/ArrayExtensions.swift
@@ -2,14 +2,12 @@ import Foundation
 
 public extension Array {
 
-   func parallelMap<T>(transform: (Element) -> T) -> [T] {
-       var result = ContiguousArray<T?>(repeating: nil, count: count)
-       return result.withUnsafeMutableBufferPointer { buffer in
-           DispatchQueue.concurrentPerform(iterations: buffer.count) { idx in
-               buffer[idx] = transform(self[idx])
-           }
-           return buffer.map { $0! }
+    func parallelMap<T>(transform: @Sendable (Element) -> T) -> [T] {
+       var buffer: [T] = []
+       DispatchQueue.concurrentPerform(iterations: count) { idx in
+           buffer[idx] = transform(self[idx])
        }
+       return buffer
    }
 }
 

--- a/Sources/XcodeGenCore/ArrayExtensions.swift
+++ b/Sources/XcodeGenCore/ArrayExtensions.swift
@@ -3,7 +3,7 @@ import Foundation
 public extension Array where Element: Sendable {
 
     func parallelMap<T>(transform: @Sendable (Element) -> T) -> [T] {
-      var buffer = Array<T?>(repeating: nil, count: count)
+      var buffer = ContiguousArray<T?>(repeating: nil, count: count)
       DispatchQueue.concurrentPerform(iterations: count) { idx in
         buffer[idx] = transform(self[idx])
       }

--- a/Sources/XcodeGenCore/ArrayExtensions.swift
+++ b/Sources/XcodeGenCore/ArrayExtensions.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-public extension Array {
+public extension Array where Element: Sendable {
 
     func parallelMap<T>(transform: @Sendable (Element) -> T) -> [T] {
-       var buffer: [T] = []
-       DispatchQueue.concurrentPerform(iterations: count) { idx in
-           buffer[idx] = transform(self[idx])
-       }
-       return buffer
+      var buffer = Array<T?>(repeating: nil, count: count)
+      DispatchQueue.concurrentPerform(iterations: count) { idx in
+        buffer[idx] = transform(self[idx])
+      }
+      return buffer.map { $0! }
    }
 }
 

--- a/Sources/XcodeGenCore/Glob.swift
+++ b/Sources/XcodeGenCore/Glob.swift
@@ -90,12 +90,12 @@ public class Glob: Collection {
 
         let patterns = behavior.supportsGlobstar ? expandGlobstar(pattern: adjustedPattern) : [adjustedPattern]
 
-        #if os(macOS)
         let isIncludingFiles = includeFiles
+        #if os(macOS)
         paths = patterns.parallelMap { paths(usingPattern: $0, includeFiles: isIncludingFiles) }.flatMap { $0 }
         #else
         // Parallel invocations of Glob on Linux seems to be causing unexpected crashes
-        paths = patterns.map { paths(usingPattern: $0, includeFiles: includeFiles) }.flatMap { $0 }
+        paths = patterns.map { paths(usingPattern: $0, includeFiles: isIncludingFiles) }.flatMap { $0 }
         #endif
 
         paths = Array(Set(paths)).sorted { lhs, rhs in

--- a/Sources/XcodeGenCore/Glob.swift
+++ b/Sources/XcodeGenCore/Glob.swift
@@ -89,9 +89,10 @@ public class Glob: Collection {
         }
 
         let patterns = behavior.supportsGlobstar ? expandGlobstar(pattern: adjustedPattern) : [adjustedPattern]
-        
+
         #if os(macOS)
-        paths = patterns.parallelMap { paths(usingPattern: $0, includeFiles: includeFiles) }.flatMap { $0 }
+        let isIncludingFiles = includeFiles
+        paths = patterns.parallelMap { paths(usingPattern: $0, includeFiles: isIncludingFiles) }.flatMap { $0 }
         #else
         // Parallel invocations of Glob on Linux seems to be causing unexpected crashes
         paths = patterns.map { paths(usingPattern: $0, includeFiles: includeFiles) }.flatMap { $0 }


### PR DESCRIPTION
closes #1491
[Build failure due to concurrency issue since Xcode 16 Beta 5 · Issue #1491 · yonaskolb/XcodeGen](https://github.com/yonaskolb/XcodeGen/issues/1491)

The current main can't build with Xcode 16 Beta 5.
Because, `UnsafeMutableBudderPointer` is not a thread-safe, so we can't pass it to `Sendable` closure even if compiled in Swift 5 mode.

This PR resolves this issue.

This change may cause the performance, but I have no idea how much not using `ContiguousArray` will affect performance