### PR TITLE
Fix supportedDestinations presets being injected when settingPresets is none

### DIFF
--- a/Sources/XcodeGenKit/SettingsBuilder.swift
+++ b/Sources/XcodeGenKit/SettingsBuilder.swift
@@ -65,26 +65,26 @@ extension Project {
                 // this fix is necessary because the platform preset overrides the original value
                 buildSettings["SDKROOT"] = .string(Platform.auto.rawValue)
             }
-        }
-        
-        if !specSupportedDestinations.isEmpty {
-            var supportedPlatforms: [String] = []
-            var targetedDeviceFamily: [String] = []
             
-            for supportedDestination in specSupportedDestinations {
-                let supportedPlatformBuildSettings = SettingsPresetFile.supportedDestination(supportedDestination).getBuildSettings()
-                buildSettings += supportedPlatformBuildSettings
+            if !specSupportedDestinations.isEmpty {
+                var supportedPlatforms: [String] = []
+                var targetedDeviceFamily: [String] = []
                 
-                if let value = supportedPlatformBuildSettings?["SUPPORTED_PLATFORMS"]?.stringValue {
-                    supportedPlatforms += value.components(separatedBy: " ")
+                for supportedDestination in specSupportedDestinations {
+                    let supportedPlatformBuildSettings = SettingsPresetFile.supportedDestination(supportedDestination).getBuildSettings()
+                    buildSettings += supportedPlatformBuildSettings
+                    
+                    if let value = supportedPlatformBuildSettings?["SUPPORTED_PLATFORMS"]?.stringValue {
+                        supportedPlatforms += value.components(separatedBy: " ")
+                    }
+                    if let value = supportedPlatformBuildSettings?["TARGETED_DEVICE_FAMILY"]?.stringValue {
+                        targetedDeviceFamily += value.components(separatedBy: ",")
+                    }
                 }
-                if let value = supportedPlatformBuildSettings?["TARGETED_DEVICE_FAMILY"]?.stringValue {
-                    targetedDeviceFamily += value.components(separatedBy: ",")
-                }
+                
+                buildSettings["SUPPORTED_PLATFORMS"] = .string(supportedPlatforms.joined(separator: " "))
+                buildSettings["TARGETED_DEVICE_FAMILY"] = .string(targetedDeviceFamily.joined(separator: ","))
             }
-            
-            buildSettings["SUPPORTED_PLATFORMS"] = .string(supportedPlatforms.joined(separator: " "))
-            buildSettings["TARGETED_DEVICE_FAMILY"] = .string(targetedDeviceFamily.joined(separator: ","))
         }
         
         // apply custom platform version

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -516,6 +516,21 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetConfig1.buildSettings["SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD"]?.boolValue) == false
             }
 
+            $0.it("supportedDestinations respects settingPresets none") {
+                let target = Target(name: "Target", type: .application, platform: .auto, supportedDestinations: [.iOS, .macOS])
+                let options = SpecOptions(settingPresets: .none)
+                let project = Project(name: "", targets: [target], options: options)
+
+                let pbxProject = try project.generatePbxProj()
+                let targetConfig = try unwrap(pbxProject.nativeTargets.first?.buildConfigurationList?.buildConfigurations.first)
+
+                try expect(targetConfig.buildSettings["SUPPORTS_MACCATALYST"]).beNil()
+                try expect(targetConfig.buildSettings["SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD"]).beNil()
+                try expect(targetConfig.buildSettings["SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD"]).beNil()
+                try expect(targetConfig.buildSettings["SUPPORTED_PLATFORMS"]).beNil()
+                try expect(targetConfig.buildSettings["TARGETED_DEVICE_FAMILY"]).beNil()
+            }
+
             $0.it("generates dependencies") {
                 let pbxProject = try project.generatePbxProj()
 


### PR DESCRIPTION
Gate the supportedDestinations YAML preset block inside the applyTarget check so that settingPresets: none (and project) suppresses Catalyst-related settings (SUPPORTS_MACCATALYST, SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD, SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD) that were previously always injected.

Fixes #1598