### PR TITLE
feat(query): add query command with structured JSON output

### DIFF
--- a/Sources/XcodeGenCLI/Commands/QueryCommand.swift
+++ b/Sources/XcodeGenCLI/Commands/QueryCommand.swift
@@ -1,0 +1,146 @@
+import Foundation
+import PathKit
+import ProjectSpec
+import SwiftCLI
+import Version
+
+class QueryCommand: ProjectCommand {
+
+    @Key("--type", "-t", description: "Query type. One of: targets, target, sources, settings, dependencies. Defaults to targets.")
+    private var queryType: QueryType?
+
+    @Key("--name", "-n", description: "Target name. Required for: target, sources, settings, dependencies.")
+    private var targetName: String?
+
+    @Key("--config", description: "Config name for settings queries (e.g. Debug, Release).")
+    private var config: String?
+
+    init(version: Version) {
+        super.init(version: version,
+                   name: "query",
+                   shortDescription: "Query the resolved project spec and return focused JSON")
+    }
+
+    override func execute(specLoader: SpecLoader, projectSpecPath: Path, project: Project) throws {
+        let type = queryType ?? .targets
+
+        switch type {
+        case .targets:
+            let summaries = project.targets.map {
+                TargetSummary(name: $0.name, type: $0.type.name, platform: $0.platform.rawValue)
+            }
+            success(try encode(summaries))
+
+        case .target:
+            let name = try requireName(for: type)
+            guard let target = project.getTarget(name) else { throw QueryError.targetNotFound(name) }
+            success(try encode(TargetDetail(target: target)))
+
+        case .sources:
+            let name = try requireName(for: type)
+            guard let target = project.getTarget(name) else { throw QueryError.targetNotFound(name) }
+            success(try encode(target.sources.map { $0.path }))
+
+        case .settings:
+            let name = try requireName(for: type)
+            guard let target = project.getTarget(name) else { throw QueryError.targetNotFound(name) }
+            let settings: [String: String]
+            if let config = config {
+                let configSettings = target.settings.configSettings[config]?.buildSettings ?? [:]
+                settings = configSettings.mapValues { $0.description }
+            } else {
+                settings = target.settings.buildSettings.mapValues { $0.description }
+            }
+            success(try encode(settings))
+
+        case .dependencies:
+            let name = try requireName(for: type)
+            guard let target = project.getTarget(name) else { throw QueryError.targetNotFound(name) }
+            success(try encode(target.dependencies.map { DependencySummary(dependency: $0) }))
+        }
+    }
+
+    private func requireName(for type: QueryType) throws -> String {
+        guard let name = targetName else {
+            throw QueryError.missingName(type.rawValue)
+        }
+        return name
+    }
+
+    private func encode<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(value)
+        return String(data: data, encoding: .utf8)!
+    }
+}
+
+// MARK: - Query type
+
+private enum QueryType: String, ConvertibleFromString {
+    case targets
+    case target
+    case sources
+    case settings
+    case dependencies
+}
+
+// MARK: - Errors
+
+private enum QueryError: Error, CustomStringConvertible, ProcessError {
+    case targetNotFound(String)
+    case missingName(String)
+
+    var description: String {
+        switch self {
+        case let .targetNotFound(name): return #"{"error":"target '\#(name)' not found"}"#
+        case let .missingName(type):    return #"{"error":"--name is required for query type '\#(type)'"}"#
+        }
+    }
+
+    var message: String? { description }
+    var exitStatus: Int32 { 1 }
+}
+
+// MARK: - Encodable response types
+
+private struct TargetSummary: Encodable {
+    let name: String
+    let type: String
+    let platform: String
+}
+
+private struct TargetDetail: Encodable {
+    let name: String
+    let type: String
+    let platform: String
+    let deploymentTarget: String?
+    let sources: [String]
+    let dependencies: [DependencySummary]
+
+    init(target: Target) {
+        self.name = target.name
+        self.type = target.type.name
+        self.platform = target.platform.rawValue
+        self.deploymentTarget = target.deploymentTarget?.description
+        self.sources = target.sources.map { $0.path }
+        self.dependencies = target.dependencies.map { DependencySummary(dependency: $0) }
+    }
+}
+
+private struct DependencySummary: Encodable {
+    let type: String
+    let reference: String
+
+    init(dependency: Dependency) {
+        self.reference = dependency.reference
+        switch dependency.type {
+        case .target:    self.type = "target"
+        case .framework: self.type = "framework"
+        case .sdk:       self.type = "sdk"
+        case .package:   self.type = "package"
+        case .carthage:  self.type = "carthage"
+        case .bundle:    self.type = "bundle"
+        }
+    }
+}

--- a/Sources/XcodeGenCLI/XcodeGenCLI.swift
+++ b/Sources/XcodeGenCLI/XcodeGenCLI.swift
@@ -17,6 +17,7 @@ public class XcodeGenCLI {
                 generateCommand,
                 CacheCommand(version: version),
                 DumpCommand(version: version),
+                QueryCommand(version: version),
             ]
         )
         cli.parser.routeBehavior = .searchWithFallback(generateCommand)


### PR DESCRIPTION
## Summary

Adds a new `xcodegen query` command for introspecting the resolved project spec without generating a project. All output is pretty-printed JSON.

- **No side effects** — read-only; never writes files or modifies state
- **Composable** — JSON output pipes cleanly into `jq`, CI scripts, or editor integrations
- **Error-safe** — missing target or missing `--name` returns `{"error":"..."}` with exit code 1

## Query types (`--type`)

| Type | Description | Requires |
|------|-------------|---------|
| `targets` | List all targets with name, type, platform | — |
| `target` | Full detail for one target | `--name` |
| `sources` | Source paths for a target | `--name` |
| `settings` | Build settings for a target | `--name` (optional `--config`) |
| `dependencies` | Dependencies for a target | `--name` |

## Output examples

**`xcodegen query --type targets`**
```json
[
  { "name": "MyApp", "platform": "iOS", "type": "application" },
  { "name": "MyTests", "platform": "iOS", "type": "bundle.unit-test" }
]
```

**`xcodegen query --type target --name MyApp`**
```json
{
  "dependencies": [{ "reference": "MyLib", "type": "target" }],
  "deploymentTarget": "16.0",
  "name": "MyApp",
  "platform": "iOS",
  "sources": ["Sources/App.swift"],
  "type": "application"
}
```

**`xcodegen query --type settings --name MyApp --config Debug`**
```json
{
  "PRODUCT_BUNDLE_IDENTIFIER": "com.example.myapp",
  "SWIFT_VERSION": "5.9"
}
```

## Use cases

- **CI**: fail the build if a required target is missing, without running `generate`
- **Editor plugins**: surface target list or build settings without parsing `.xcodeproj`
- **Scripting**: `xcodegen query --type sources --name MyApp | jq '.[]'`
- **LLM agents**: query structured project data for context without reading raw YAML

## Test plan

- [ ] `xcodegen query` → JSON array of all targets
- [ ] `xcodegen query --type target --name MyApp` → full target detail
- [ ] `xcodegen query --type target --name Missing` → `{"error":"..."}`, exit 1
- [ ] `xcodegen query --type sources` (missing --name) → `{"error":"..."}`, exit 1
- [ ] `xcodegen query --type settings --name MyApp --config Debug` → config-specific settings
- [ ] `swift test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)