### PR TITLE
Fix localized files leaking into synced folder targets

### DIFF
--- a/Sources/XcodeGenKit/PBXProjGenerator.swift
+++ b/Sources/XcodeGenKit/PBXProjGenerator.swift
@@ -1491,6 +1491,13 @@ public class PBXProjGenerator {
         var exceptions: Set<String> = Set(
             sourceGenerator.syncedFolderExceptions(for: targetSource, at: syncedPath)
                 .compactMap { try? $0.relativePath(from: syncedPath).string }
+                .map { rel in
+                    // Xcode only honors localized exclusions in the variant-group form; per-language paths are ignored.
+                    var parts = rel.split(separator: "/")
+                    guard let i = parts.firstIndex(where: { $0.hasSuffix(".lproj") }) else { return rel }
+                    parts.remove(at: i)
+                    return "/Localized: \(parts.joined(separator: "/"))"
+                }
         )
 
         for infoPlistPath in Set(infoPlistFiles.values) {

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -203,6 +203,39 @@ class SourceGeneratorTests: XCTestCase {
                 try expect(exceptions.contains("a.swift")) == false
             }
 
+            $0.it("excludes localized files from synced folders using the variant-group form") {
+                let directories = """
+                Sources:
+                  - a.swift
+                  - b.swift
+                  - Resources:
+                    - en.lproj:
+                      - Localizable.strings
+                      - AppShortcuts.strings
+                    - fr.lproj:
+                      - Localizable.strings
+                      - AppShortcuts.strings
+                """
+                try createDirectories(directories)
+
+                let source = TargetSource(path: "Sources", includes: ["a.swift", "Resources/*.lproj/Localizable.strings"], type: .syncedFolder)
+                let target = Target(name: "Test", type: .application, platform: .iOS, sources: [source])
+                let project = Project(basePath: directoryPath, name: "Test", targets: [target])
+
+                let pbxProj = try project.generatePbxProj()
+                let syncedFolders = try pbxProj.getMainGroup().children.compactMap { $0 as? PBXFileSystemSynchronizedRootGroup }
+                let syncedFolder = try unwrap(syncedFolders.first)
+
+                let exceptionSet = try unwrap(syncedFolder.exceptions?.first as? PBXFileSystemSynchronizedBuildFileExceptionSet)
+                let exceptions = try unwrap(exceptionSet.membershipExceptions)
+
+                try expect(exceptions.contains("/Localized: Resources/AppShortcuts.strings")) == true
+                try expect(exceptions.contains("Resources/en.lproj/AppShortcuts.strings")) == false
+                try expect(exceptions.contains("Resources/fr.lproj/AppShortcuts.strings")) == false
+                try expect(exceptions.contains("/Localized: Resources/Localizable.strings")) == false
+                try expect(exceptions.contains("b.swift")) == true
+            }
+
             $0.it("adds membership exceptions for nested synced folder with intermediate groups") {
                 let directories = """
                 Sources:


### PR DESCRIPTION
### Problem

When a target uses a synced folder and that folder contains localized resources (`*.lproj/Foo.strings`), the localized files become members of **every** target syncing the folder, even when a target excludes them via `includes:`/`excludes:`.

XcodeGen *does* write the excluded localized files into the target's `PBXFileSystemSynchronizedBuildFileExceptionSet.membershipExceptions`, but Xcode **ignores** them, because they use the per-language path form:

```
Resources/en.lproj/AppShortcuts.strings
```

Xcode only honors localized exclusions in the **variant-group** form (the same thing Xcode writes when you uncheck a localized file's target membership in the File inspector):

```
/Localized: Resources/AppShortcuts.strings
```

In practice this leaks e.g. `AppShortcuts.strings` into app extensions / UI-test targets that have no `AppShortcutsProvider`, producing build warnings like *"This phrase is not used in any App Shortcut or as a Negative Phrase"* and *"Unable to read App Intents metadata, AppShortcuts phrases will go through basic validation"*.

### Fix

In `PBXProjGenerator.configureMembershipExceptions`, rewrite exception paths for files inside a `*.lproj` directory to the `/Localized:` variant-group form (with the `.lproj` component removed). The surrounding `Set` dedupes the per-language entries into one.

### Verified

- New unit test passes.
- Confirmed on a real multi-target project (app + widget + notification-service + UI-tests): with the fix, the localized app-only strings are excluded from the secondary targets, the app itself keeps them, and the App Intents build warnings are gone with no `project.yml` change.
