### PR TITLE
Fix makePathRelative using wrong base path when projectDirectory differs

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -886,7 +886,7 @@ class SourceGenerator {
             element = parent
         }
 
-        let completePath = project.basePath + Path(paths.joined(separator: "/"))
+        let completePath = (projectDirectory ?? project.basePath) + Path(paths.joined(separator: "/"))
         let relativePath = try path.relativePath(from: completePath)
         let relativePathString = relativePath.string
 

--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -32,6 +32,12 @@ class SourceGenerator {
 
     private(set) var knownRegions: Set<String> = []
 
+    /// The effective base path for resolving group and file paths in the generated project.
+    /// Uses `projectDirectory` when the xcodeproj is generated in a different location than the spec.
+    private var basePath: Path {
+        projectDirectory ?? project.basePath
+    }
+
     init(project: Project, pbxProj: PBXProj, projectDirectory: Path?) {
         self.project = project
         self.pbxProj = pbxProj
@@ -39,7 +45,7 @@ class SourceGenerator {
     }
 
     private func resolveGroupPath(_ path: Path, isTopLevelGroup: Bool) -> String {
-        if isTopLevelGroup, let relativePath = try? path.relativePath(from: projectDirectory ?? project.basePath).string {
+        if isTopLevelGroup, let relativePath = try? path.relativePath(from: basePath).string {
             return relativePath
         } else {
             return path.lastComponent
@@ -62,7 +68,7 @@ class SourceGenerator {
         let absolutePath = project.basePath + path.normalize()
 
         // Get the local package's relative path from the project root
-        let fileReferencePath = try? absolutePath.relativePath(from: projectDirectory ?? project.basePath).string
+        let fileReferencePath = try? absolutePath.relativePath(from: basePath).string
 
         let fileReference = addObject(
             PBXFileReference(
@@ -886,7 +892,7 @@ class SourceGenerator {
             element = parent
         }
 
-        let completePath = (projectDirectory ?? project.basePath) + Path(paths.joined(separator: "/"))
+        let completePath = (basePath) + Path(paths.joined(separator: "/"))
         let relativePath = try path.relativePath(from: completePath)
         let relativePathString = relativePath.string
 

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -911,6 +911,40 @@ class SourceGeneratorTests: XCTestCase {
                 try pbxProj.expectFile(paths: ["Sources/B", "b.swift"], names: ["B", "b.swift"], buildPhase: .sources)
             }
 
+            $0.it("generates intermediate groups with different projectDirectory") {
+
+                let directories = """
+                Sources:
+                  - a.swift
+                  - b.swift
+                Modules:
+                  - m.swift
+                """
+                try createDirectories(directories)
+
+                let target = Target(name: "Test", type: .application, platform: .iOS, sources: [
+                    "../Sources",
+                    "../Modules",
+                ])
+                let options = SpecOptions(createIntermediateGroups: true)
+                // basePath is a subdirectory (simulating spec in a subdir like ProjectRoot/XcodeGen/)
+                // projectDirectory is the parent (simulating --project pointing to ProjectRoot/)
+                let subdir = directoryPath + "SubDir"
+                try subdir.mkpath()
+                let project = Project(basePath: subdir, name: "Test", targets: [target], options: options)
+
+                let generator = PBXProjGenerator(project: project, projectDirectory: directoryPath)
+                let pbxProj = try generator.generate()
+
+                // Sources and Modules should have path = "Sources"/"Modules" (not "../Sources")
+                // The intermediate group for TestDirectory should have path = "."
+                // So Xcode resolves: projectDir/./Sources = correct
+                // Before fix: path was "../Sources", resolving to projectDir/./../Sources = wrong
+                try pbxProj.expectFile(paths: [".", "Sources", "a.swift"], names: ["TestDirectory", "Sources", "a.swift"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: [".", "Sources", "b.swift"], names: ["TestDirectory", "Sources", "b.swift"], buildPhase: .sources)
+                try pbxProj.expectFile(paths: [".", "Modules", "m.swift"], names: ["TestDirectory", "Modules", "m.swift"], buildPhase: .sources)
+            }
+
             $0.it("generates custom groups") {
 
                 let directories = """


### PR DESCRIPTION
## Summary

- Fixes #1606
- `makePathRelative` used `project.basePath` to compute the aggregated parent path, while `resolveGroupPath` used `projectDirectory ?? project.basePath`. When these differ (e.g. via `--project` flag), intermediate group paths become inconsistent, causing Xcode to resolve source files to the wrong location (parent directory dropped).
- Regression from #1596 which added the `makePathRelative` call in the `createIntermediateGroups` code path.
- Extracts a `basePath` computed property to consolidate `projectDirectory ?? project.basePath` and prevent future mismatches.

## Test plan

- [x] Added test: "generates intermediate groups with different projectDirectory" — verifies paths resolve correctly when `projectDirectory` differs from `basePath`
- [x] All 74 existing tests pass
- [x] Verified with real project generation: `xcodegen generate --spec ProjectRoot/XcodeGen/project.yml --project ProjectRoot/` now produces correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)