### PR TITLE
Fix folder source path regression with createIntermediateGroups (#1603)

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -780,7 +780,9 @@ class SourceGenerator {
             try makePathRelative(for: sourceReference, at: path)
         } else if createIntermediateGroups {
             createIntermediaGroups(for: sourceReference, at: sourcePath)
-            try makePathRelative(for: sourceReference, at: sourcePath)
+            if type != .folder {
+                try makePathRelative(for: sourceReference, at: sourcePath)
+            }
         }
 
         return sourceFiles

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -968,6 +968,29 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFileMissing(paths: ["Sources", "A", "a.swift"])
             }
 
+            $0.it("generates folder references with createIntermediateGroups") {
+                let directories = """
+                Sources:
+                  A:
+                    - a.resource
+                    - b.resource
+                """
+                try createDirectories(directories)
+
+                let target = Target(name: "Test", type: .application, platform: .iOS, sources: [
+                    TargetSource(path: "Sources/A", type: .folder),
+                ])
+                let project = Project(
+                    basePath: directoryPath,
+                    name: "Test",
+                    targets: [target],
+                    options: .init(createIntermediateGroups: true)
+                )
+
+                let pbxProj = try project.generatePbxProj()
+                try pbxProj.expectFile(paths: ["Sources", "Sources/A"], names: ["Sources", "A"], buildPhase: .resources)
+            }
+
             $0.it("adds files to correct build phase") {
                 let directories = """
                   A:


### PR DESCRIPTION
## Summary

- Fixes #1603 where `type: folder` sources generated a PBXFileReference with only the leaf directory name instead of the full relative path when `createIntermediateGroups` was enabled
- PR #1596 added `makePathRelative` to the `createIntermediateGroups` code path for synced folders, but it inadvertently also ran for regular `.folder` sources which use `sourceTree: .sourceRoot` and need the full path preserved
- Skips `makePathRelative` for `.folder` type sources; `.syncedFolder` and other types are unaffected

## Test plan

- [x] Added test case "generates folder references with createIntermediateGroups"
- [x] Existing folder reference test still passes
- [x] Full test suite passes (74 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)