### PR TITLE
Skip failing test on Linux until upstream fix

### DIFF
--- a/Sources/TestSupport/TestHelpers.swift
+++ b/Sources/TestSupport/TestHelpers.swift
@@ -124,3 +124,11 @@ extension XCTestCase {
         describe(name, test)
     }
 }
+
+
+public func skipIfNecessary() throws {
+    #if os(Linux) && swift(<6.0.2)
+        // https://github.com/swiftlang/swift-foundation/pull/1002
+        throw XCTSkip("Skipping test on Linux until PropertyListDecoder issues are fixed.")
+    #endif
+}

--- a/Tests/FixtureTests/FixtureTests.swift
+++ b/Tests/FixtureTests/FixtureTests.swift
@@ -8,7 +8,8 @@ import TestSupport
 
 class FixtureTests: XCTestCase {
 
-    func testProjectFixture() {
+    func testProjectFixture() throws {
+        try skipIfNecessary()
         describe {
             $0.it("generates Test Project") {
                 try generateXcodeProject(specPath: fixturePath + "TestProject/AnotherProject/project.yml")

--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -62,6 +62,11 @@ class FixturePerformanceTests: XCTestCase {
     }
 
     func testFixtureGeneration() throws {
+        #if os(Linux) && swift(<6.0.2)
+            // https://github.com/swiftlang/swift-foundation/pull/1002
+            throw XCTSkip("Skipping test on Linux until PropertyListDecoder issues are fixed.")
+        #endif
+
         let project = try Project(path: specPath)
         measure {
             let generator = ProjectGenerator(project: project)
@@ -70,6 +75,11 @@ class FixturePerformanceTests: XCTestCase {
     }
 
     func testFixtureWriting() throws {
+        #if os(Linux) && swift(<6.0.2)
+            // https://github.com/swiftlang/swift-foundation/pull/1002
+            throw XCTSkip("Skipping test on Linux until PropertyListDecoder issues are fixed.")
+        #endif
+
         let project = try Project(path: specPath)
         let generator = ProjectGenerator(project: project)
         let xcodeProject = try generator.generateXcodeProject(userName: "someUser")

--- a/Tests/PerformanceTests/PerformanceTests.swift
+++ b/Tests/PerformanceTests/PerformanceTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import PathKit
 import ProjectSpec
+import TestSupport
 import XcodeGenKit
 import XcodeProj
 import XCTest
@@ -62,11 +63,7 @@ class FixturePerformanceTests: XCTestCase {
     }
 
     func testFixtureGeneration() throws {
-        #if os(Linux) && swift(<6.0.2)
-            // https://github.com/swiftlang/swift-foundation/pull/1002
-            throw XCTSkip("Skipping test on Linux until PropertyListDecoder issues are fixed.")
-        #endif
-
+        try skipIfNecessary()
         let project = try Project(path: specPath)
         measure {
             let generator = ProjectGenerator(project: project)
@@ -75,11 +72,7 @@ class FixturePerformanceTests: XCTestCase {
     }
 
     func testFixtureWriting() throws {
-        #if os(Linux) && swift(<6.0.2)
-            // https://github.com/swiftlang/swift-foundation/pull/1002
-            throw XCTSkip("Skipping test on Linux until PropertyListDecoder issues are fixed.")
-        #endif
-
+        try skipIfNecessary()
         let project = try Project(path: specPath)
         let generator = ProjectGenerator(project: project)
         let xcodeProject = try generator.generateXcodeProject(userName: "someUser")

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -275,7 +275,8 @@ class ProjectGeneratorTests: XCTestCase {
         }
     }
 
-    func testTargets() {
+    func testTargets() throws {
+        try skipIfNecessary()
         describe {
 
             let project = Project(name: "test", targets: targets)

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -41,7 +41,8 @@ private let uiTest = Target(
 
 class SchemeGeneratorTests: XCTestCase {
 
-    func testSchemes() {
+    func testSchemes() throws {
+        try skipIfNecessary()
         describe {
 
             let buildTarget = Scheme.BuildTarget(target: .local(app.name))

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -10,10 +10,7 @@ import TestSupport
 class SourceGeneratorTests: XCTestCase {
 
     func testSourceGenerator() throws {
-        #if os(Linux) && swift(<6.0.2)
-            // https://github.com/swiftlang/swift-foundation/pull/1002
-            throw XCTSkip("Skipping test on Linux until PropertyListDecoder issues are fixed.")
-        #endif
+        try skipIfNecessary()
         describe {
 
             let directoryPath = Path("TestDirectory")

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -9,7 +9,11 @@ import TestSupport
 
 class SourceGeneratorTests: XCTestCase {
 
-    func testSourceGenerator() {
+    func testSourceGenerator() throws {
+        #if os(Linux) && swift(<6.0.2)
+            // https://github.com/swiftlang/swift-foundation/pull/1002         
+            throw XCTSkip("Skipping test on Linux until PropertyListDecoder issues are fixed.")
+        #endif
         describe {
 
             let directoryPath = Path("TestDirectory")

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -11,7 +11,7 @@ class SourceGeneratorTests: XCTestCase {
 
     func testSourceGenerator() throws {
         #if os(Linux) && swift(<6.0.2)
-            // https://github.com/swiftlang/swift-foundation/pull/1002         
+            // https://github.com/swiftlang/swift-foundation/pull/1002
             throw XCTSkip("Skipping test on Linux until PropertyListDecoder issues are fixed.")
         #endif
         describe {


### PR DESCRIPTION
The linux CI job started failing after ubuntu-latest was updated
from: [actions/runner-images@ubuntu22/20240908.1/images/ubuntu/Ubuntu2204-Readme.md](https://github.com/actions/runner-images/blob/ubuntu22/20240908.1/images/ubuntu/Ubuntu2204-Readme.md)
to: [actions/runner-images@ubuntu22/20241006.1/images/ubuntu/Ubuntu2204-Readme.md](https://github.com/actions/runner-images/blob/ubuntu22/20241006.1/images/ubuntu/Ubuntu2204-Readme.md)

The error message was "The openStep format is unsupported on this platform" which comes from the new [swift-foundation implementation](https://github.com/swiftlang/swift-foundation/blob/60506f3af4ea2e27cc9cb80c97f9624ea43a9e2a/Sources/FoundationEssentials/PropertyList/PlistDecoder.swift#L166)

That functionality has now been back-ported to the state it was on Swift 5.10 on this PR https://github.com/swiftlang/swift-foundation/pull/1002 so Linux test should pass whenever `ubunutu-latest` includes a swift version with the fix.

Skipping is not the most elegant solution but it's better than a 100% red CI since the tool will already fail for Swift 6+ in Linux and there's no way to workaround the problem in foundation.

