### PR TITLE
Fix checking optional group existence relative to the current working dir

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -664,7 +664,7 @@ class SourceGenerator {
             sourceFiles.append(sourceFile)
 
         case .group:
-            if targetSource.optional && !Path(targetSource.path).exists {
+            if targetSource.optional && !path.exists {
                 // This group is missing, so if's optional just return an empty array
                 return []
             }


### PR DESCRIPTION
An optional group for a directory that does not exist is omitted as a source from the project. Unfortunately, there's a small bug in this check, and xcodegen actually checks for the group's existence relative to the current working directory. If you're running xcodegen from another directory than your project spec, this can mean that the optional directory is incorrectly detected as nonexistant and it is omitted from the project.

To fix, we just need to check the group's existence relative to the project. There's already even a convenient local variable for this, so using it means less code than before.
https://github.com/yonaskolb/XcodeGen/blob/5644662e5be9ab3b1a4416ccf992e12734662059/Sources/XcodeGenKit/SourceGenerator.swift#L607

After this PR, optional groups are no longer skipped when generating projects from a different directory.