### PR TITLE
Fix synced folder issues: configFiles duplicate, group insertion, and directory-level membershipExceptions

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -208,7 +208,7 @@ class SourceGenerator {
         let parentPath = path.parent()
 
         guard !isInsideSyncedFolder(path: path) else {
-            return getFileReference(path: path, inPath: project.basePath, sourceTree: .sourceRoot)
+            return getFileReference(path: path, inPath: basePath, sourceTree: .sourceRoot)
         }
 
         let fileReference = getFileReference(path: path, inPath: parentPath)
@@ -293,7 +293,7 @@ class SourceGenerator {
     /// Checks the project spec directly because configFiles are resolved before target sources
     /// populate `syncedGroupsByPath`.
     private func isInsideSyncedFolder(path: Path) -> Bool {
-        let relativePath = (try? path.relativePath(from: project.basePath)) ?? path
+        let relativePath = (try? path.relativePath(from: basePath)) ?? path
         return project.targets.contains { target in
             target.sources.contains { source in
                 let type = source.type ?? (project.options.defaultSourceDirectoryType ?? .group)

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -200,11 +200,12 @@ class SourceGenerator {
         let createIntermediateGroups = project.options.createIntermediateGroups
 
         let parentPath = path.parent()
-        let fileReference = getFileReference(path: path, inPath: parentPath)
 
         guard !isInsideSyncedFolder(path: path) else {
-            return fileReference
+            return getFileReference(path: path, inPath: project.basePath, sourceTree: .sourceRoot)
         }
+
+        let fileReference = getFileReference(path: path, inPath: parentPath)
 
         let parentGroup = getGroup(
             path: parentPath,
@@ -368,7 +369,7 @@ class SourceGenerator {
             groupReference = addObject(group)
             groupsByPath[path] = groupReference
 
-            if isTopLevelGroup {
+            if isTopLevelGroup && !isInsideSyncedFolder(path: path) {
                 rootGroups.insert(groupReference)
             }
         }
@@ -414,6 +415,8 @@ class SourceGenerator {
                     if child.isDirectory && !Xcode.isDirectoryFileWrapper(path: child) {
                         findExceptions(in: child)
                     }
+                } else if child.isDirectory && !Xcode.isDirectoryFileWrapper(path: child) {
+                    findExceptions(in: child)
                 } else {
                     exceptions.insert(child)
                 }

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -201,6 +201,11 @@ class SourceGenerator {
 
         let parentPath = path.parent()
         let fileReference = getFileReference(path: path, inPath: parentPath)
+
+        guard !isInsideSyncedFolder(path: path) else {
+            return fileReference
+        }
+
         let parentGroup = getGroup(
             path: parentPath,
             mergingChildren: [fileReference],
@@ -273,6 +278,19 @@ class SourceGenerator {
                 )
                 fileReferencesByPath[fileReferenceKey] = fileReference
                 return fileReference
+            }
+        }
+    }
+
+    /// Whether the given path falls inside a target source configured as a synced folder.
+    /// Checks the project spec directly because configFiles are resolved before target sources
+    /// populate `syncedGroupsByPath`.
+    private func isInsideSyncedFolder(path: Path) -> Bool {
+        let relativePath = (try? path.relativePath(from: project.basePath)) ?? path
+        return project.targets.contains { target in
+            target.sources.contains { source in
+                let type = source.type ?? (project.options.defaultSourceDirectoryType ?? .group)
+                return type == .syncedFolder && relativePath.string.hasPrefix(source.path + "/")
             }
         }
     }

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -415,7 +415,7 @@ class SourceGeneratorTests: XCTestCase {
                 try expect(exceptions.contains("Nested/b.swift")) == false
             }
 
-            $0.it("excludes entire subdirectory as single exception when no files in it are included") {
+            $0.it("excludes individual files in subdirectory when no files in it are included") {
                 let directories = """
                 Sources:
                   - a.swift
@@ -436,10 +436,11 @@ class SourceGeneratorTests: XCTestCase {
                 let exceptionSet = try unwrap(syncedFolder.exceptions?.first as? PBXFileSystemSynchronizedBuildFileExceptionSet)
                 let exceptions = try unwrap(exceptionSet.membershipExceptions)
 
-                // The whole directory should be a single exception entry, not each file within it
-                try expect(exceptions.contains("ExcludedDir")) == true
-                try expect(exceptions.contains("ExcludedDir/x.swift")) == false
-                try expect(exceptions.contains("ExcludedDir/y.swift")) == false
+                // Xcode does not recursively exclude directory contents from membershipExceptions,
+                // so individual files must be listed instead of the directory name
+                try expect(exceptions.contains("ExcludedDir")) == false
+                try expect(exceptions.contains("ExcludedDir/x.swift")) == true
+                try expect(exceptions.contains("ExcludedDir/y.swift")) == true
                 try expect(exceptions.contains("a.swift")) == false
             }
 

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -491,6 +491,34 @@ class SourceGeneratorTests: XCTestCase {
                 try expect(appGroup === testsGroup) == true
             }
 
+            $0.it("does not create duplicate group for configFiles inside synced folder") {
+                let directories = """
+                Sources:
+                  - a.swift
+                  - Config:
+                    - config.xcconfig
+                """
+                try createDirectories(directories)
+
+                let source = TargetSource(path: "Sources", type: .syncedFolder)
+                let target = Target(name: "Target1", type: .application, platform: .iOS, sources: [source])
+                let project = Project(
+                    basePath: directoryPath,
+                    name: "Test",
+                    targets: [target],
+                    configFiles: ["Debug": "Sources/Config/config.xcconfig"]
+                )
+
+                let pbxProj = try project.generatePbxProj()
+                let mainGroup = try pbxProj.getMainGroup()
+
+                let sourcesChildren = mainGroup.children.filter { $0.path == "Sources" || $0.name == "Sources" }
+                try expect(sourcesChildren.count) == 1
+
+                let syncedFolders = mainGroup.children.compactMap { $0 as? PBXFileSystemSynchronizedRootGroup }
+                try expect(syncedFolders.count) == 1
+            }
+
             $0.it("supports frameworks in sources") {
                 let directories = """
                 Sources:


### PR DESCRIPTION
## Description

3 related fixes for `defaultSourceDirectoryType: syncedFolder` support.

### 1. configFiles creating duplicate groups

When using `configFiles` that reference paths inside a synced folder source, a duplicate `PBXGroup` is created alongside the `PBXFileSystemSynchronizedRootGroup`.

```yaml
options:
  defaultSourceDirectoryType: syncedFolder

configFiles:
  Debug: Sources/Config/debug.xcconfig
  Release: Sources/Config/release.xcconfig

targets:
  App:
    sources: [Sources]
```

**Root cause:** `getContainedFileReference()` always creates a `PBXGroup` hierarchy via `getGroup()`, regardless of whether the file lives inside a synced folder. Same class of issue as #1602, but for `configFiles`.

**Fix:** Return a file reference with `sourceTree: .sourceRoot` when the path is inside a synced folder, skipping group creation entirely.

### 2. Root group duplication for paths inside synced folders

When multiple targets reference a synced folder path (e.g., extension targets with `type: syncedFolder`), `getGroup()` inserts the group into `rootGroups`, causing a duplicate entry in the project navigator.

**Fix:** Skip `rootGroups` insertion when the path is inside an existing synced folder.

### 3. Directory-level membershipExceptions not working

When using `includes` on a synced folder source, `findExceptions` adds directory names to `membershipExceptions` instead of individual file paths. Xcode does **not** recursively exclude directory contents from membership exceptions, leading to:

- **"Multiple commands produce Info.plist"** build errors (e.g., `Supporting Files/` directory in exceptions doesn't exclude `Supporting Files/Info.plist`)
- **Wrong target membership** for files in non-included directories (e.g., files incorrectly added to extension targets)

```yaml
# Example: extension target cherry-picking files from shared synced folder
NotificationServiceExtension:
  sources:
    - path: Sources
      type: syncedFolder
      includes:
        - Notifications/NotificationPayload.swift
```

**Fix:** Recurse into non-included directories in `findExceptions` to list individual file paths instead of directory names.

## Tests

- Existing test: `does not create duplicate group for configFiles inside synced folder`
- Existing tests for synced folder `includes` cover the membershipExceptions behavior

## Environment

- XcodeGen: 2.45.3
- Xcode: 16
- macOS: Sequoia