### PR TITLE
Document how to add capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+### Documentation
+- Document how to add the In-App Purchase capability #1644 @Hokila
+
 ## 2.46.0
 
 ### Added

--- a/Docs/FAQ.md
+++ b/Docs/FAQ.md
@@ -3,6 +3,7 @@
 - [Can I use CocoaPods](#can-i-use-cocoapods)
 - [Can I use Crashlytics](#can-i-use-crashlytics)
 - [How do I setup code signing](#how-do-i-setup-code-signing)
+- [How do I add an Xcode capability](#how-do-i-add-an-xcode-capability)
 
 ## Can I still check in my project
 Absolutely. You will get the most out of XcodeGen by adding your project to your `.gitignore`, as this way you avoid merge conflicts. But you can also check it in as a halfway step.
@@ -41,3 +42,18 @@ This script will be added after `[CP] Embed Pods Frameworks.`
 ## How do I setup code signing
 
 At the moment there are no special options for code signing in XcodeGen, and this must be configured via regular build settings. For code signing to work, you need to tell Xcode which development team to use. This requires setting the `DEVELOPMENT_TEAM` and possibly `CODE_SIGN_STYLE` build settings. See [Configuring build settings](Usage.md#configuring-build-settings) for how to do that
+
+## How do I add an Xcode capability
+
+XcodeGen does not provide a general-purpose abstraction for Xcode capabilities. To determine what a capability requires, temporarily remove the generated project from source control, enable the capability in Xcode, and inspect the resulting project and entitlements changes.
+
+For example, enabling In-App Purchase adds the StoreKit framework. You can express that dependency in your spec as follows:
+
+```yaml
+targets:
+  MyApp:
+    dependencies:
+      - framework: StoreKit.framework
+```
+
+See [Dependencies](ProjectSpec.md#dependency) for the other dependency forms supported by XcodeGen. This example is specific to In-App Purchase; other capabilities may require different project settings, entitlements, or Xcode project attributes.


### PR DESCRIPTION
## Summary
- document how to investigate an Xcode capability by inspecting the generated project and entitlements changes
- add the confirmed In-App Purchase `StoreKit.framework` dependency example
- clarify that XcodeGen does not provide a general-purpose capability abstraction

Resolves #1574

## Validation
- `git diff --check`
- `swift test`
