### PR TITLE
Synced folders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,8 @@ jobs:
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:
-        xcode: ["15.4", "16.0"]
+        xcode: ["16.0"]
         include:
-        - xcode: "15.4"
-          macos: macos-15
         - xcode: "16.0"
           macos: macos-15
     env:

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -153,6 +153,10 @@ Note that target names can also be changed by adding a `name` property to a targ
 - [ ] **postGenCommand**: **String** - A bash command to run after the project has been generated. If the project isn't generated due to no changes when using the cache then this won't run. This is useful for running things like `pod install` only if the project is actually regenerated.
 - [ ] **useBaseInternationalization**: **Bool** If this is `false` and your project does not include resources located in a **Base.lproj** directory then `Base` will not be included in the projects 'known regions'. The default value is `true`. 
 - [ ] **schemePathPrefix**: **String** - A path prefix for relative paths in schemes, such as StoreKitConfiguration. The default is `"../../"`, which is suitable for non-workspace projects. For use in workspaces, use `"../"`.
+- [ ] **defaultSourceDirectoryType**: **String** - When a [Target source](#target-source) doesn't specify a type and is a directory, this is the type that will be used. If nothing is specified for either then `group` will be used.
+  - `group` (default)
+  - `folder`
+  - `syncedFolder`
 
 ```yaml
 options:
@@ -542,6 +546,7 @@ A source can be provided via a string (the path) or an object of the form:
 	- `file`: a file reference with a parent group will be created (Default for files or directories with extensions)
 	- `group`: a group with all it's containing files. (Default for directories without extensions)
 	- `folder`: a folder reference.
+	- `syncedFolder`: Xcode 16's synchronized folders, also knows as buildable folders
 - [ ] **headerVisibility**: **String** - The visibility of any headers. This defaults to `public`, but can be either:
 	- `public`
 	- `private`

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tadija/AEXML.git",
       "state" : {
-        "revision" : "38f7d00b23ecd891e1ee656fa6aeebd6ba04ecc3",
-        "version" : "4.6.1"
+        "revision" : "db806756c989760b35108146381535aec231092b",
+        "version" : "4.7.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tuist/XcodeProj.git",
       "state" : {
-        "revision" : "dc3b87a4e69f9cd06c6cb16199f5d0472e57ef6b",
-        "version" : "8.24.3"
+        "revision" : "b1caa062d4aaab3e3d2bed5fe0ac5f8ce9bf84f4",
+        "version" : "8.27.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .package(url: "https://github.com/yonaskolb/JSONUtilities.git", from: "4.2.0"),
         .package(url: "https://github.com/kylef/Spectre.git", from: "0.9.2"),
         .package(url: "https://github.com/onevcat/Rainbow.git", from: "4.0.0"),
-        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.24.3"),
+        .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.27.7"),
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
         .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.6")

--- a/Sources/ProjectSpec/SourceType.swift
+++ b/Sources/ProjectSpec/SourceType.swift
@@ -11,4 +11,5 @@ public enum SourceType: String {
     case group
     case file
     case folder
+    case syncedFolder
 }

--- a/Sources/ProjectSpec/SpecOptions.swift
+++ b/Sources/ProjectSpec/SpecOptions.swift
@@ -37,6 +37,7 @@ public struct SpecOptions: Equatable {
     public var postGenCommand: String?
     public var useBaseInternationalization: Bool
     public var schemePathPrefix: String
+    public var defaultSourceDirectoryType: SourceType?
 
     public enum ValidationType: String {
         case missingConfigs
@@ -100,7 +101,8 @@ public struct SpecOptions: Equatable {
         preGenCommand: String? = nil,
         postGenCommand: String? = nil,
         useBaseInternationalization: Bool = useBaseInternationalizationDefault,
-        schemePathPrefix: String = schemePathPrefixDefault
+        schemePathPrefix: String = schemePathPrefixDefault,
+        defaultSourceDirectoryType: SourceType? = nil
     ) {
         self.minimumXcodeGenVersion = minimumXcodeGenVersion
         self.carthageBuildPath = carthageBuildPath
@@ -127,6 +129,7 @@ public struct SpecOptions: Equatable {
         self.postGenCommand = postGenCommand
         self.useBaseInternationalization = useBaseInternationalization
         self.schemePathPrefix = schemePathPrefix
+        self.defaultSourceDirectoryType = defaultSourceDirectoryType
     }
 }
 
@@ -160,6 +163,7 @@ extension SpecOptions: JSONObjectConvertible {
         postGenCommand = jsonDictionary.json(atKeyPath: "postGenCommand")
         useBaseInternationalization = jsonDictionary.json(atKeyPath: "useBaseInternationalization") ?? SpecOptions.useBaseInternationalizationDefault
         schemePathPrefix = jsonDictionary.json(atKeyPath: "schemePathPrefix") ?? SpecOptions.schemePathPrefixDefault
+        defaultSourceDirectoryType = jsonDictionary.json(atKeyPath: "defaultSourceDirectoryType")
         if jsonDictionary["fileTypes"] != nil {
             fileTypes = try jsonDictionary.json(atKeyPath: "fileTypes")
         } else {

--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -1454,6 +1454,12 @@ public class PBXProjGenerator {
         if !target.isLegacy {
             targetObject.productType = target.type
         }
+
+        // add fileSystemSynchronizedGroups
+        let synchronizedRootGroups = sourceFiles.compactMap { $0.synchronizedRootGroup }
+        if !synchronizedRootGroups.isEmpty {
+            targetObject.fileSystemSynchronizedGroups = synchronizedRootGroups
+        }
     }
     
     private func makePlatformFilter(for filter: Dependency.PlatformFilter) -> String? {

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -9,6 +9,7 @@ struct SourceFile {
     let fileReference: PBXFileElement
     let buildFile: PBXBuildFile
     let buildPhase: BuildPhaseSpec?
+    var synchronizedRootGroup: PBXFileSystemSynchronizedRootGroup?
 }
 
 class SourceGenerator {
@@ -687,6 +688,33 @@ class SourceGenerator {
 
             sourceFiles += groupSourceFiles
             sourceReference = group
+        case .syncedFolder:
+
+            let relativePath = (try? path.relativePath(from: project.basePath)) ?? path
+
+            let syncedRootGroup = PBXFileSystemSynchronizedRootGroup(
+                sourceTree: .group,
+                path: relativePath.string,
+                name: targetSource.name,
+                explicitFileTypes: [:],
+                exceptions: [],
+                explicitFolders: []
+            )
+            addObject(syncedRootGroup)
+            sourceReference = syncedRootGroup
+
+            // TODO: adjust if hasCustomParent == true
+            rootGroups.insert(syncedRootGroup)
+
+            var sourceFile = generateSourceFile(
+                targetType: targetType,
+                targetSource: targetSource,
+                path: path,
+                fileReference: syncedRootGroup,
+                buildPhases: buildPhases
+            )
+            sourceFile.synchronizedRootGroup = syncedRootGroup
+            sourceFiles.append(sourceFile)
         }
 
         if hasCustomParent {
@@ -703,7 +731,17 @@ class SourceGenerator {
     ///
     /// While `TargetSource` declares `type`, its optional and in the event that the value is not defined then we must resolve a sensible default based on the path of the source.
     private func resolvedTargetSourceType(for targetSource: TargetSource, at path: Path) -> SourceType {
-        return targetSource.type ?? (path.isFile || path.extension != nil ? .file : .group)
+        if let chosenType = targetSource.type {
+            return chosenType
+        } else {
+            if path.isFile || path.extension != nil {
+                return .file
+            } else if let sourceType = project.options.defaultSourceDirectoryType {
+                return sourceType
+            } else {
+                return .group
+            }
+        }
     }
 
     private func createParentGroups(_ parentGroups: [String], for fileElement: PBXFileElement) {

--- a/Sources/XcodeGenKit/Version.swift
+++ b/Sources/XcodeGenKit/Version.swift
@@ -16,7 +16,7 @@ extension Project {
     }
 
     var objectVersion: UInt {
-        54
+        70
     }
 
     var minimizedProjectReferenceProxies: Int {

--- a/Sources/XcodeGenKit/XCProjExtensions.swift
+++ b/Sources/XcodeGenKit/XCProjExtensions.swift
@@ -38,6 +38,8 @@ extension PBXProj {
                 string += "\n 🌎 " + variantGroup.nameOrPath
             } else if let versionGroup = child as? XCVersionGroup {
                 string += "\n 🔢 " + versionGroup.nameOrPath
+            } else if let syncedFolder = child as? PBXFileSystemSynchronizedRootGroup {
+                string += "\n 📁 " + syncedFolder.nameOrPath
             }
         }
         return string

--- a/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/CarthageProject/Project.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -322,8 +322,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = D91E14E36EC0B415578456F2 /* Build configuration list for PBXProject "Project" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -335,7 +333,7 @@
 			);
 			mainGroup = 293D0FF827366B513839236A;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 54;
+			preferredProjectObjectVersion = 70;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -239,8 +239,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 425866ADA259DB93FC4AF1E3 /* Build configuration list for PBXProject "SPM" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -259,7 +257,7 @@
 				630A8CE9F2BE39704ED9D461 /* XCLocalSwiftPackageReference "FooFeature" */,
 				C6539B364583AE96C18CE377 /* XCLocalSwiftPackageReference "../../.." */,
 			);
-			preferredProjectObjectVersion = 54;
+			preferredProjectObjectVersion = 70;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (

--- a/Tests/Fixtures/SPM/SPM.xcodeproj/xcshareddata/xcschemes/App.xcscheme
+++ b/Tests/Fixtures/SPM/SPM.xcodeproj/xcshareddata/xcschemes/App.xcscheme
@@ -40,7 +40,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "XcodeGenKitTests"
@@ -50,7 +51,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "339863E54E2D955C00B56802"

--- a/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/AnotherProject/AnotherProject.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXFileReference section */
@@ -120,8 +120,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = 3DFC1105373EDB6483D4BC5D /* Build configuration list for PBXProject "AnotherProject" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -132,7 +130,7 @@
 			);
 			mainGroup = 4E8CFA4275C972686621210C;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 54;
+			preferredProjectObjectVersion = 70;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (

--- a/Tests/Fixtures/TestProject/App_iOS/AppDelegate.swift
+++ b/Tests/Fixtures/TestProject/App_iOS/AppDelegate.swift
@@ -7,10 +7,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+
+        // file from a framework
         _ = FrameworkStruct()
+
         // Standalone files added to project by path-to-file.
         _ = standaloneHello()
+
+        // file in a synced folder
+        _ = SyncedStruct()
+
         return true
     }
 }

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -2443,7 +2443,7 @@
 			packageReferences = (
 				4EDA79334592CBBA0E507AD2 /* XCRemoteSwiftPackageReference "Swinject" */,
 			);
-			preferredProjectObjectVersion = 54;
+			preferredProjectObjectVersion = 70;
 			projectDirPath = "";
 			projectReferences = (
 				{

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -830,6 +830,18 @@
 		FED40A89162E446494DDE7C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		AE2AB2772F70DFFF402AA02B /* SyncedFolder */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = SyncedFolder;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		117840B4DBC04099F6779D00 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -1050,6 +1062,7 @@
 				2E1E747C7BC434ADB80CC269 /* Headers */,
 				6B1603BA83AA0C7B94E45168 /* ResourceFolder */,
 				6BBE762F36D94AB6FFBFE834 /* SomeFile */,
+				AE2AB2772F70DFFF402AA02B /* SyncedFolder */,
 				79DC4A1E4D2E0D3A215179BC /* Bundles */,
 				FC1515684236259C50A7747F /* Frameworks */,
 				AC523591AC7BE9275003D2DB /* Products */,
@@ -1685,6 +1698,9 @@
 				E84285243DE0BB361A708079 /* PBXTargetDependency */,
 				E8C078B0A2A2B0E1D35694D5 /* PBXTargetDependency */,
 				981D116D40DBA0407D0E0E94 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				AE2AB2772F70DFFF402AA02B /* SyncedFolder */,
 			);
 			name = App_iOS;
 			packageProductDependencies = (

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Clip.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Clip.xcscheme
@@ -40,7 +40,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "63BFF75AA22335E3DDD5E26A"
@@ -50,7 +51,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "91C3E922A8482E07649971B9"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
@@ -48,7 +48,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA"
@@ -59,7 +60,6 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
-            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Production.xcscheme
@@ -42,7 +42,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DC2F16BAA6E13B44AB62F888"
@@ -52,7 +53,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Staging.xcscheme
@@ -42,7 +42,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DC2F16BAA6E13B44AB62F888"
@@ -52,7 +53,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA"

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_iOS Test.xcscheme
@@ -42,7 +42,8 @@
       </MacroExpansion>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DC2F16BAA6E13B44AB62F888"
@@ -52,7 +53,8 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "F674B2CFC4738EEC49BAD0DA"

--- a/Tests/Fixtures/TestProject/SyncedFolder/SyncedFile.swift
+++ b/Tests/Fixtures/TestProject/SyncedFolder/SyncedFile.swift
@@ -1,0 +1,4 @@
+
+struct SyncedStruct {
+  
+}

--- a/Tests/Fixtures/TestProject/project.yml
+++ b/Tests/Fixtures/TestProject/project.yml
@@ -164,6 +164,8 @@ targets:
           - tag1
           - tag2
       - String Catalogs/LocalizableStrings.xcstrings
+      - path: SyncedFolder
+        type: syncedFolder
     settings:
       INFOPLIST_FILE: App_iOS/Info.plist
       PRODUCT_BUNDLE_IDENTIFIER: com.project.app

--- a/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/scheme_test/TestProject.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXFileReference section */
@@ -72,8 +72,6 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = E903F6E8184E2A86CEC31778 /* Build configuration list for PBXProject "TestProject" */;
 			compatibilityVersion = "Xcode 14.0";
@@ -85,7 +83,7 @@
 			);
 			mainGroup = 2D08B11F4EE060D112B7BCA1;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 54;
+			preferredProjectObjectVersion = 70;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (


### PR DESCRIPTION
This adds support for Xcode 16's synchronized folders, which depending where you look have a few different names:
- synchronized root groups
- synchronized folders
- folder references
- buildable folders

For our purposes I've chosen the name `syncedFolder`, looking for feedback on this.

This initial push supports the following:
- [x] a new `syncedFolder` source type
- [x] a new `defaultSourceDirectoryType` project spec option of the same type that can be used to override the default directory type of `group`

At the moment only top level synced folders are supported. Xcode also includes a `PBXFileSystemSynchronizedBuildFileExceptionSet` which has not been added yet here either. 
There is a load of complexity that has been added to XcodeGen over the years to sources around relative paths, custom parent groups, includes and excludes, mixed target phases, and various other options. In this first pass anything beyond the basics is unsupported for these special folders.

Please test this in your own projects and give feedback about what is broken and how this should be expanded