### PR TITLE
Exclude .DS_Store and .orig files from cache tracking

### DIFF
--- a/Sources/ProjectSpec/Project.swift
+++ b/Sources/ProjectSpec/Project.swift
@@ -252,6 +252,21 @@ extension Project: PathContainer {
 
 extension Project {
 
+    /// Files excluded from cache tracking to match SourceGenerator's default exclusions.
+    /// Without this filter, changes to these files cause spurious project regeneration.
+    private static let defaultExcludedFileNames: Set<String> = [".DS_Store"]
+    private static let defaultExcludedExtensions: Set<String> = ["orig"]
+
+    private static func isTrackedFile(_ path: Path) -> Bool {
+        if defaultExcludedFileNames.contains(path.lastComponent) {
+            return false
+        }
+        if let ext = path.extension, defaultExcludedExtensions.contains(ext) {
+            return false
+        }
+        return true
+    }
+
     public var allTrackedFiles: [Path] {
         var files: [Path] = []
         files.append(contentsOf: configFilePaths)
@@ -270,7 +285,7 @@ extension Project {
             files.append(contentsOf: target.configFilePaths)
             for source in target.sources {
                 let sourcePath = basePath + source.path
-                
+
                 let type = source.type ?? options.defaultSourceDirectoryType ?? .group
                 if type.projectTracksChildren {
                     let sourceChildren = (try? sourcePath.recursiveChildren()) ?? []
@@ -279,7 +294,7 @@ extension Project {
                 files.append(sourcePath)
             }
         }
-        return files
+        return files.filter(Self.isTrackedFile)
     }
 }
 

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -593,7 +593,7 @@ class ProjectSpecTests: XCTestCase {
 
     func testAllTrackedFilesExcludesIgnoredFiles() {
         describe {
-            let directoryPath = Path(ProcessInfo.processInfo.globallyUniqueString)
+            let directoryPath = Path(components: [NSTemporaryDirectory(), ProcessInfo.processInfo.globallyUniqueString])
 
             $0.before {
                 try? directoryPath.delete()

--- a/Tests/ProjectSpecTests/ProjectSpecTests.swift
+++ b/Tests/ProjectSpecTests/ProjectSpecTests.swift
@@ -591,6 +591,69 @@ class ProjectSpecTests: XCTestCase {
         }
     }
 
+    func testAllTrackedFilesExcludesIgnoredFiles() {
+        describe {
+            let directoryPath = Path(ProcessInfo.processInfo.globallyUniqueString)
+
+            $0.before {
+                try? directoryPath.delete()
+            }
+
+            $0.after {
+                try? directoryPath.delete()
+            }
+
+            $0.it("excludes .DS_Store and .orig files from tracked files") {
+                // Create source directory with a mix of valid and ignored files
+                let sourcesDir = directoryPath + "Sources"
+                try sourcesDir.mkpath()
+                try (sourcesDir + "main.swift").write("")
+                try (sourcesDir + ".DS_Store").write("")
+                try (sourcesDir + "file.swift.orig").write("")
+
+                let target = Target(
+                    name: "App",
+                    type: .application,
+                    platform: .iOS,
+                    sources: [TargetSource(path: "Sources")]
+                )
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
+                let trackedFiles = project.allTrackedFiles
+
+                let trackedFileStrings = trackedFiles.map { $0.string }
+                let hasDSStore = trackedFileStrings.contains { $0.contains(".DS_Store") }
+                let hasOrig = trackedFileStrings.contains { $0.hasSuffix(".orig") }
+                let hasSwift = trackedFileStrings.contains { $0.contains("main.swift") }
+
+                try expect(hasDSStore).to.beFalse()
+                try expect(hasOrig).to.beFalse()
+                try expect(hasSwift).to.beTrue()
+            }
+
+            $0.it("excludes .DS_Store from fileGroup tracked files") {
+                // Create fileGroup directory with .DS_Store
+                let fileGroupDir = directoryPath + "Resources"
+                try fileGroupDir.mkpath()
+                try (fileGroupDir + "image.png").write("")
+                try (fileGroupDir + ".DS_Store").write("")
+
+                let project = Project(
+                    basePath: directoryPath,
+                    name: "Test",
+                    fileGroups: ["Resources"]
+                )
+                let trackedFiles = project.allTrackedFiles
+
+                let trackedFileStrings = trackedFiles.map { $0.string }
+                let hasDSStore = trackedFileStrings.contains { $0.contains(".DS_Store") }
+                let hasImage = trackedFileStrings.contains { $0.contains("image.png") }
+
+                try expect(hasDSStore).to.beFalse()
+                try expect(hasImage).to.beTrue()
+            }
+        }
+    }
+
     func testJSONEncodable() {
         describe {
             $0.it("encodes to json") {


### PR DESCRIPTION
## Summary

- Filters `.DS_Store` and `.orig` files from `allTrackedFiles`, matching the exclusions already present in `SourceGenerator`
- Without this, changes to `.DS_Store` files (created by macOS Finder) cause spurious project regeneration even when no real sources changed
- Adds tests verifying exclusion works for both source directories and file groups

Fixes #1032

## Test plan

- [x] `swift test` -- all tests pass, including new `testAllTrackedFilesExcludesIgnoredFiles`
- [x] Tests use `NSTemporaryDirectory` to avoid polluting the repo
- [x] Verified `.DS_Store` and `.orig` are excluded while normal files (`.swift`, `.png`) are tracked

## Hypothesis graph

Reasoning trace and prior evidence: https://github.com/kimjune01/sweep/blob/master/repo-hypotheses/yonaskolb-XcodeGen.md

<!-- sweep:amend:attestation -->
[Failing tests before](https://github.com/kimjune01/sweep/blob/0299d3934f8c0e9e0ad5afd992c201140e1e0817/attestations/yonaskolb-XcodeGen/issue-1622-before.txt) / [Passing tests after](https://github.com/kimjune01/sweep/blob/0299d3934f8c0e9e0ad5afd992c201140e1e0817/attestations/yonaskolb-XcodeGen/issue-1622-after.txt) / [How the tests ran](https://github.com/kimjune01/sweep/blob/0299d3934f8c0e9e0ad5afd992c201140e1e0817/attestations/yonaskolb-XcodeGen/issue-1622-manifest.json)
<!-- /sweep:amend:attestation -->

<!-- sweep:compose -->
_Sweep attestation `1439a1c200bc` — see the receipts footer below._
<!-- /sweep:compose -->




