### PR TITLE
Feature: Custom Working Directory

### DIFF
--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -1055,7 +1055,6 @@ A multiline script can be written using the various YAML multiline methods, for 
 - [ ] **executable**: **String** - the name of the target to launch as an executable. Defaults to the first runnable build target in the scheme, or the first build target if a runnable build target is not found
 - [ ] **customLLDBInit**: **String** - the absolute path to the custom `.lldbinit` file
 - [ ] **customWorkingDirectory**: **String** - a path to use as the working directory when launching the executable.
-- [ ] **useCustomWorkingDirectory**: **Bool** - sets if the custom working directory should be used. This defaults to false.
 
 ### Test Action
 

--- a/Docs/ProjectSpec.md
+++ b/Docs/ProjectSpec.md
@@ -1054,6 +1054,8 @@ A multiline script can be written using the various YAML multiline methods, for 
 ### Run Action
 - [ ] **executable**: **String** - the name of the target to launch as an executable. Defaults to the first runnable build target in the scheme, or the first build target if a runnable build target is not found
 - [ ] **customLLDBInit**: **String** - the absolute path to the custom `.lldbinit` file
+- [ ] **customWorkingDirectory**: **String** - a path to use as the working directory when launching the executable.
+- [ ] **useCustomWorkingDirectory**: **Bool** - sets if the custom working directory should be used. This defaults to false.
 
 ### Test Action
 

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -132,6 +132,7 @@ public struct Scheme: Equatable {
         public static let disableThreadPerformanceCheckerDefault = false
         public static let debugEnabledDefault = true
         public static let enableGPUValidationModeDefault = true
+        public static let useCustomWorkingDirectoryDefault = false
 
         public var config: String?
         public var commandLineArguments: [String: Bool]
@@ -153,6 +154,8 @@ public struct Scheme: Equatable {
         public var storeKitConfiguration: String?
         public var customLLDBInit: String?
         public var macroExpansion: String?
+        public var customWorkingDirectory: String?
+        public var useCustomWorkingDirectory: Bool
 
         public init(
             config: String? = nil,
@@ -174,7 +177,9 @@ public struct Scheme: Equatable {
             simulateLocation: SimulateLocation? = nil,
             storeKitConfiguration: String? = nil,
             customLLDBInit: String? = nil,
-            macroExpansion: String? = nil
+            macroExpansion: String? = nil,
+            customWorkingDirectory: String? = nil,
+            useCustomWorkingDirectory: Bool = useCustomWorkingDirectoryDefault
         ) {
             self.config = config
             self.commandLineArguments = commandLineArguments
@@ -195,6 +200,8 @@ public struct Scheme: Equatable {
             self.storeKitConfiguration = storeKitConfiguration
             self.customLLDBInit = customLLDBInit
             self.macroExpansion = macroExpansion
+            self.customWorkingDirectory = customWorkingDirectory
+            self.useCustomWorkingDirectory = useCustomWorkingDirectory
         }
     }
 
@@ -523,6 +530,8 @@ extension Scheme.Run: JSONObjectConvertible {
         }
         customLLDBInit = jsonDictionary.json(atKeyPath: "customLLDBInit")
         macroExpansion = jsonDictionary.json(atKeyPath: "macroExpansion")
+        customWorkingDirectory = jsonDictionary.json(atKeyPath: "customWorkingDirectory")
+        useCustomWorkingDirectory = jsonDictionary.json(atKeyPath: "useCustomWorkingDirectory") ?? Scheme.Run.useCustomWorkingDirectoryDefault
     }
 }
 

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -584,6 +584,9 @@ extension Scheme.Run: JSONEncodable {
         if let customLLDBInit = customLLDBInit {
             dict["customLLDBInit"] = customLLDBInit
         }
+        if let customWorkingDirectory = customWorkingDirectory {
+            dict["customWorkingDirectory"] = customWorkingDirectory
+        }
         return dict
     }
 }

--- a/Sources/ProjectSpec/Scheme.swift
+++ b/Sources/ProjectSpec/Scheme.swift
@@ -132,7 +132,6 @@ public struct Scheme: Equatable {
         public static let disableThreadPerformanceCheckerDefault = false
         public static let debugEnabledDefault = true
         public static let enableGPUValidationModeDefault = true
-        public static let useCustomWorkingDirectoryDefault = false
 
         public var config: String?
         public var commandLineArguments: [String: Bool]
@@ -155,7 +154,6 @@ public struct Scheme: Equatable {
         public var customLLDBInit: String?
         public var macroExpansion: String?
         public var customWorkingDirectory: String?
-        public var useCustomWorkingDirectory: Bool
 
         public init(
             config: String? = nil,
@@ -178,8 +176,7 @@ public struct Scheme: Equatable {
             storeKitConfiguration: String? = nil,
             customLLDBInit: String? = nil,
             macroExpansion: String? = nil,
-            customWorkingDirectory: String? = nil,
-            useCustomWorkingDirectory: Bool = useCustomWorkingDirectoryDefault
+            customWorkingDirectory: String? = nil
         ) {
             self.config = config
             self.commandLineArguments = commandLineArguments
@@ -201,7 +198,6 @@ public struct Scheme: Equatable {
             self.customLLDBInit = customLLDBInit
             self.macroExpansion = macroExpansion
             self.customWorkingDirectory = customWorkingDirectory
-            self.useCustomWorkingDirectory = useCustomWorkingDirectory
         }
     }
 
@@ -531,7 +527,6 @@ extension Scheme.Run: JSONObjectConvertible {
         customLLDBInit = jsonDictionary.json(atKeyPath: "customLLDBInit")
         macroExpansion = jsonDictionary.json(atKeyPath: "macroExpansion")
         customWorkingDirectory = jsonDictionary.json(atKeyPath: "customWorkingDirectory")
-        useCustomWorkingDirectory = jsonDictionary.json(atKeyPath: "useCustomWorkingDirectory") ?? Scheme.Run.useCustomWorkingDirectoryDefault
     }
 }
 

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -355,6 +355,8 @@ public class SchemeGenerator {
             selectedDebuggerIdentifier: selectedDebuggerIdentifier(for: schemeTarget, run: scheme.run),
             selectedLauncherIdentifier: selectedLauncherIdentifier(for: schemeTarget, run: scheme.run),
             askForAppToLaunch: scheme.run?.askForAppToLaunch,
+            customWorkingDirectory: scheme.run?.customWorkingDirectory,
+            useCustomWorkingDirectory: scheme.run?.useCustomWorkingDirectory ?? Scheme.Run.useCustomWorkingDirectoryDefault,
             allowLocationSimulation: allowLocationSimulation,
             locationScenarioReference: locationScenarioReference,
             enableGPUFrameCaptureMode: scheme.run?.enableGPUFrameCaptureMode ?? XCScheme.LaunchAction.defaultGPUFrameCaptureMode,

--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -356,7 +356,7 @@ public class SchemeGenerator {
             selectedLauncherIdentifier: selectedLauncherIdentifier(for: schemeTarget, run: scheme.run),
             askForAppToLaunch: scheme.run?.askForAppToLaunch,
             customWorkingDirectory: scheme.run?.customWorkingDirectory,
-            useCustomWorkingDirectory: scheme.run?.useCustomWorkingDirectory ?? Scheme.Run.useCustomWorkingDirectoryDefault,
+            useCustomWorkingDirectory: scheme.run?.customWorkingDirectory != nil,
             allowLocationSimulation: allowLocationSimulation,
             locationScenarioReference: locationScenarioReference,
             enableGPUFrameCaptureMode: scheme.run?.enableGPUFrameCaptureMode ?? XCScheme.LaunchAction.defaultGPUFrameCaptureMode,

--- a/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SchemeGeneratorTests.swift
@@ -53,7 +53,7 @@ class SchemeGeneratorTests: XCTestCase {
                 let scheme = try Scheme(
                     name: "MyScheme",
                     build: Scheme.Build(targets: [buildTarget], preActions: [preAction]),
-                    run: Scheme.Run(config: "Debug", enableGPUFrameCaptureMode: .metal, askForAppToLaunch: true, launchAutomaticallySubstyle: "2", simulateLocation: simulateLocation, storeKitConfiguration: storeKitConfiguration, customLLDBInit: "/sample/.lldbinit"),
+                    run: Scheme.Run(config: "Debug", enableGPUFrameCaptureMode: .metal, askForAppToLaunch: true, launchAutomaticallySubstyle: "2", simulateLocation: simulateLocation, storeKitConfiguration: storeKitConfiguration, customLLDBInit: "/sample/.lldbinit", customWorkingDirectory: "/test"),
                     test: Scheme.Test(config: "Debug", targets: [
                         Scheme.Test.TestTarget(targetReference: TestableTargetReference(framework.name), location: "test.gpx"),
                         Scheme.Test.TestTarget(targetReference: TestableTargetReference(framework.name), location: "New York, NY, USA")
@@ -114,7 +114,10 @@ class SchemeGeneratorTests: XCTestCase {
                 try expect(xcscheme.launchAction?.enableGPUFrameCaptureMode) == .metal
                 try expect(xcscheme.testAction?.customLLDBInitFile) == "/test/.lldbinit"
                 try expect(xcscheme.testAction?.systemAttachmentLifetime).to.beNil()
-                
+
+                try expect(xcscheme.launchAction?.useCustomWorkingDirectory) == true
+                try expect(xcscheme.launchAction?.customWorkingDirectory) == "/test"
+
                 try expect(xcscheme.testAction?.testables[0].locationScenarioReference?.referenceType) == "0"
                 try expect(xcscheme.testAction?.testables[0].locationScenarioReference?.identifier) == "../test.gpx"
                 


### PR DESCRIPTION
I wanted the ability to set the current working directory in the run action:

<img width="1086" alt="Screenshot 2025-04-18 at 9 17 34 PM" src="https://github.com/user-attachments/assets/db6e5ab3-6f4f-4ac8-bb84-1e5ee2c86519" />

XcodeProj already supports this so I just added two new properties to `Scheme.Run` so that they can be passed to `XCScheme.LaunchAction` during the generation process.