### PR TITLE
Fix non-deterministic/incorrect serialization of nested target attributes (e.g. SystemCapabilities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Master
+
+### Fixed
+- Fix nested target attributes (e.g. `attributes.SystemCapabilities`) being serialized as a stringified Swift `Dictionary` description instead of a proper nested plist dictionary, which also caused non-deterministic key ordering in generated `project.pbxproj` files across runs @imadaan
+
 ## 2.46.0
 
 ### Added

--- a/Sources/ProjectSpec/Settings.swift
+++ b/Sources/ProjectSpec/Settings.swift
@@ -144,6 +144,14 @@ extension ProjectAttribute {
             self = .array(array)
         } else if let object = value as? PBXObject {
             self = .targetReference(object)
+        } else if let dictionary = value as? [String: [String: Any]] {
+            // e.g. `SystemCapabilities`, which is a dictionary of dictionaries.
+            // Without this case, such values fall through to the `.string("\(value)")`
+            // branch below, which interpolates the raw Swift `Dictionary`. Its
+            // `description` iterates in the process's random hash-seed order, so the
+            // same input can non-deterministically produce a different key order (and
+            // isn't a valid nested plist dictionary in the first place).
+            self = .attributeDictionary(dictionary.mapValues { $0.mapValues { ProjectAttribute(any: $0) } })
         } else {
             self = .string("\(value)")
         }

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -324,6 +324,27 @@ class ProjectGeneratorTests: XCTestCase {
                 try expect(targetAttributes[appTarget]?["DevelopmentTeam"]?.stringValue) == "123"
             }
 
+            $0.it("generates nested target attributes such as SystemCapabilities") {
+                var appTargetWithAttributes = app
+                appTargetWithAttributes.attributes = [
+                    "SystemCapabilities": [
+                        "com.apple.Push": ["enabled": 1],
+                        "com.apple.Keychain": ["enabled": 1],
+                    ],
+                ]
+                let project = Project(name: "test", targets: [appTargetWithAttributes])
+                let pbxProject = try project.generatePbxProj()
+
+                let targetAttributes = try unwrap(pbxProject.projects.first?.targetAttributes)
+                let appTarget = try unwrap(pbxProject.targets(named: app.name).first)
+
+                guard case let .attributeDictionary(systemCapabilities)? = targetAttributes[appTarget]?["SystemCapabilities"] else {
+                    throw failure("Expected SystemCapabilities to be a nested attribute dictionary, not a string")
+                }
+                try expect(systemCapabilities["com.apple.Push"]?["enabled"]?.stringValue) == "1"
+                try expect(systemCapabilities["com.apple.Keychain"]?["enabled"]?.stringValue) == "1"
+            }
+
             $0.it("generates platform version") {
                 let target = Target(name: "Target", type: .application, platform: .watchOS, deploymentTarget: "2.0")
                 let project = Project(name: "", targets: [target], options: .init(deploymentTarget: DeploymentTarget(iOS: "10.0", watchOS: "3.0")))

--- a/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
+++ b/Tests/XcodeGenKitTests/ProjectGeneratorTests.swift
@@ -332,7 +332,7 @@ class ProjectGeneratorTests: XCTestCase {
                         "com.apple.Keychain": ["enabled": 1],
                     ],
                 ]
-                let project = Project(name: "test", targets: [appTargetWithAttributes])
+                let project = Project(name: "test", targets: [appTargetWithAttributes, framework])
                 let pbxProject = try project.generatePbxProj()
 
                 let targetAttributes = try unwrap(pbxProject.projects.first?.targetAttributes)


### PR DESCRIPTION
## Problem

`target.attributes` values that are nested dictionaries — most commonly `SystemCapabilities` (e.g. `com.apple.Push`, `com.apple.Keychain`) — are never converted to the existing `ProjectAttribute.attributeDictionary` case. Instead, `ProjectAttribute.init(any:)` only handles `[String]` and `PBXObject`, and falls back to `.string("\(value)")` for anything else:

```swift
extension ProjectAttribute {
    public init(any value: Any) {
        if let array = value as? [String] {
            self = .array(array)
        } else if let object = value as? PBXObject {
            self = .targetReference(object)
        } else {
            self = .string("\(value)")
        }
    }
}
```

For a nested dictionary like:

```yaml
attributes:
  SystemCapabilities:
    com.apple.Push:
      enabled: 1
    com.apple.Keychain:
      enabled: 1
```

this produces a `project.pbxproj` entry like:

```
SystemCapabilities = "[\"com.apple.Push\": [\"enabled\": 1], \"com.apple.Keychain\": [\"enabled\": 1]]";
```

i.e. a raw Swift `Dictionary` interpolated into a string, rather than a proper nested plist dictionary. This has two consequences:

1. **It isn't valid/expected pbxproj structure** for `SystemCapabilities` — Xcode's own tooling expects a nested dictionary here, not a quoted string.
2. **It's non-deterministic.** `Dictionary.description` iterates keys in the process's random hash-seed order, so regenerating the exact same `project.yml` can flip the key order inside that string between runs (e.g. `Push` before `Keychain`, or vice versa), producing spurious diffs in version control on every `xcodegen generate`, even though nothing in the spec changed.

## Fix

Add a case to `ProjectAttribute.init(any:)` that recognizes the `[String: [String: Any]]` shape (which is exactly what `.attributeDictionary([String: [String: ProjectAttribute]])` expects) and maps it recursively instead of falling through to `.string(...)`:

```swift
} else if let dictionary = value as? [String: [String: Any]] {
    self = .attributeDictionary(dictionary.mapValues { $0.mapValues { ProjectAttribute(any: $0) } })
}
```

`PBXProjEncoder` (in XcodeProj) already sorts dictionary keys alphabetically when writing plist dictionaries, so routing through `.attributeDictionary` also makes the output deterministic across runs, in addition to producing correct nested plist structure.

## Testing

- Added a regression test (`generates nested target attributes such as SystemCapabilities`) in `ProjectGeneratorTests.swift` asserting that `SystemCapabilities` produces a `.attributeDictionary` (not a `.string`) with the expected nested values.
- Verified the change with a syntax/parse check locally; the sandboxed environment I authored this in couldn't fetch SwiftPM dependencies to run the full test suite, so I'd appreciate CI running the suite on this PR.

## Repro

Given a target with:
```yaml
attributes:
  SystemCapabilities:
    com.apple.Push:
      enabled: 1
    com.apple.Keychain:
      enabled: 1
```

Running `xcodegen generate` repeatedly (without pinning `SWIFT_DETERMINISTIC_HASHING=1`) produces a flip-flopping diff purely in the order of keys inside the `SystemCapabilities` string value. After this fix, it serializes as a proper nested dictionary and is stable across runs.