### PR TITLE
Ignore info plist in synced folders

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -686,8 +686,14 @@ public class PBXProjGenerator {
         let infoPlistFiles: [Config: String] = getInfoPlists(for: target)
         let sourceFileBuildPhaseOverrideSequence: [(Path, BuildPhaseSpec)] = Set(infoPlistFiles.values).map({ (project.basePath + $0, .none) })
         let sourceFileBuildPhaseOverrides = Dictionary(uniqueKeysWithValues: sourceFileBuildPhaseOverrideSequence)
-        let sourceFiles = try sourceGenerator.getAllSourceFiles(targetType: target.type, sources: target.sources, buildPhases: sourceFileBuildPhaseOverrides)
-            .sorted { $0.path.lastComponent < $1.path.lastComponent }
+        let targetObject = targetObjects[target.name]!
+        let sourceFiles = try sourceGenerator.getAllSourceFiles(
+            target: targetObject,
+            targetType: target.type,
+            sources: target.sources,
+            buildPhases: sourceFileBuildPhaseOverrides
+        )
+        .sorted { $0.path.lastComponent < $1.path.lastComponent }
 
         var anyDependencyRequiresObjCLinking = false
 
@@ -1438,8 +1444,6 @@ public class PBXProjGenerator {
             buildConfigurations: configs,
             defaultConfigurationName: defaultConfigurationName
         ))
-
-        let targetObject = targetObjects[target.name]!
 
         let targetFileReference = targetFileReferences[target.name]
 

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/project.pbxproj
@@ -830,9 +830,22 @@
 		FED40A89162E446494DDE7C7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		"TEMP_067E2B5F-0F9F-4B71-A34B-DB4FEB8A01AC" /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				App_iOS/Info.plist,
+			);
+			target = 0867B0DACEF28C11442DE8F7 /* App_iOS */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		AE2AB2772F70DFFF402AA02B /* SyncedFolder */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				"TEMP_067E2B5F-0F9F-4B71-A34B-DB4FEB8A01AC" /* PBXFileSystemSynchronizedBuildFileExceptionSet */,
+			);
 			explicitFileTypes = {
 			};
 			explicitFolders = (


### PR DESCRIPTION
This is an addition to #1541 that adds each target's Info.plist to the exception list of the synced folder to fix the duplicate Info.plist error.
This currently isn't working due to this open issue in XcodeProj https://github.com/tuist/XcodeProj/issues/934