### PR TITLE
Update ArtifactBundleGen to 0.0.8

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/freddi-kit/ArtifactBundleGen",
       "state" : {
-        "revision" : "707e4ccc4b1c7e48e881cd5ea91e493a95df24bf",
-        "version" : "0.0.6"
+        "revision" : "33f4a65acb296dcde04aeb828b6850fcf9dceb6c",
+        "version" : "0.0.8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/XcodeProj.git", exact: "8.27.7"),
         .package(url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
         .package(url: "https://github.com/mxcl/Version", from: "2.0.0"),
-        .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.6")
+        .package(url: "https://github.com/freddi-kit/ArtifactBundleGen", exact: "0.0.8")
     ],
     targets: [
         .executableTarget(name: "XcodeGen", dependencies: [


### PR DESCRIPTION
I noticed that the artifact bundles in the release assets had multiple versions of XcodeGen instead of only the version that was just released. After some investigation I deduced that it was a bug in ArtifactBundleGen, so I submitted a [bugfix](https://github.com/freddi-kit/ArtifactBundleGen/pull/10). This PR updates to the new version with that fix.