### PR TITLE
Map parallelizable true to parallelization all (#1564)

### DIFF
--- a/Sources/XcodeGenKit/SchemeGenerator.swift
+++ b/Sources/XcodeGenKit/SchemeGenerator.swift
@@ -260,7 +260,7 @@ public class SchemeGenerator {
             
             return XCScheme.TestableReference(
                 skipped: testTarget.skipped,
-                parallelizable: testTarget.parallelizable,
+                parallelization: testTarget.parallelizable ? .all : .none,
                 randomExecutionOrdering: testTarget.randomExecutionOrder,
                 buildableReference: testBuildEntries.buildableReference,
                 locationScenarioReference: locationScenarioReference,

--- a/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
+++ b/Tests/Fixtures/TestProject/Project.xcodeproj/xcshareddata/xcschemes/App_Scheme.xcscheme
@@ -60,6 +60,7 @@
          </TestableReference>
          <TestableReference
             skipped = "NO"
+            parallelizable = "YES"
             testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"


### PR DESCRIPTION
- Map `parallelizable` true to `parallelization` all to match the behaviour from Xcodeproj 8.24.3.

- Fixes #1564