### PR TITLE
Runs pre-gen command before validating project

### DIFF
--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -69,17 +69,17 @@ class GenerateCommand: ProjectCommand {
             }
         }
 
+        // run pre gen command
+        if let command = project.options.preGenCommand {
+            try Task.run(bash: command, directory: projectDirectory.absolute().string)
+        }
+
         // validate project
         do {
             try project.validateMinimumXcodeGenVersion(version)
             try project.validate()
         } catch let error as SpecValidationError {
             throw GenerationError.validationError(error)
-        }
-
-        // run pre gen command
-        if let command = project.options.preGenCommand {
-            try Task.run(bash: command, directory: projectDirectory.absolute().string)
         }
 
         // generate plists


### PR DESCRIPTION
This PR updates the order of operations in the `generate` command to run the pre-gen command before project validation.

When running the `generate` command, the validation step fails if a target's `sources` list contains directories that don't exist yet. This is an issue when these directories are meant to be created by a pre-gen command.

Consider the following project specification:

```yml
name: Example
options:
  preGenCommand: ./scripts/generate-sources.sh
targets:
  Example:
    scheme: {}
    deploymentTarget: '16.0'
    platform: iOS
    type: application
    sources:
    - path: Example
    - path: GeneratedSources
```

The pre-gen command generates Swift source files into the GeneratedSources folder, which is in .gitignore. Without the changes in this PR, running `generate` results in an error:

> Spec validation error: Target "Example" has a missing source directory "/Users/simonbs/Developer/Example/GeneratedSources"

With the changes in this PR, the pre-gen command is executed before the project is validated, meaning that `GeneratedSources` is present during validation. This prevents the error and causes project generation to succeed.