### PR TITLE
Use USER env var instead of LOGNAME

### DIFF
--- a/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/GenerateCommand.swift
@@ -100,7 +100,7 @@ class GenerateCommand: ProjectCommand {
         do {
             let projectGenerator = ProjectGenerator(project: project)
 
-            guard let userName = ProcessInfo.processInfo.environment["LOGNAME"] else {
+            guard let userName = ProcessInfo.processInfo.environment["USER"] else {
                 throw GenerationError.missingUsername
             }
 


### PR DESCRIPTION
During user switch with su/sudo in system LOGNAME may not be initialised, but USER env var is always exist.