### PR TITLE
Embed watchOS apps in PlugIns directory for Xcode 16+

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -1295,11 +1295,15 @@ public class PBXProjGenerator {
         }
         
         if !copyWatchReferences.isEmpty {
+            // Xcode 16+ requires watchOS apps to be embedded in PlugIns/
+            // (as foundation extensions) instead of the legacy Watch/ directory.
+            let xcodeVersionNumber = Int(project.xcodeVersion.prefix(2)) ?? 0
+            let usePlugIns = xcodeVersionNumber >= 16
 
             let copyFilesPhase = addObject(
                 PBXCopyFilesBuildPhase(
-                    dstPath: "$(CONTENTS_FOLDER_PATH)/Watch",
-                    dstSubfolderSpec: .productsDirectory,
+                    dstPath: usePlugIns ? "" : "$(CONTENTS_FOLDER_PATH)/Watch",
+                    dstSubfolderSpec: usePlugIns ? .plugins : .productsDirectory,
                     name: "Embed Watch Content",
                     files: copyWatchReferences
                 )


### PR DESCRIPTION
## Summary

Starting with Xcode 16, watchOS apps must be embedded in the parent app bundle's `PlugIns/` directory instead of the legacy `Watch/` directory. Without this change, installing on device fails with:

```
MyWatchApp.app is a Foundation extension and must be embedded in the parent
app bundle's PlugIns directory, but is embedded in the parent app bundle's Watch directory.
```

## Changes

In `PBXProjGenerator.swift`, the "Embed Watch Content" copy phase now checks the project's `xcodeVersion`:

- **Xcode 16+**: `dstSubfolderSpec = .plugins` (13), `dstPath = ""`
- **Xcode < 16**: `dstSubfolderSpec = .productsDirectory` (16), `dstPath = "$(CONTENTS_FOLDER_PATH)/Watch"` (unchanged)

## Test plan

- Existing tests pass (the test fixture uses the default xcodeVersion `14.3`, so it continues to use the legacy Watch/ embedding)
- Verified with a real watchOS project on Xcode 26.4 that the generated project installs correctly on device

Fixes #1613