### PR TITLE
Respect relativePaths in local package paths

### DIFF
--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -241,6 +241,7 @@ extension Project: PathContainer {
             .object("aggregateTargets", AggregateTarget.pathProperties),
             .object("schemes", Scheme.pathProperties),
             .object("projectReferences", ProjectReference.pathProperties),
+            .object("packages", SwiftPackage.pathProperties)
         ]
     }
 }

--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -241,7 +241,8 @@ extension Project: PathContainer {
             .object("aggregateTargets", AggregateTarget.pathProperties),
             .object("schemes", Scheme.pathProperties),
             .object("projectReferences", ProjectReference.pathProperties),
-            .object("packages", SwiftPackage.pathProperties)
+            .object("packages", SwiftPackage.pathProperties),
+            .string("localPackages")
         ]
     }
 }

--- a/Sources/ProjectSpec/SwiftPackage.swift
+++ b/Sources/ProjectSpec/SwiftPackage.swift
@@ -127,3 +127,13 @@ extension SwiftPackage.VersionRequirement: JSONObjectConvertible {
         }
     }
 }
+
+extension SwiftPackage: PathContainer {
+    static var pathProperties: [PathProperty] {
+        [
+            .dictionary([
+                .string("path"),
+            ]),
+        ]
+    }
+}

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -1,6 +1,8 @@
 include:
   - recursive_test/recursive_test.yml
   - same_relative_path_test/same_relative_path_test.yml
+  - path: relative_local_package/inc.yml
+    relativePaths: true
 configFiles:
   IncludedConfig: config
 projectReferences:

--- a/Tests/Fixtures/paths_test/relative_local_package/LocalPackage/.gitignore
+++ b/Tests/Fixtures/paths_test/relative_local_package/LocalPackage/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Tests/Fixtures/paths_test/relative_local_package/LocalPackage/Package.swift
+++ b/Tests/Fixtures/paths_test/relative_local_package/LocalPackage/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LocalPackage",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "LocalPackage",
+            targets: ["LocalPackage"]
+        )
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(name: "LocalPackage")
+    ]
+)

--- a/Tests/Fixtures/paths_test/relative_local_package/LocalPackage/Sources/LocalPackage/LocalPackage.swift
+++ b/Tests/Fixtures/paths_test/relative_local_package/LocalPackage/Sources/LocalPackage/LocalPackage.swift
@@ -1,0 +1,2 @@
+// The Swift Programming Language
+// https://docs.swift.org/swift-book

--- a/Tests/Fixtures/paths_test/relative_local_package/inc.yml
+++ b/Tests/Fixtures/paths_test/relative_local_package/inc.yml
@@ -1,0 +1,3 @@
+packages:
+  LocalPackage:
+    path: LocalPackage

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -193,6 +193,10 @@ class SpecLoadingTests: XCTestCase {
                         test: .init(testPlans: [.init(path: "paths_test/TestPlan.xctestplan")])
                     )
                 ]
+
+                try expect(project.packages) == [
+                    "LocalPackage": .local(path: "paths_test/relative_local_package/LocalPackage", group: nil),
+                ]
             }
 
             $0.it("respects directory expansion preference") {


### PR DESCRIPTION
Before this a local package defined in an included file would not respect relativePaths: true.

This fixes #1497.

This is a breaking change because this changes how paths are resolved.
