### PR TITLE
Use package name for local package fileref name

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -177,7 +177,7 @@ public class PBXProjGenerator {
 
                 if !excludeFromProject {
                     addObject(packageReference)
-                    try sourceGenerator.createLocalPackage(path: Path(path), group: group.map { Path($0) })
+                    try sourceGenerator.createLocalPackage(name: name, path: Path(path), group: group.map { Path($0) })
                 }
             }
         }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -52,7 +52,7 @@ class SourceGenerator {
         return object
     }
 
-    func createLocalPackage(path: Path, group: Path?) throws {
+    func createLocalPackage(name: String, path: Path, group: Path?) throws {
         var parentGroup: String = project.options.localPackagesGroup ?? "Packages"
         if let group {
           parentGroup = group.string
@@ -66,7 +66,7 @@ class SourceGenerator {
         let fileReference = addObject(
             PBXFileReference(
                 sourceTree: .sourceRoot,
-                name: absolutePath.lastComponent,
+                name: name,
                 lastKnownFileType: "folder",
                 path: fileReferencePath
             )


### PR DESCRIPTION
Otherwise, if you git clone XcodeGen under a different directory name (say `foo`), running `swift test` will result in a diff in `Tests/Fixtures/SPM/SPM.xcodeproj/project.pbxproj` that changes the `PBXFileReference` name from `XcodeGen` to `foo`