### PR TITLE
Fix membershipExceptions for localized files in synced folders

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -1491,6 +1491,7 @@ public class PBXProjGenerator {
         var exceptions: Set<String> = Set(
             sourceGenerator.syncedFolderExceptions(for: targetSource, at: syncedPath)
                 .compactMap { try? $0.relativePath(from: syncedPath).string }
+                .map { syncedFolderLocalizedMembershipException($0) }
         )
 
         for infoPlistPath in Set(infoPlistFiles.values) {
@@ -1514,7 +1515,19 @@ public class PBXProjGenerator {
         addObject(exceptionSet)
         syncedGroup.exceptions = (syncedGroup.exceptions ?? []) + [exceptionSet]
     }
-    
+
+    /// In synced folders, Xcode expects localized file membership exceptions to use a
+    /// `/Localized:` prefix with the variant-group path (stripping the `.lproj` component), e.g.:
+    /// `Resources/de.lproj/Localizable.strings` → `/Localized: Resources/Localizable.strings`
+    private func syncedFolderLocalizedMembershipException(_ path: String) -> String {
+        var components = path.split(separator: "/").map(String.init)
+        guard let lprojIndex = components.firstIndex(where: { $0.hasSuffix(".lproj") }) else {
+            return path
+        }
+        components.remove(at: lprojIndex)
+        return "/Localized: " + components.joined(separator: "/")
+    }
+
     private func makePlatformFilter(for filter: Dependency.PlatformFilter) -> String? {
         switch filter {
         case .all:

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -470,6 +470,70 @@ class SourceGeneratorTests: XCTestCase {
                 try expect(exceptions.contains("c.swift")) == true
             }
 
+            $0.it("uses /Localized: prefix for lproj membership exceptions") {
+                let directories = """
+                Sources:
+                  - a.swift
+                  - Resources:
+                    - de.lproj:
+                      - Localizable.strings
+                      - AppShortcuts.strings
+                    - fr.lproj:
+                      - Localizable.strings
+                      - AppShortcuts.strings
+                """
+                try createDirectories(directories)
+
+                let source = TargetSource(path: "Sources", includes: ["a.swift"], type: .syncedFolder)
+                let target = Target(name: "Test", type: .application, platform: .iOS, sources: [source])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
+
+                let pbxProj = try project.generatePbxProj()
+                let syncedFolders = try pbxProj.getMainGroup().children.compactMap { $0 as? PBXFileSystemSynchronizedRootGroup }
+                let syncedFolder = try unwrap(syncedFolders.first)
+
+                let exceptionSet = try unwrap(syncedFolder.exceptions?.first as? PBXFileSystemSynchronizedBuildFileExceptionSet)
+                let exceptions = try unwrap(exceptionSet.membershipExceptions)
+
+                try expect(exceptions.contains("/Localized: Resources/Localizable.strings")) == true
+                try expect(exceptions.contains("/Localized: Resources/AppShortcuts.strings")) == true
+                try expect(exceptions.contains("Resources/de.lproj/Localizable.strings")) == false
+                try expect(exceptions.contains("Resources/fr.lproj/Localizable.strings")) == false
+                try expect(exceptions.contains("a.swift")) == false
+                // de + fr variants deduplicate into one /Localized: entry per file
+                let localizedCount = exceptions.filter { $0.hasPrefix("/Localized:") }.count
+                try expect(localizedCount) == 2
+            }
+
+            $0.it("preserves non-localized exceptions alongside /Localized: entries") {
+                let directories = """
+                Sources:
+                  - a.swift
+                  - b.swift
+                  - Resources:
+                    - de.lproj:
+                      - Localizable.strings
+                    - fr.lproj:
+                      - Localizable.strings
+                """
+                try createDirectories(directories)
+
+                let source = TargetSource(path: "Sources", includes: ["a.swift"], type: .syncedFolder)
+                let target = Target(name: "Test", type: .application, platform: .iOS, sources: [source])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
+
+                let pbxProj = try project.generatePbxProj()
+                let syncedFolders = try pbxProj.getMainGroup().children.compactMap { $0 as? PBXFileSystemSynchronizedRootGroup }
+                let syncedFolder = try unwrap(syncedFolders.first)
+
+                let exceptionSet = try unwrap(syncedFolder.exceptions?.first as? PBXFileSystemSynchronizedBuildFileExceptionSet)
+                let exceptions = try unwrap(exceptionSet.membershipExceptions)
+
+                try expect(exceptions.contains("b.swift")) == true
+                try expect(exceptions.contains("/Localized: Resources/Localizable.strings")) == true
+                try expect(exceptions.contains("a.swift")) == false
+            }
+
             $0.it("deduplicates synced folders and both targets reference the same group object") {
                 let directories = """
                 Sources:


### PR DESCRIPTION
## Description

- Localized files (`.strings` inside `.lproj` directories) in synced folders were not properly excluded via `membershipExceptions` when using `includes` filters
- Xcode expects a `/Localized:` prefix format (e.g., `/Localized: Resources/AppShortcuts.strings`) for variant-group membership exceptions, but XcodeGen was generating individual per-language paths (e.g., `Resources/de.lproj/AppShortcuts.strings`)
- These per-language paths were silently ignored by Xcode, causing localized resources to leak into targets that should have excluded them

## Fix

In `configureMembershipExceptions()`, paths containing `.lproj` directory components are now transformed into the `/Localized:` variant-group format that Xcode expects.

**Before** (ignored by Xcode):
```
Resources/de.lproj/AppShortcuts.strings,
Resources/fr.lproj/AppShortcuts.strings,
```

**After** (honored by Xcode):
```
"/Localized: Resources/AppShortcuts.strings",
```

## How to reproduce

1. Create a project with `defaultSourceDirectoryType: syncedFolder`
2. Add a target that references a synced folder with `includes` filtering only specific files
3. The synced folder contains `.lproj` directories with `.strings` files
4. After generation, `.strings` files appear as members of the target despite not being in `includes`
5. This causes build warnings like "This phrase is not used in any App Shortcut" for `AppShortcuts.strings` being processed by unrelated targets