### PR TITLE
Support relative paths for fileGroups in includes

### DIFF
--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -242,7 +242,8 @@ extension Project: PathContainer {
             .object("schemes", Scheme.pathProperties),
             .object("projectReferences", ProjectReference.pathProperties),
             .object("packages", SwiftPackage.pathProperties),
-            .string("localPackages")
+            .string("localPackages"),
+            .string("fileGroups")
         ]
     }
 }

--- a/Tests/Fixtures/duplicated_include/duplicated_import_sut.yml
+++ b/Tests/Fixtures/duplicated_include/duplicated_import_sut.yml
@@ -2,7 +2,8 @@ include:
   - duplicated_import_transitive.yml
   - duplicated_import_root.yml
   - duplicated_import_root.yml
-  - different_path/duplicated_import_root.yml
+  - path: different_path/duplicated_import_root.yml
+    relativePaths: false
 name: DuplicatedImportDependent
 targets:
   IncludedTarget:

--- a/Tests/Fixtures/paths_test/included_paths_test.yml
+++ b/Tests/Fixtures/paths_test/included_paths_test.yml
@@ -1,7 +1,10 @@
+name: IncludedPathsTest
 include:
   - recursive_test/recursive_test.yml
   - same_relative_path_test/same_relative_path_test.yml
   - path: relative_local_package/inc.yml
+    relativePaths: true
+  - path: relative_file_groups/inc.yml
     relativePaths: true
 configFiles:
   IncludedConfig: config

--- a/Tests/Fixtures/paths_test/relative_file_groups/TestFile.md
+++ b/Tests/Fixtures/paths_test/relative_file_groups/TestFile.md
@@ -1,0 +1,1 @@
+This is a test file for relative file groups

--- a/Tests/Fixtures/paths_test/relative_file_groups/inc.yml
+++ b/Tests/Fixtures/paths_test/relative_file_groups/inc.yml
@@ -1,0 +1,2 @@
+fileGroups:
+  - TestFile.md

--- a/Tests/ProjectSpecTests/SpecLoadingTests.swift
+++ b/Tests/ProjectSpecTests/SpecLoadingTests.swift
@@ -197,6 +197,8 @@ class SpecLoadingTests: XCTestCase {
                 try expect(project.packages) == [
                     "LocalPackage": .local(path: "paths_test/relative_local_package/LocalPackage", group: nil, excludeFromProject: false),
                 ]
+
+                try expect(project.fileGroups.contains("paths_test/relative_file_groups/TestFile.md")) == true
             }
 
             $0.it("respects directory expansion preference") {


### PR DESCRIPTION
Adds support for handling paths in `fileGroups` as relative when included from subfiles.

