### PR TITLE
add rule to copy app extensions ('.appex') to product's Plugins dir

### DIFF
--- a/Sources/ProjectSpec/BuildPhaseSpec.swift
+++ b/Sources/ProjectSpec/BuildPhaseSpec.swift
@@ -27,6 +27,12 @@ public enum BuildPhaseSpec: Equatable {
             phaseOrder: .postCompile
         )
 
+        public static let plugins = CopyFilesSettings(
+            destination: .plugins,
+            subpath: "$(CONTENTS_FOLDER_PATH)/PlugIns",
+            phaseOrder: .postCompile
+        )
+
         public enum Destination: String {
             case absolutePath
             case productsDirectory

--- a/Sources/ProjectSpec/FileType.swift
+++ b/Sources/ProjectSpec/FileType.swift
@@ -110,6 +110,7 @@ extension FileType {
 
         // copyfiles
         "xpc": FileType(buildPhase: .copyFiles(.xpcServices)),
+        "appex": FileType(buildPhase: .copyFiles(.plugins)),
 
         // no build phase (not resources)
         "xcconfig": FileType(buildPhase: BuildPhaseSpec.none),


### PR DESCRIPTION
Add a default build rule to put app extensions (.appex) into the product's "PlugIns" directory, instead of the "Resources" directory, where they won't be found by the system.