### PR TITLE
Update CI equipments and drop Xcode 15 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,11 @@ on:
   pull_request: {}
 jobs:
   run:
-    runs-on: ${{ matrix.macos }}
+    runs-on: macos-15
     name: Xcode ${{ matrix.xcode }}
     strategy:
       matrix:
-        xcode: ["15.4", "16.0"]
-        include:
-        - xcode: "15.4"
-          macos: macos-15
-        - xcode: "16.0"
-          macos: macos-15
+        xcode: ["16.0", "16.3"]
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
     steps:


### PR DESCRIPTION
Updated CI equipment to support Xcode 16.3 and dropped Xcode 15.4 from CI stacks.

Swift Testing are introduced since Xcode 16.0. We are using Spectre as a test framework, however, we want to replace them into Swift Testing gradually.

However, Xcode 15 doesn't support Swift Testing yet.
It prevents introducing Swift Testing on #1547.