### PR TITLE
[swift] Fix Swift 6 warnings

### DIFF
--- a/Sources/ProjectSpec/Decoding.swift
+++ b/Sources/ProjectSpec/Decoding.swift
@@ -13,14 +13,15 @@ extension Dictionary where Key: JSONKey {
             let keys = Array(dictionary.keys)
             var itemResults: [Result<T, Error>] = Array(repeating: .failure(defaultError), count: keys.count)
             itemResults.withUnsafeMutableBufferPointer { buffer in
+                let bufferWrapper = BufferWrapper(buffer: buffer)
                 DispatchQueue.concurrentPerform(iterations: dictionary.count) { idx in
                     do {
                         let key = keys[idx]
                         let jsonDictionary: JSONDictionary = try dictionary.json(atKeyPath: .key(key))
                         let item = try T(name: key, jsonDictionary: jsonDictionary)
-                        buffer[idx] = .success(item)
+                        bufferWrapper.buffer[idx] = .success(item)
                     } catch {
-                        buffer[idx] = .failure(error)
+                        bufferWrapper.buffer[idx] = .failure(error)
                     }
                 }
             }
@@ -46,6 +47,14 @@ extension Dictionary where Key: JSONKey {
             items.append(item)
         }
         return items
+    }
+}
+
+private final class BufferWrapper<T>: @unchecked Sendable {
+    var buffer: UnsafeMutableBufferPointer<T>
+
+    init(buffer: UnsafeMutableBufferPointer<T>) {
+        self.buffer = buffer
     }
 }
 

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -878,7 +878,7 @@ extension Scheme.Build: JSONEncodable {
     }
 }
 
-extension BuildType: JSONPrimitiveConvertible {
+extension BuildType: JSONUtilities.JSONPrimitiveConvertible {
 
     public typealias JSONType = String
 
@@ -910,7 +910,7 @@ extension BuildType: JSONEncodable {
     }
 }
 
-extension XCScheme.EnvironmentVariable: JSONObjectConvertible {
+extension XCScheme.EnvironmentVariable: JSONUtilities.JSONObjectConvertible {
     public static let enabledDefault = true
 
     private static func parseValue(_ value: Any) -> String {

--- a/Sources/ProjectSpec/SwiftPackage.swift
+++ b/Sources/ProjectSpec/SwiftPackage.swift
@@ -101,7 +101,7 @@ extension SwiftPackage: JSONEncodable {
     }
 }
 
-extension SwiftPackage.VersionRequirement: JSONObjectConvertible {
+extension SwiftPackage.VersionRequirement: JSONUtilities.JSONObjectConvertible {
 
     public init(jsonDictionary: JSONDictionary) throws {
         if jsonDictionary["exactVersion"] != nil {

--- a/Sources/ProjectSpec/VersionExtensions.swift
+++ b/Sources/ProjectSpec/VersionExtensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Version
 
-extension Version: ExpressibleByStringLiteral {
+extension Version: Swift.ExpressibleByStringLiteral {
 
     public static func parse(_ string: String) throws -> Version {
         if let version = Version(tolerant: string) {

--- a/Sources/XcodeGenCLI/Arguments.swift
+++ b/Sources/XcodeGenCLI/Arguments.swift
@@ -2,7 +2,7 @@ import Foundation
 import PathKit
 import SwiftCLI
 
-extension Path: ConvertibleFromString {
+extension Path: SwiftCLI.ConvertibleFromString {
 
     public init?(input: String) {
         self.init(input)

--- a/Sources/XcodeGenKit/CarthageVersionLoader.swift
+++ b/Sources/XcodeGenKit/CarthageVersionLoader.swift
@@ -73,7 +73,7 @@ struct CarthageVersionFile: Decodable {
     }
 }
 
-extension Platform: CodingKey {
+extension Platform: Swift.CodingKey {
 
     public var stringValue: String {
         carthageName


### PR DESCRIPTION
Add backwards compatible Swift 6 (Swift 5 language mode) fixes to protocol conformance and non-sendable type warnings