### PR TITLE
Add validation to ensure that settings.configs values are dictionaries, in order to prevent misuse

### DIFF
--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -173,7 +173,17 @@ extension Project {
         let jsonDictionary = Project.resolveProject(jsonDictionary: jsonDictionary)
 
         name = try jsonDictionary.json(atKeyPath: "name")
-        settings = jsonDictionary.json(atKeyPath: "settings") ?? .empty
+
+        do {
+            settings = try jsonDictionary.json(atKeyPath: "settings")
+        } catch let specParsingError as SpecParsingError {
+            // Rethrow SpecParsingError to prevent misuse of settings.configs
+            throw specParsingError
+        } catch {
+            // Ignore any errors other than SpecParsingError
+            settings = .empty
+        }
+
         settingGroups = jsonDictionary.json(atKeyPath: "settingGroups")
             ?? jsonDictionary.json(atKeyPath: "settingPresets") ?? [:]
         let configs: [String: String] = jsonDictionary.json(atKeyPath: "configs") ?? [:]

--- a/Sources/ProjectSpec/SpecParsingError.swift
+++ b/Sources/ProjectSpec/SpecParsingError.swift
@@ -15,6 +15,7 @@ public enum SpecParsingError: Error, CustomStringConvertible {
     case unknownBreakpointActionType(String)
     case unknownBreakpointActionConveyanceType(String)
     case unknownBreakpointActionSoundName(String)
+    case invalidConfigsFormat(keys: Set<String>)
 
     public var description: String {
         switch self {
@@ -46,6 +47,8 @@ public enum SpecParsingError: Error, CustomStringConvertible {
             return "Unknown Breakpoint Action conveyance type: \(type)"
         case let .unknownBreakpointActionSoundName(name):
             return "Unknown Breakpoint Action sound name: \(name)"
+        case let .invalidConfigsFormat(keys):
+            return "The value for \"\(keys.sorted().joined(separator: ", "))\" in configs must be a dictionary"
         }
     }
 }

--- a/Tests/Fixtures/invalid_configs_value_non_dict.yml
+++ b/Tests/Fixtures/invalid_configs_value_non_dict.yml
@@ -1,0 +1,8 @@
+name: InvalidConfigsNonDict
+
+settings:
+  configs:
+    invalid_key0: value0
+    debug:
+      valid_key: value1
+    invalid_key1: value2

--- a/Tests/ProjectSpecTests/InvalidConfigsFormatTests.swift
+++ b/Tests/ProjectSpecTests/InvalidConfigsFormatTests.swift
@@ -1,0 +1,35 @@
+import ProjectSpec
+import Testing
+import TestSupport
+import PathKit
+
+struct InvalidConfigsFormatTests {
+    @Test("throws invalidConfigsFormat error for non-dictionary configs entries")
+    func testNonDictionaryConfigsEntries() throws {
+        let path = fixturePath + "invalid_configs_value_non_dict.yml"
+        let expectedError = SpecParsingError.invalidConfigsFormat(keys: ["invalid_key0", "invalid_key1"])
+
+        #expect(throws: EquatableErrorBox(expectedError)) {
+            try perform(path: path)
+        }
+    }
+
+    private func perform(path: Path) throws {
+        do {
+            _ = try Project(path: path)
+        } catch let error as SpecParsingError {
+            throw EquatableErrorBox(error)
+        } catch {
+            throw error
+        }
+    }
+
+    // SpecParsingError does not conform to Equatable, so we wrap its description here
+    private struct EquatableErrorBox: Error, Equatable {
+        let description: String
+
+        init<E: Error & CustomStringConvertible>(_ error: E) {
+            self.description = error.description
+        }
+    }
+}


### PR DESCRIPTION
## Motivation
In our team, we previously encountered cases where `settings.configs` was misused by passing non-dictionary values.  
However, because no error was raised, so the issue went unnoticed.

## Proposed Solution
This PR adds validation to ensure that all values in `settings.configs` are dictionaries.  
For example, the following invalid configuration will now throw a `SpecParsingError.invalidConfigsFormat` during parsing:

```yaml
settings:
  configs:
    SOME_FLAG: true
```
If any non-dictionary values are found, a `SpecParsingError.invalidConfigsFormat` is thrown during parsing.

By introducing this validation, such misconfigurations can now be detected early.