### PR TITLE
chore(docs): add external link for a Modular SwiftUI Multi-platform example

### DIFF
--- a/Docs/Examples.md
+++ b/Docs/Examples.md
@@ -11,3 +11,4 @@ These are a bunch of real world examples of XcodeGen project specs. Feel free to
 - [pvinis/react-native-xcodegen](https://github.com/pvinis/react-native-xcodegen/blob/master/templates)
 - [covid19cz/erouska-ios](https://github.com/covid19cz/erouska-ios/blob/develop/project.yml)
 - [markst/hotreloading-vscode-ios](https://github.com/markst/hotreloading-vscode-ios)
+- [MultiPlatformApp](https://github.com/hgq287/HGSwift/tree/master/Examples/MultiPlatformApp) - A modern **SwiftUI** multi-platform (iOS & macOS) example featuring a modular 3-tier architecture and shared logic.


### PR DESCRIPTION
### Summary
Added a link to a SwiftUI Multi-platform (iOS & macOS) example in `Docs/Examples.md`.

### Why this is helpful
Modern apps often need to share code between iOS and macOS. This example shows:
- **Modular Setup**: App, Shared, and Core layers.
- **SwiftUI**: Shared views and app lifecycle.
- **Dependencies**: How to use Alamofire and GRDB with XcodeGen.
- **Best Practices**: Using `.xcconfig` and `SUPPORTED_PLATFORMS`.

### Checklist
- [x] Link works correctly.
- [x] Project generates successfully with XcodeGen.