### PR TITLE
Fix syncedFolder path when projectDirectory differs

### DIFF
--- a/Sources/XcodeGenKit/SourceGenerator.swift
+++ b/Sources/XcodeGenKit/SourceGenerator.swift
@@ -764,7 +764,7 @@ class SourceGenerator {
             sourceReference = group
         case .syncedFolder:
 
-            let relativePath = (try? path.relativePath(from: project.basePath)) ?? path
+            let relativePath = (try? path.relativePath(from: basePath)) ?? path
             let resolvedExplicitFolders = resolveExplicitFolders(targetSource: targetSource)
 
             let syncedRootGroup: PBXFileSystemSynchronizedRootGroup

--- a/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/SourceGeneratorTests.swift
@@ -102,6 +102,27 @@ class SourceGeneratorTests: XCTestCase {
                 try expect([syncedFolder]) == pbxProj.nativeTargets.first?.fileSystemSynchronizedGroups
             }
 
+            $0.it("generates synced folder with different projectDirectory") {
+                let directories = """
+                SubDir:
+                  Sources:
+                    - a.swift
+                """
+                try createDirectories(directories)
+
+                let target = Target(name: "Test", type: .application, platform: .iOS, sources: [.init(path: "Sources", type: .syncedFolder)])
+                let project = Project(basePath: directoryPath + "SubDir", name: "Test", targets: [target])
+
+                let generator = PBXProjGenerator(project: project, projectDirectory: directoryPath)
+                let pbxProj = try generator.generate()
+
+                let syncedFolders = try pbxProj.getMainGroup().children.compactMap { $0 as? PBXFileSystemSynchronizedRootGroup }
+                let syncedFolder = try unwrap(syncedFolders.first)
+
+                try expect(syncedFolder.path) == "SubDir/Sources"
+                try expect([syncedFolder]) == pbxProj.nativeTargets.first?.fileSystemSynchronizedGroups
+            }
+
             $0.it("generates synced folder with explicitFolders") {
                 let directories = """
                 Sources:


### PR DESCRIPTION
## Description

When the spec file and the generated project are in different directories, a `syncedFolder` source gets a path relative to the spec directory instead of the project directory. Xcode resolves that path from the xcodeproj location, so it points at a directory that doesn't exist. The synced folder is then silently treated as empty: the target compiles zero files but still reports BUILD SUCCEEDED.

```yaml
# Modules/Shared/FooKit/project.yml
targets:
  FooKit:
    type: framework
    platform: iOS
    sources:
      - path: Sources
        type: syncedFolder
```

```
$ xcodegen generate --spec Modules/Shared/FooKit/project.yml --project .

# actual:   path = Sources;                        (resolves to <root>/Sources, doesn't exist)
# expected: path = Modules/Shared/FooKit/Sources;
```

The syncedFolder branch computes the relative path from `project.basePath`, which is the spec directory. Paths written into the pbxproj need to be relative to the output directory instead. Regular groups already handle this through `resolveGroupPath`, which uses the `basePath` property (`projectDirectory ?? project.basePath`).

Added a regression test that fails without the fix.
